### PR TITLE
feat: Payment domain events + shared Outbox unit-of-work (all phases)

### DIFF
--- a/api-gateway/ApiGateway.Tests/ApiGateway.Tests.csproj.lscache
+++ b/api-gateway/ApiGateway.Tests/ApiGateway.Tests.csproj.lscache
@@ -1,0 +1,512 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[properties]
+AssemblyName=ApiGateway.Tests
+CommandLineArgsForDesignTimeEvaluation=-langversion:14.0 -define:TRACE
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=14.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=ApiGateway.Tests
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../../MicroservicesInDotNet.sln
+TargetFrameworkIdentifier=.NETCoreApp
+TargetPath=<PATH>bin/Debug/net10.0/ApiGateway.Tests.dll
+TargetRefPath=<PATH>obj/Debug/net10.0/ref/ApiGateway.Tests.dll
+TemporaryDependencyNodeTargetIdentifier=net10.0
+
+[commandLineArguments]
+/noconfig
+/unsafe-
+/checked-
+/nowarn:NU1603,NU1902,NU1903,NU5104,CA1711,CA1707,CA1716,1701,1702,8002
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/warn:10
+/define:TRACE;DEBUG;NET;NET10_0;NETCOREAPP;NET5_0_OR_GREATER;NET6_0_OR_GREATER;NET7_0_OR_GREATER;NET8_0_OR_GREATER;NET9_0_OR_GREATER;NET10_0_OR_GREATER;NETCOREAPP1_0_OR_GREATER;NETCOREAPP1_1_OR_GREATER;NETCOREAPP2_0_OR_GREATER;NETCOREAPP2_1_OR_GREATER;NETCOREAPP2_2_OR_GREATER;NETCOREAPP3_0_OR_GREATER;NETCOREAPP3_1_OR_GREATER
+/highentropyva+
+/nullable:enable
+/features:"InterceptorsNamespaces=;Microsoft.Extensions.Validation.Generated"
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\net10.0\ApiGateway.Tests.dll
+/refout:obj\Debug\net10.0\refint\ApiGateway.Tests.dll
+/target:exe
+/warnaserror+
+/utf8output
+/deterministic+
+/langversion:14.0
+/features:use-roslyn-tokenizer=true
+/warnaserror+:NU1605,SYSLIB0011
+
+[sourceFiles]
+<NUGET>/microsoft.net.test.sdk/17.14.1/build/net8.0/Microsoft.NET.Test.Sdk.Program.cs
+Gateway/
+ GatewayProviderExtensionsTests.cs
+ SwaggerAggregation/GatewaySpecTransformerTests.cs
+Integration/
+ GatewayIntegrationTests.cs
+ GatewayWebApplicationFactory.cs
+ StubHttpServer.cs
+ SwaggerAggregationIntegrationTests.cs
+ SwaggerStubServer.cs
+obj/Debug/net10.0/
+ .NETCoreApp,Version=v10.0.AssemblyAttributes.cs
+ ApiGateway.Tests.AssemblyInfo.cs
+ ApiGateway.Tests.GlobalUsings.g.cs
+Operator/
+ DeadLetterDetailEndpointTests.cs
+ DeadLetterDiscardEndpointTests.cs
+ DeadLetterReplayBatchEndpointTests.cs
+ OperatorEndpointsRoutingTests.cs
+ OperatorMessagingProviderTests.cs
+ OutboxFailurePollerTests.cs
+
+[metadataReferences]
+../ApiGateway/obj/Debug/net10.0/ref/ApiGateway.dll
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.AspNetCore.Antiforgery.dll
+ Microsoft.AspNetCore.Authentication.Abstractions.dll
+ Microsoft.AspNetCore.Authentication.BearerToken.dll
+ Microsoft.AspNetCore.Authentication.Cookies.dll
+ Microsoft.AspNetCore.Authentication.Core.dll
+ Microsoft.AspNetCore.Authentication.dll
+ Microsoft.AspNetCore.Authentication.OAuth.dll
+ Microsoft.AspNetCore.Authorization.dll
+ Microsoft.AspNetCore.Authorization.Policy.dll
+ Microsoft.AspNetCore.Components.Authorization.dll
+ Microsoft.AspNetCore.Components.dll
+ Microsoft.AspNetCore.Components.Endpoints.dll
+ Microsoft.AspNetCore.Components.Forms.dll
+ Microsoft.AspNetCore.Components.Server.dll
+ Microsoft.AspNetCore.Components.Web.dll
+ Microsoft.AspNetCore.Connections.Abstractions.dll
+ Microsoft.AspNetCore.CookiePolicy.dll
+ Microsoft.AspNetCore.Cors.dll
+ Microsoft.AspNetCore.Cryptography.Internal.dll
+ Microsoft.AspNetCore.Cryptography.KeyDerivation.dll
+ Microsoft.AspNetCore.DataProtection.Abstractions.dll
+ Microsoft.AspNetCore.DataProtection.dll
+ Microsoft.AspNetCore.DataProtection.Extensions.dll
+ Microsoft.AspNetCore.Diagnostics.Abstractions.dll
+ Microsoft.AspNetCore.Diagnostics.dll
+ Microsoft.AspNetCore.Diagnostics.HealthChecks.dll
+ Microsoft.AspNetCore.dll
+ Microsoft.AspNetCore.HostFiltering.dll
+ Microsoft.AspNetCore.Hosting.Abstractions.dll
+ Microsoft.AspNetCore.Hosting.dll
+ Microsoft.AspNetCore.Hosting.Server.Abstractions.dll
+ Microsoft.AspNetCore.Html.Abstractions.dll
+ Microsoft.AspNetCore.Http.Abstractions.dll
+ Microsoft.AspNetCore.Http.Connections.Common.dll
+ Microsoft.AspNetCore.Http.Connections.dll
+ Microsoft.AspNetCore.Http.dll
+ Microsoft.AspNetCore.Http.Extensions.dll
+ Microsoft.AspNetCore.Http.Features.dll
+ Microsoft.AspNetCore.Http.Results.dll
+ Microsoft.AspNetCore.HttpLogging.dll
+ Microsoft.AspNetCore.HttpOverrides.dll
+ Microsoft.AspNetCore.HttpsPolicy.dll
+ Microsoft.AspNetCore.Identity.dll
+ Microsoft.AspNetCore.Localization.dll
+ Microsoft.AspNetCore.Localization.Routing.dll
+ Microsoft.AspNetCore.Metadata.dll
+ Microsoft.AspNetCore.Mvc.Abstractions.dll
+ Microsoft.AspNetCore.Mvc.ApiExplorer.dll
+ Microsoft.AspNetCore.Mvc.Core.dll
+ Microsoft.AspNetCore.Mvc.Cors.dll
+ Microsoft.AspNetCore.Mvc.DataAnnotations.dll
+ Microsoft.AspNetCore.Mvc.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Json.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Xml.dll
+ Microsoft.AspNetCore.Mvc.Localization.dll
+ Microsoft.AspNetCore.Mvc.Razor.dll
+ Microsoft.AspNetCore.Mvc.RazorPages.dll
+ Microsoft.AspNetCore.Mvc.TagHelpers.dll
+ Microsoft.AspNetCore.Mvc.ViewFeatures.dll
+ Microsoft.AspNetCore.OutputCaching.dll
+ Microsoft.AspNetCore.RateLimiting.dll
+ Microsoft.AspNetCore.Razor.dll
+ Microsoft.AspNetCore.Razor.Runtime.dll
+ Microsoft.AspNetCore.RequestDecompression.dll
+ Microsoft.AspNetCore.ResponseCaching.Abstractions.dll
+ Microsoft.AspNetCore.ResponseCaching.dll
+ Microsoft.AspNetCore.ResponseCompression.dll
+ Microsoft.AspNetCore.Rewrite.dll
+ Microsoft.AspNetCore.Routing.Abstractions.dll
+ Microsoft.AspNetCore.Routing.dll
+ Microsoft.AspNetCore.Server.HttpSys.dll
+ Microsoft.AspNetCore.Server.IIS.dll
+ Microsoft.AspNetCore.Server.IISIntegration.dll
+ Microsoft.AspNetCore.Server.Kestrel.Core.dll
+ Microsoft.AspNetCore.Server.Kestrel.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll
+ Microsoft.AspNetCore.Session.dll
+ Microsoft.AspNetCore.SignalR.Common.dll
+ Microsoft.AspNetCore.SignalR.Core.dll
+ Microsoft.AspNetCore.SignalR.dll
+ Microsoft.AspNetCore.SignalR.Protocols.Json.dll
+ Microsoft.AspNetCore.StaticAssets.dll
+ Microsoft.AspNetCore.StaticFiles.dll
+ Microsoft.AspNetCore.WebSockets.dll
+ Microsoft.AspNetCore.WebUtilities.dll
+ Microsoft.Extensions.Caching.Abstractions.dll
+ Microsoft.Extensions.Caching.Memory.dll
+ Microsoft.Extensions.Configuration.Abstractions.dll
+ Microsoft.Extensions.Configuration.Binder.dll
+ Microsoft.Extensions.Configuration.CommandLine.dll
+ Microsoft.Extensions.Configuration.dll
+ Microsoft.Extensions.Configuration.EnvironmentVariables.dll
+ Microsoft.Extensions.Configuration.FileExtensions.dll
+ Microsoft.Extensions.Configuration.Ini.dll
+ Microsoft.Extensions.Configuration.Json.dll
+ Microsoft.Extensions.Configuration.KeyPerFile.dll
+ Microsoft.Extensions.Configuration.UserSecrets.dll
+ Microsoft.Extensions.Configuration.Xml.dll
+ Microsoft.Extensions.DependencyInjection.Abstractions.dll
+ Microsoft.Extensions.DependencyInjection.dll
+ Microsoft.Extensions.Diagnostics.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.dll
+ Microsoft.Extensions.Features.dll
+ Microsoft.Extensions.FileProviders.Abstractions.dll
+ Microsoft.Extensions.FileProviders.Composite.dll
+ Microsoft.Extensions.FileProviders.Embedded.dll
+ Microsoft.Extensions.FileProviders.Physical.dll
+ Microsoft.Extensions.FileSystemGlobbing.dll
+ Microsoft.Extensions.Hosting.Abstractions.dll
+ Microsoft.Extensions.Hosting.dll
+ Microsoft.Extensions.Http.dll
+ Microsoft.Extensions.Identity.Core.dll
+ Microsoft.Extensions.Identity.Stores.dll
+ Microsoft.Extensions.Localization.Abstractions.dll
+ Microsoft.Extensions.Localization.dll
+ Microsoft.Extensions.Logging.Abstractions.dll
+ Microsoft.Extensions.Logging.Configuration.dll
+ Microsoft.Extensions.Logging.Console.dll
+ Microsoft.Extensions.Logging.Debug.dll
+ Microsoft.Extensions.Logging.dll
+ Microsoft.Extensions.Logging.EventLog.dll
+ Microsoft.Extensions.Logging.EventSource.dll
+ Microsoft.Extensions.Logging.TraceSource.dll
+ Microsoft.Extensions.ObjectPool.dll
+ Microsoft.Extensions.Options.ConfigurationExtensions.dll
+ Microsoft.Extensions.Options.DataAnnotations.dll
+ Microsoft.Extensions.Options.dll
+ Microsoft.Extensions.Primitives.dll
+ Microsoft.Extensions.Validation.dll
+ Microsoft.Extensions.WebEncoders.dll
+ Microsoft.JSInterop.dll
+ Microsoft.Net.Http.Headers.dll
+ System.Diagnostics.EventLog.dll
+ System.Formats.Cbor.dll
+ System.Security.Cryptography.Xml.dll
+ System.Threading.RateLimiting.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.CSharp.dll
+ Microsoft.VisualBasic.Core.dll
+ Microsoft.VisualBasic.dll
+ Microsoft.Win32.Primitives.dll
+ Microsoft.Win32.Registry.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.Immutable.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Annotations.dll
+ System.ComponentModel.DataAnnotations.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Configuration.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.DataSetExtensions.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.DiagnosticSource.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Formats.Asn1.dll
+ System.Formats.Tar.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.Brotli.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.AccessControl.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipelines.dll
+ System.IO.Pipes.AccessControl.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.AsyncEnumerable.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.Http.Json.dll
+ System.Net.HttpListener.dll
+ System.Net.Mail.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Quic.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.ServerSentEvents.dll
+ System.Net.ServicePoint.dll
+ System.Net.Sockets.dll
+ System.Net.WebClient.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebProxy.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Metadata.dll
+ System.Reflection.Primitives.dll
+ System.Reflection.TypeExtensions.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.Unsafe.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.JavaScript.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Intrinsics.dll
+ System.Runtime.Loader.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.AccessControl.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Cng.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.OpenSsl.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.dll
+ System.Security.Principal.dll
+ System.Security.Principal.Windows.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.ServiceProcess.dll
+ System.Text.Encoding.CodePages.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.Encodings.Web.dll
+ System.Text.Json.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.AccessControl.dll
+ System.Threading.Channels.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.Dataflow.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.Transactions.Local.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Web.HttpUtility.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+ WindowsBase.dll
+<NUGET>/
+ azure.core.amqp/1.3.1/lib/netstandard2.0/Azure.Core.Amqp.dll
+ azure.core/1.47.1/lib/net8.0/Azure.Core.dll
+ azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
+ azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
+ azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
+ ecommerce.shared/2.14.0/lib/net10.0/ECommerce.Shared.dll
+ fluentvalidation/12.1.1/lib/net8.0/FluentValidation.dll
+ google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
+ grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
+ grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll
+ grpc.net.common/2.52.0/lib/net7.0/Grpc.Net.Common.dll
+ ipaddressrange/6.3.0/lib/net10.0/IPAddressRange.dll
+ microsoft.aspnetcore.authentication.jwtbearer/10.0.5/lib/net10.0/Microsoft.AspNetCore.Authentication.JwtBearer.dll
+ microsoft.aspnetcore.jsonpatch/9.0.11/lib/net9.0/Microsoft.AspNetCore.JsonPatch.dll
+ microsoft.aspnetcore.middlewareanalysis/9.0.11/lib/net9.0/Microsoft.AspNetCore.MiddlewareAnalysis.dll
+ microsoft.aspnetcore.mvc.newtonsoftjson/9.0.11/lib/net9.0/Microsoft.AspNetCore.Mvc.NewtonsoftJson.dll
+ microsoft.azure.amqp/2.6.7/lib/netstandard2.0/Microsoft.Azure.Amqp.dll
+ microsoft.bcl.asyncinterfaces/8.0.0/lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll
+ microsoft.bcl.cryptography/9.0.4/lib/net9.0/Microsoft.Bcl.Cryptography.dll
+ microsoft.codecoverage/17.14.1/lib/net8.0/Microsoft.VisualStudio.CodeCoverage.Shim.dll
+ microsoft.data.sqlclient/6.1.1/ref/net9.0/Microsoft.Data.SqlClient.dll
+ microsoft.entityframeworkcore.abstractions/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Abstractions.dll
+ microsoft.entityframeworkcore.inmemory/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.InMemory.dll
+ microsoft.entityframeworkcore.relational/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Relational.dll
+ microsoft.entityframeworkcore.sqlserver/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.SqlServer.dll
+ microsoft.entityframeworkcore/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.dll
+ microsoft.extensions.diagnosticadapter/3.1.32/lib/netcoreapp2.0/Microsoft.Extensions.DiagnosticAdapter.dll
+ microsoft.identity.client.extensions.msal/4.73.1/lib/net8.0/Microsoft.Identity.Client.Extensions.Msal.dll
+ microsoft.identity.client/4.73.1/lib/net8.0/Microsoft.Identity.Client.dll
+ microsoft.identitymodel.abstractions/8.0.1/lib/net9.0/Microsoft.IdentityModel.Abstractions.dll
+ microsoft.identitymodel.jsonwebtokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.JsonWebTokens.dll
+ microsoft.identitymodel.logging/8.0.1/lib/net9.0/Microsoft.IdentityModel.Logging.dll
+ microsoft.identitymodel.protocols.openidconnect/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.dll
+ microsoft.identitymodel.protocols/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.dll
+ microsoft.identitymodel.tokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.Tokens.dll
+ microsoft.openapi/1.6.14/lib/netstandard2.0/Microsoft.OpenApi.dll
+ microsoft.sqlserver.server/1.0.0/lib/netstandard2.0/Microsoft.SqlServer.Server.dll
+ microsoft.testplatform.testhost/17.14.1/lib/net8.0/
+  Microsoft.TestPlatform.CommunicationUtilities.dll
+  Microsoft.TestPlatform.CoreUtilities.dll
+  Microsoft.TestPlatform.CrossPlatEngine.dll
+  Microsoft.TestPlatform.PlatformAbstractions.dll
+  Microsoft.TestPlatform.Utilities.dll
+  Microsoft.VisualStudio.TestPlatform.Common.dll
+  Microsoft.VisualStudio.TestPlatform.ObjectModel.dll
+  testhost.dll
+ newtonsoft.json.bson/1.0.2/lib/netstandard2.0/Newtonsoft.Json.Bson.dll
+ newtonsoft.json/13.0.3/lib/net6.0/Newtonsoft.Json.dll
+ ocelot/24.1.0/lib/net9.0/Ocelot.dll
+ opentelemetry.api.providerbuilderextensions/1.10.0/lib/net9.0/OpenTelemetry.Api.ProviderBuilderExtensions.dll
+ opentelemetry.api/1.10.0/lib/net9.0/OpenTelemetry.Api.dll
+ opentelemetry.exporter.console/1.9.0/lib/net8.0/OpenTelemetry.Exporter.Console.dll
+ opentelemetry.exporter.opentelemetryprotocol/1.9.0/lib/net8.0/OpenTelemetry.Exporter.OpenTelemetryProtocol.dll
+ opentelemetry.exporter.prometheus.aspnetcore/1.10.0-beta.1/lib/net9.0/OpenTelemetry.Exporter.Prometheus.AspNetCore.dll
+ opentelemetry.extensions.hosting/1.9.0/lib/net8.0/OpenTelemetry.Extensions.Hosting.dll
+ opentelemetry.instrumentation.aspnetcore/1.9.0/lib/net8.0/OpenTelemetry.Instrumentation.AspNetCore.dll
+ opentelemetry.instrumentation.sqlclient/1.9.0-beta.1/lib/net8.0/OpenTelemetry.Instrumentation.SqlClient.dll
+ opentelemetry.persistentstorage.abstractions/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.Abstractions.dll
+ opentelemetry.persistentstorage.filesystem/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.FileSystem.dll
+ opentelemetry/1.10.0/lib/net9.0/OpenTelemetry.dll
+ pipelines.sockets.unofficial/2.2.8/lib/net5.0/Pipelines.Sockets.Unofficial.dll
+ polly.core/8.6.6/lib/net8.0/Polly.Core.dll
+ rabbitmq.client/6.8.1/lib/netstandard2.0/RabbitMQ.Client.dll
+ stackexchange.redis/2.8.16/lib/net6.0/StackExchange.Redis.dll
+ swashbuckle.aspnetcore.swagger/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.Swagger.dll
+ swashbuckle.aspnetcore.swaggergen/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.dll
+ swashbuckle.aspnetcore.swaggerui/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.dll
+ system.clientmodel/1.5.1/lib/net8.0/System.ClientModel.dll
+ system.identitymodel.tokens.jwt/8.0.1/lib/net9.0/System.IdentityModel.Tokens.Jwt.dll
+ system.io.hashing/8.0.0/lib/net8.0/System.IO.Hashing.dll
+ system.memory.data/8.0.1/lib/net8.0/System.Memory.Data.dll
+ system.security.cryptography.pkcs/9.0.4/lib/net9.0/System.Security.Cryptography.Pkcs.dll
+ system.security.cryptography.protecteddata/9.0.4/lib/net9.0/System.Security.Cryptography.ProtectedData.dll
+ xunit.abstractions/2.0.3/lib/netstandard2.0/xunit.abstractions.dll
+ xunit.assert/2.9.3/lib/net6.0/xunit.assert.dll
+ xunit.extensibility.core/2.9.3/lib/netstandard1.1/xunit.core.dll
+ xunit.extensibility.execution/2.9.3/lib/netstandard1.1/xunit.execution.dotnet.dll
+ yarp.reverseproxy/2.3.0/lib/net8.0/Yarp.ReverseProxy.dll
+
+[analyzerReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.AspNetCore.App.Analyzers.dll
+ Microsoft.AspNetCore.App.CodeFixes.dll
+ Microsoft.AspNetCore.App.SourceGenerators.dll
+ Microsoft.AspNetCore.Components.Analyzers.dll
+ Microsoft.Extensions.Logging.Generators.dll
+ Microsoft.Extensions.Options.SourceGeneration.dll
+ Microsoft.Extensions.Validation.ValidationsGenerator.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.Interop.ComInterfaceGenerator.dll
+ Microsoft.Interop.JavaScript.JSImportGenerator.dll
+ Microsoft.Interop.LibraryImportGenerator.dll
+ Microsoft.Interop.SourceGeneration.dll
+ System.Text.Json.SourceGeneration.dll
+ System.Text.RegularExpressions.Generator.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk.Razor/source-generators/
+ Microsoft.AspNetCore.Razor.Utilities.Shared.dll
+ Microsoft.CodeAnalysis.Razor.Compiler.dll
+ Microsoft.Extensions.ObjectPool.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk.Web/analyzers/cs/
+ Microsoft.AspNetCore.Analyzers.dll
+ Microsoft.AspNetCore.Mvc.Analyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/
+ Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll
+ Microsoft.CodeAnalysis.NetAnalyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/codestyle/cs/
+ Microsoft.CodeAnalysis.CodeStyle.dll
+ Microsoft.CodeAnalysis.CodeStyle.Fixes.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.dll
+<NUGET>/
+ microsoft.entityframeworkcore.analyzers/10.0.5/analyzers/dotnet/cs/Microsoft.EntityFrameworkCore.Analyzers.dll
+ system.clientmodel/1.5.1/analyzers/dotnet/cs/System.ClientModel.SourceGeneration.dll
+ xunit.analyzers/1.18.0/analyzers/dotnet/cs/
+  xunit.analyzers.dll
+  xunit.analyzers.fixes.dll
+
+[analyzerConfigFiles]
+../../.editorconfig
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_10_recommended.globalconfig
+obj/Debug/net10.0/ApiGateway.Tests.GeneratedMSBuildEditorConfig.editorconfig

--- a/api-gateway/ApiGateway/ApiGateway.csproj.lscache
+++ b/api-gateway/ApiGateway/ApiGateway.csproj.lscache
@@ -1,0 +1,495 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[properties]
+AssemblyName=ApiGateway
+CommandLineArgsForDesignTimeEvaluation=-langversion:14.0 -define:TRACE
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=14.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=ApiGateway
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../../MicroservicesInDotNet.sln
+TargetFrameworkIdentifier=.NETCoreApp
+TargetPath=<PATH>bin/Debug/net10.0/ApiGateway.dll
+TargetRefPath=<PATH>obj/Debug/net10.0/ref/ApiGateway.dll
+TemporaryDependencyNodeTargetIdentifier=net10.0
+
+[commandLineArguments]
+/noconfig
+/unsafe-
+/checked-
+/nowarn:NU1603,NU1902,NU1903,NU5104,CA1711,CA1707,CA1716,1701,1702,8002
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/warn:10
+/define:TRACE;DEBUG;NET;NET10_0;NETCOREAPP;NET5_0_OR_GREATER;NET6_0_OR_GREATER;NET7_0_OR_GREATER;NET8_0_OR_GREATER;NET9_0_OR_GREATER;NET10_0_OR_GREATER;NETCOREAPP1_0_OR_GREATER;NETCOREAPP1_1_OR_GREATER;NETCOREAPP2_0_OR_GREATER;NETCOREAPP2_1_OR_GREATER;NETCOREAPP2_2_OR_GREATER;NETCOREAPP3_0_OR_GREATER;NETCOREAPP3_1_OR_GREATER
+/highentropyva+
+/nullable:enable
+/features:"InterceptorsNamespaces=;Microsoft.Extensions.Validation.Generated"
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\net10.0\ApiGateway.dll
+/refout:obj\Debug\net10.0\refint\ApiGateway.dll
+/target:exe
+/warnaserror+
+/utf8output
+/deterministic+
+/langversion:14.0
+/features:use-roslyn-tokenizer=true
+/warnaserror+:NU1605,SYSLIB0011
+
+[sourceFiles]
+Gateway/
+ GatewayProvider.cs
+ GatewayProviderExtensions.cs
+ GatewayProviderOptions.cs
+ OcelotGatewayModule.cs
+ SwaggerAggregation/
+  GatewayRouteDiscovery.cs
+  GatewayRouteInfo.cs
+  GatewaySpecTransformer.cs
+  SwaggerAggregationModule.cs
+ YarpGatewayModule.cs
+obj/Debug/net10.0/
+ .NETCoreApp,Version=v10.0.AssemblyAttributes.cs
+ ApiGateway.AssemblyInfo.cs
+ ApiGateway.GlobalUsings.g.cs
+Operator/
+ OperatorModule.cs
+ OutboxPolling/
+  OutboxFailureClient.cs
+  OutboxFailureItem.cs
+  OutboxFailurePoller.cs
+  OutboxPollerOptions.cs
+Program.cs
+
+[metadataReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.AspNetCore.Antiforgery.dll
+ Microsoft.AspNetCore.Authentication.Abstractions.dll
+ Microsoft.AspNetCore.Authentication.BearerToken.dll
+ Microsoft.AspNetCore.Authentication.Cookies.dll
+ Microsoft.AspNetCore.Authentication.Core.dll
+ Microsoft.AspNetCore.Authentication.dll
+ Microsoft.AspNetCore.Authentication.OAuth.dll
+ Microsoft.AspNetCore.Authorization.dll
+ Microsoft.AspNetCore.Authorization.Policy.dll
+ Microsoft.AspNetCore.Components.Authorization.dll
+ Microsoft.AspNetCore.Components.dll
+ Microsoft.AspNetCore.Components.Endpoints.dll
+ Microsoft.AspNetCore.Components.Forms.dll
+ Microsoft.AspNetCore.Components.Server.dll
+ Microsoft.AspNetCore.Components.Web.dll
+ Microsoft.AspNetCore.Connections.Abstractions.dll
+ Microsoft.AspNetCore.CookiePolicy.dll
+ Microsoft.AspNetCore.Cors.dll
+ Microsoft.AspNetCore.Cryptography.Internal.dll
+ Microsoft.AspNetCore.Cryptography.KeyDerivation.dll
+ Microsoft.AspNetCore.DataProtection.Abstractions.dll
+ Microsoft.AspNetCore.DataProtection.dll
+ Microsoft.AspNetCore.DataProtection.Extensions.dll
+ Microsoft.AspNetCore.Diagnostics.Abstractions.dll
+ Microsoft.AspNetCore.Diagnostics.dll
+ Microsoft.AspNetCore.Diagnostics.HealthChecks.dll
+ Microsoft.AspNetCore.dll
+ Microsoft.AspNetCore.HostFiltering.dll
+ Microsoft.AspNetCore.Hosting.Abstractions.dll
+ Microsoft.AspNetCore.Hosting.dll
+ Microsoft.AspNetCore.Hosting.Server.Abstractions.dll
+ Microsoft.AspNetCore.Html.Abstractions.dll
+ Microsoft.AspNetCore.Http.Abstractions.dll
+ Microsoft.AspNetCore.Http.Connections.Common.dll
+ Microsoft.AspNetCore.Http.Connections.dll
+ Microsoft.AspNetCore.Http.dll
+ Microsoft.AspNetCore.Http.Extensions.dll
+ Microsoft.AspNetCore.Http.Features.dll
+ Microsoft.AspNetCore.Http.Results.dll
+ Microsoft.AspNetCore.HttpLogging.dll
+ Microsoft.AspNetCore.HttpOverrides.dll
+ Microsoft.AspNetCore.HttpsPolicy.dll
+ Microsoft.AspNetCore.Identity.dll
+ Microsoft.AspNetCore.Localization.dll
+ Microsoft.AspNetCore.Localization.Routing.dll
+ Microsoft.AspNetCore.Metadata.dll
+ Microsoft.AspNetCore.Mvc.Abstractions.dll
+ Microsoft.AspNetCore.Mvc.ApiExplorer.dll
+ Microsoft.AspNetCore.Mvc.Core.dll
+ Microsoft.AspNetCore.Mvc.Cors.dll
+ Microsoft.AspNetCore.Mvc.DataAnnotations.dll
+ Microsoft.AspNetCore.Mvc.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Json.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Xml.dll
+ Microsoft.AspNetCore.Mvc.Localization.dll
+ Microsoft.AspNetCore.Mvc.Razor.dll
+ Microsoft.AspNetCore.Mvc.RazorPages.dll
+ Microsoft.AspNetCore.Mvc.TagHelpers.dll
+ Microsoft.AspNetCore.Mvc.ViewFeatures.dll
+ Microsoft.AspNetCore.OutputCaching.dll
+ Microsoft.AspNetCore.RateLimiting.dll
+ Microsoft.AspNetCore.Razor.dll
+ Microsoft.AspNetCore.Razor.Runtime.dll
+ Microsoft.AspNetCore.RequestDecompression.dll
+ Microsoft.AspNetCore.ResponseCaching.Abstractions.dll
+ Microsoft.AspNetCore.ResponseCaching.dll
+ Microsoft.AspNetCore.ResponseCompression.dll
+ Microsoft.AspNetCore.Rewrite.dll
+ Microsoft.AspNetCore.Routing.Abstractions.dll
+ Microsoft.AspNetCore.Routing.dll
+ Microsoft.AspNetCore.Server.HttpSys.dll
+ Microsoft.AspNetCore.Server.IIS.dll
+ Microsoft.AspNetCore.Server.IISIntegration.dll
+ Microsoft.AspNetCore.Server.Kestrel.Core.dll
+ Microsoft.AspNetCore.Server.Kestrel.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll
+ Microsoft.AspNetCore.Session.dll
+ Microsoft.AspNetCore.SignalR.Common.dll
+ Microsoft.AspNetCore.SignalR.Core.dll
+ Microsoft.AspNetCore.SignalR.dll
+ Microsoft.AspNetCore.SignalR.Protocols.Json.dll
+ Microsoft.AspNetCore.StaticAssets.dll
+ Microsoft.AspNetCore.StaticFiles.dll
+ Microsoft.AspNetCore.WebSockets.dll
+ Microsoft.AspNetCore.WebUtilities.dll
+ Microsoft.Extensions.Caching.Abstractions.dll
+ Microsoft.Extensions.Caching.Memory.dll
+ Microsoft.Extensions.Configuration.Abstractions.dll
+ Microsoft.Extensions.Configuration.Binder.dll
+ Microsoft.Extensions.Configuration.CommandLine.dll
+ Microsoft.Extensions.Configuration.dll
+ Microsoft.Extensions.Configuration.EnvironmentVariables.dll
+ Microsoft.Extensions.Configuration.FileExtensions.dll
+ Microsoft.Extensions.Configuration.Ini.dll
+ Microsoft.Extensions.Configuration.Json.dll
+ Microsoft.Extensions.Configuration.KeyPerFile.dll
+ Microsoft.Extensions.Configuration.UserSecrets.dll
+ Microsoft.Extensions.Configuration.Xml.dll
+ Microsoft.Extensions.DependencyInjection.Abstractions.dll
+ Microsoft.Extensions.DependencyInjection.dll
+ Microsoft.Extensions.Diagnostics.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.dll
+ Microsoft.Extensions.Features.dll
+ Microsoft.Extensions.FileProviders.Abstractions.dll
+ Microsoft.Extensions.FileProviders.Composite.dll
+ Microsoft.Extensions.FileProviders.Embedded.dll
+ Microsoft.Extensions.FileProviders.Physical.dll
+ Microsoft.Extensions.FileSystemGlobbing.dll
+ Microsoft.Extensions.Hosting.Abstractions.dll
+ Microsoft.Extensions.Hosting.dll
+ Microsoft.Extensions.Http.dll
+ Microsoft.Extensions.Identity.Core.dll
+ Microsoft.Extensions.Identity.Stores.dll
+ Microsoft.Extensions.Localization.Abstractions.dll
+ Microsoft.Extensions.Localization.dll
+ Microsoft.Extensions.Logging.Abstractions.dll
+ Microsoft.Extensions.Logging.Configuration.dll
+ Microsoft.Extensions.Logging.Console.dll
+ Microsoft.Extensions.Logging.Debug.dll
+ Microsoft.Extensions.Logging.dll
+ Microsoft.Extensions.Logging.EventLog.dll
+ Microsoft.Extensions.Logging.EventSource.dll
+ Microsoft.Extensions.Logging.TraceSource.dll
+ Microsoft.Extensions.ObjectPool.dll
+ Microsoft.Extensions.Options.ConfigurationExtensions.dll
+ Microsoft.Extensions.Options.DataAnnotations.dll
+ Microsoft.Extensions.Options.dll
+ Microsoft.Extensions.Primitives.dll
+ Microsoft.Extensions.Validation.dll
+ Microsoft.Extensions.WebEncoders.dll
+ Microsoft.JSInterop.dll
+ Microsoft.Net.Http.Headers.dll
+ System.Diagnostics.EventLog.dll
+ System.Formats.Cbor.dll
+ System.Security.Cryptography.Xml.dll
+ System.Threading.RateLimiting.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.CSharp.dll
+ Microsoft.VisualBasic.Core.dll
+ Microsoft.VisualBasic.dll
+ Microsoft.Win32.Primitives.dll
+ Microsoft.Win32.Registry.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.Immutable.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Annotations.dll
+ System.ComponentModel.DataAnnotations.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Configuration.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.DataSetExtensions.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.DiagnosticSource.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Formats.Asn1.dll
+ System.Formats.Tar.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.Brotli.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.AccessControl.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipelines.dll
+ System.IO.Pipes.AccessControl.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.AsyncEnumerable.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.Http.Json.dll
+ System.Net.HttpListener.dll
+ System.Net.Mail.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Quic.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.ServerSentEvents.dll
+ System.Net.ServicePoint.dll
+ System.Net.Sockets.dll
+ System.Net.WebClient.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebProxy.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Metadata.dll
+ System.Reflection.Primitives.dll
+ System.Reflection.TypeExtensions.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.Unsafe.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.JavaScript.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Intrinsics.dll
+ System.Runtime.Loader.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.AccessControl.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Cng.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.OpenSsl.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.dll
+ System.Security.Principal.dll
+ System.Security.Principal.Windows.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.ServiceProcess.dll
+ System.Text.Encoding.CodePages.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.Encodings.Web.dll
+ System.Text.Json.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.AccessControl.dll
+ System.Threading.Channels.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.Dataflow.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.Transactions.Local.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Web.HttpUtility.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+ WindowsBase.dll
+<NUGET>/
+ azure.core.amqp/1.3.1/lib/netstandard2.0/Azure.Core.Amqp.dll
+ azure.core/1.47.1/lib/net8.0/Azure.Core.dll
+ azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
+ azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
+ azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
+ ecommerce.shared/2.14.0/lib/net10.0/ECommerce.Shared.dll
+ fluentvalidation/12.1.1/lib/net8.0/FluentValidation.dll
+ google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
+ grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
+ grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll
+ grpc.net.common/2.52.0/lib/net7.0/Grpc.Net.Common.dll
+ ipaddressrange/6.3.0/lib/net10.0/IPAddressRange.dll
+ microsoft.aspnetcore.authentication.jwtbearer/10.0.5/lib/net10.0/Microsoft.AspNetCore.Authentication.JwtBearer.dll
+ microsoft.aspnetcore.jsonpatch/9.0.11/lib/net9.0/Microsoft.AspNetCore.JsonPatch.dll
+ microsoft.aspnetcore.middlewareanalysis/9.0.11/lib/net9.0/Microsoft.AspNetCore.MiddlewareAnalysis.dll
+ microsoft.aspnetcore.mvc.newtonsoftjson/9.0.11/lib/net9.0/Microsoft.AspNetCore.Mvc.NewtonsoftJson.dll
+ microsoft.azure.amqp/2.6.7/lib/netstandard2.0/Microsoft.Azure.Amqp.dll
+ microsoft.bcl.asyncinterfaces/8.0.0/lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll
+ microsoft.bcl.cryptography/9.0.4/lib/net9.0/Microsoft.Bcl.Cryptography.dll
+ microsoft.data.sqlclient/6.1.1/ref/net9.0/Microsoft.Data.SqlClient.dll
+ microsoft.entityframeworkcore.abstractions/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Abstractions.dll
+ microsoft.entityframeworkcore.relational/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Relational.dll
+ microsoft.entityframeworkcore.sqlserver/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.SqlServer.dll
+ microsoft.entityframeworkcore/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.dll
+ microsoft.extensions.diagnosticadapter/3.1.32/lib/netcoreapp2.0/Microsoft.Extensions.DiagnosticAdapter.dll
+ microsoft.identity.client.extensions.msal/4.73.1/lib/net8.0/Microsoft.Identity.Client.Extensions.Msal.dll
+ microsoft.identity.client/4.73.1/lib/net8.0/Microsoft.Identity.Client.dll
+ microsoft.identitymodel.abstractions/8.0.1/lib/net9.0/Microsoft.IdentityModel.Abstractions.dll
+ microsoft.identitymodel.jsonwebtokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.JsonWebTokens.dll
+ microsoft.identitymodel.logging/8.0.1/lib/net9.0/Microsoft.IdentityModel.Logging.dll
+ microsoft.identitymodel.protocols.openidconnect/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.dll
+ microsoft.identitymodel.protocols/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.dll
+ microsoft.identitymodel.tokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.Tokens.dll
+ microsoft.openapi/1.6.14/lib/netstandard2.0/Microsoft.OpenApi.dll
+ microsoft.sqlserver.server/1.0.0/lib/netstandard2.0/Microsoft.SqlServer.Server.dll
+ newtonsoft.json.bson/1.0.2/lib/netstandard2.0/Newtonsoft.Json.Bson.dll
+ newtonsoft.json/13.0.3/lib/net6.0/Newtonsoft.Json.dll
+ ocelot/24.1.0/lib/net9.0/Ocelot.dll
+ opentelemetry.api.providerbuilderextensions/1.10.0/lib/net9.0/OpenTelemetry.Api.ProviderBuilderExtensions.dll
+ opentelemetry.api/1.10.0/lib/net9.0/OpenTelemetry.Api.dll
+ opentelemetry.exporter.console/1.9.0/lib/net8.0/OpenTelemetry.Exporter.Console.dll
+ opentelemetry.exporter.opentelemetryprotocol/1.9.0/lib/net8.0/OpenTelemetry.Exporter.OpenTelemetryProtocol.dll
+ opentelemetry.exporter.prometheus.aspnetcore/1.10.0-beta.1/lib/net9.0/OpenTelemetry.Exporter.Prometheus.AspNetCore.dll
+ opentelemetry.extensions.hosting/1.9.0/lib/net8.0/OpenTelemetry.Extensions.Hosting.dll
+ opentelemetry.instrumentation.aspnetcore/1.9.0/lib/net8.0/OpenTelemetry.Instrumentation.AspNetCore.dll
+ opentelemetry.instrumentation.sqlclient/1.9.0-beta.1/lib/net8.0/OpenTelemetry.Instrumentation.SqlClient.dll
+ opentelemetry.persistentstorage.abstractions/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.Abstractions.dll
+ opentelemetry.persistentstorage.filesystem/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.FileSystem.dll
+ opentelemetry/1.10.0/lib/net9.0/OpenTelemetry.dll
+ pipelines.sockets.unofficial/2.2.8/lib/net5.0/Pipelines.Sockets.Unofficial.dll
+ polly.core/8.6.6/lib/net8.0/Polly.Core.dll
+ rabbitmq.client/6.8.1/lib/netstandard2.0/RabbitMQ.Client.dll
+ stackexchange.redis/2.8.16/lib/net6.0/StackExchange.Redis.dll
+ swashbuckle.aspnetcore.swagger/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.Swagger.dll
+ swashbuckle.aspnetcore.swaggergen/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.dll
+ swashbuckle.aspnetcore.swaggerui/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.dll
+ system.clientmodel/1.5.1/lib/net8.0/System.ClientModel.dll
+ system.identitymodel.tokens.jwt/8.0.1/lib/net9.0/System.IdentityModel.Tokens.Jwt.dll
+ system.io.hashing/8.0.0/lib/net8.0/System.IO.Hashing.dll
+ system.memory.data/8.0.1/lib/net8.0/System.Memory.Data.dll
+ system.security.cryptography.pkcs/9.0.4/lib/net9.0/System.Security.Cryptography.Pkcs.dll
+ system.security.cryptography.protecteddata/9.0.4/lib/net9.0/System.Security.Cryptography.ProtectedData.dll
+ yarp.reverseproxy/2.3.0/lib/net8.0/Yarp.ReverseProxy.dll
+
+[analyzerReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.AspNetCore.App.Analyzers.dll
+ Microsoft.AspNetCore.App.CodeFixes.dll
+ Microsoft.AspNetCore.App.SourceGenerators.dll
+ Microsoft.AspNetCore.Components.Analyzers.dll
+ Microsoft.Extensions.Logging.Generators.dll
+ Microsoft.Extensions.Options.SourceGeneration.dll
+ Microsoft.Extensions.Validation.ValidationsGenerator.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.Interop.ComInterfaceGenerator.dll
+ Microsoft.Interop.JavaScript.JSImportGenerator.dll
+ Microsoft.Interop.LibraryImportGenerator.dll
+ Microsoft.Interop.SourceGeneration.dll
+ System.Text.Json.SourceGeneration.dll
+ System.Text.RegularExpressions.Generator.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk.Razor/source-generators/
+ Microsoft.AspNetCore.Razor.Utilities.Shared.dll
+ Microsoft.CodeAnalysis.Razor.Compiler.dll
+ Microsoft.Extensions.ObjectPool.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk.Web/analyzers/cs/
+ Microsoft.AspNetCore.Analyzers.dll
+ Microsoft.AspNetCore.Mvc.Analyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/
+ Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll
+ Microsoft.CodeAnalysis.NetAnalyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/codestyle/cs/
+ Microsoft.CodeAnalysis.CodeStyle.dll
+ Microsoft.CodeAnalysis.CodeStyle.Fixes.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.dll
+<NUGET>/
+ microsoft.entityframeworkcore.analyzers/10.0.5/analyzers/dotnet/cs/Microsoft.EntityFrameworkCore.Analyzers.dll
+ system.clientmodel/1.5.1/analyzers/dotnet/cs/System.ClientModel.SourceGeneration.dll
+
+[analyzerConfigFiles]
+../../.editorconfig
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_10_recommended.globalconfig
+obj/Debug/net10.0/ApiGateway.GeneratedMSBuildEditorConfig.editorconfig

--- a/auth-microservice/Auth.Service/Auth.Service.csproj.lscache
+++ b/auth-microservice/Auth.Service/Auth.Service.csproj.lscache
@@ -1,0 +1,503 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[properties]
+AssemblyName=Auth.Service
+CommandLineArgsForDesignTimeEvaluation=-langversion:14.0 -define:TRACE
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=14.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=Auth.Service
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../../MicroservicesInDotNet.sln
+TargetFrameworkIdentifier=.NETCoreApp
+TargetPath=<PATH>bin/Debug/net10.0/Auth.Service.dll
+TargetRefPath=<PATH>obj/Debug/net10.0/ref/Auth.Service.dll
+TemporaryDependencyNodeTargetIdentifier=net10.0
+
+[commandLineArguments]
+/noconfig
+/unsafe-
+/checked-
+/nowarn:NU1603,NU1902,NU1903,NU5104,CA1711,CA1707,CA1716,1701,1702,8002
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/warn:10
+/define:TRACE;DEBUG;NET;NET10_0;NETCOREAPP;NET5_0_OR_GREATER;NET6_0_OR_GREATER;NET7_0_OR_GREATER;NET8_0_OR_GREATER;NET9_0_OR_GREATER;NET10_0_OR_GREATER;NETCOREAPP1_0_OR_GREATER;NETCOREAPP1_1_OR_GREATER;NETCOREAPP2_0_OR_GREATER;NETCOREAPP2_1_OR_GREATER;NETCOREAPP2_2_OR_GREATER;NETCOREAPP3_0_OR_GREATER;NETCOREAPP3_1_OR_GREATER
+/highentropyva+
+/nullable:enable
+/features:"InterceptorsNamespaces=;Microsoft.Extensions.Validation.Generated"
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\net10.0\Auth.Service.dll
+/refout:obj\Debug\net10.0\refint\Auth.Service.dll
+/target:exe
+/warnaserror+
+/utf8output
+/deterministic+
+/langversion:14.0
+/features:use-roslyn-tokenizer=true
+/warnaserror+:NU1605,SYSLIB0011
+
+[sourceFiles]
+ApiModels/LoginRequest.cs
+Endpoints/
+ AuthApiEndpoints.cs
+ JwksEndpoint.cs
+ ServiceTokenEndpoint.cs
+Infrastructure/Data/EntityFramework/
+ AuthContext.cs
+ AuthContextDatabaseMigration.cs
+ Configurations/UserConfiguration.cs
+ EntityFrameworkExtensions.cs
+Infrastructure/Data/IAuthStore.cs
+Migrations/
+ 20260414105802_InitialCreate.cs
+ 20260414105802_InitialCreate.Designer.cs
+ 20260427103353_DropPlaintextPasswordAddPasswordHash.cs
+ 20260427103353_DropPlaintextPasswordAddPasswordHash.Designer.cs
+ 20260506132121_20260506_SeedQaData_Auth.cs
+ 20260506132121_20260506_SeedQaData_Auth.Designer.cs
+ AuthContextModelSnapshot.cs
+Models/
+ AuthToken.cs
+ ServiceClient.cs
+ User.cs
+obj/Debug/net10.0/
+ .NETCoreApp,Version=v10.0.AssemblyAttributes.cs
+ Auth.Service.AssemblyInfo.cs
+ Auth.Service.GlobalUsings.g.cs
+Program.cs
+Services/
+ IServiceTokenService.cs
+ ITokenService.cs
+ JwtTokenService.cs
+ ServiceClientOptions.cs
+ ServiceTokenService.cs
+ Signing/
+  IRsaKeyProvider.cs
+  PemFileRsaKeyProvider.cs
+  SigningOptions.cs
+ TokenStartupExtensions.cs
+
+[metadataReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.AspNetCore.Antiforgery.dll
+ Microsoft.AspNetCore.Authentication.Abstractions.dll
+ Microsoft.AspNetCore.Authentication.BearerToken.dll
+ Microsoft.AspNetCore.Authentication.Cookies.dll
+ Microsoft.AspNetCore.Authentication.Core.dll
+ Microsoft.AspNetCore.Authentication.dll
+ Microsoft.AspNetCore.Authentication.OAuth.dll
+ Microsoft.AspNetCore.Authorization.dll
+ Microsoft.AspNetCore.Authorization.Policy.dll
+ Microsoft.AspNetCore.Components.Authorization.dll
+ Microsoft.AspNetCore.Components.dll
+ Microsoft.AspNetCore.Components.Endpoints.dll
+ Microsoft.AspNetCore.Components.Forms.dll
+ Microsoft.AspNetCore.Components.Server.dll
+ Microsoft.AspNetCore.Components.Web.dll
+ Microsoft.AspNetCore.Connections.Abstractions.dll
+ Microsoft.AspNetCore.CookiePolicy.dll
+ Microsoft.AspNetCore.Cors.dll
+ Microsoft.AspNetCore.Cryptography.Internal.dll
+ Microsoft.AspNetCore.Cryptography.KeyDerivation.dll
+ Microsoft.AspNetCore.DataProtection.Abstractions.dll
+ Microsoft.AspNetCore.DataProtection.dll
+ Microsoft.AspNetCore.DataProtection.Extensions.dll
+ Microsoft.AspNetCore.Diagnostics.Abstractions.dll
+ Microsoft.AspNetCore.Diagnostics.dll
+ Microsoft.AspNetCore.Diagnostics.HealthChecks.dll
+ Microsoft.AspNetCore.dll
+ Microsoft.AspNetCore.HostFiltering.dll
+ Microsoft.AspNetCore.Hosting.Abstractions.dll
+ Microsoft.AspNetCore.Hosting.dll
+ Microsoft.AspNetCore.Hosting.Server.Abstractions.dll
+ Microsoft.AspNetCore.Html.Abstractions.dll
+ Microsoft.AspNetCore.Http.Abstractions.dll
+ Microsoft.AspNetCore.Http.Connections.Common.dll
+ Microsoft.AspNetCore.Http.Connections.dll
+ Microsoft.AspNetCore.Http.dll
+ Microsoft.AspNetCore.Http.Extensions.dll
+ Microsoft.AspNetCore.Http.Features.dll
+ Microsoft.AspNetCore.Http.Results.dll
+ Microsoft.AspNetCore.HttpLogging.dll
+ Microsoft.AspNetCore.HttpOverrides.dll
+ Microsoft.AspNetCore.HttpsPolicy.dll
+ Microsoft.AspNetCore.Identity.dll
+ Microsoft.AspNetCore.Localization.dll
+ Microsoft.AspNetCore.Localization.Routing.dll
+ Microsoft.AspNetCore.Metadata.dll
+ Microsoft.AspNetCore.Mvc.Abstractions.dll
+ Microsoft.AspNetCore.Mvc.ApiExplorer.dll
+ Microsoft.AspNetCore.Mvc.Core.dll
+ Microsoft.AspNetCore.Mvc.Cors.dll
+ Microsoft.AspNetCore.Mvc.DataAnnotations.dll
+ Microsoft.AspNetCore.Mvc.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Json.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Xml.dll
+ Microsoft.AspNetCore.Mvc.Localization.dll
+ Microsoft.AspNetCore.Mvc.Razor.dll
+ Microsoft.AspNetCore.Mvc.RazorPages.dll
+ Microsoft.AspNetCore.Mvc.TagHelpers.dll
+ Microsoft.AspNetCore.Mvc.ViewFeatures.dll
+ Microsoft.AspNetCore.OutputCaching.dll
+ Microsoft.AspNetCore.RateLimiting.dll
+ Microsoft.AspNetCore.Razor.dll
+ Microsoft.AspNetCore.Razor.Runtime.dll
+ Microsoft.AspNetCore.RequestDecompression.dll
+ Microsoft.AspNetCore.ResponseCaching.Abstractions.dll
+ Microsoft.AspNetCore.ResponseCaching.dll
+ Microsoft.AspNetCore.ResponseCompression.dll
+ Microsoft.AspNetCore.Rewrite.dll
+ Microsoft.AspNetCore.Routing.Abstractions.dll
+ Microsoft.AspNetCore.Routing.dll
+ Microsoft.AspNetCore.Server.HttpSys.dll
+ Microsoft.AspNetCore.Server.IIS.dll
+ Microsoft.AspNetCore.Server.IISIntegration.dll
+ Microsoft.AspNetCore.Server.Kestrel.Core.dll
+ Microsoft.AspNetCore.Server.Kestrel.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll
+ Microsoft.AspNetCore.Session.dll
+ Microsoft.AspNetCore.SignalR.Common.dll
+ Microsoft.AspNetCore.SignalR.Core.dll
+ Microsoft.AspNetCore.SignalR.dll
+ Microsoft.AspNetCore.SignalR.Protocols.Json.dll
+ Microsoft.AspNetCore.StaticAssets.dll
+ Microsoft.AspNetCore.StaticFiles.dll
+ Microsoft.AspNetCore.WebSockets.dll
+ Microsoft.AspNetCore.WebUtilities.dll
+ Microsoft.Extensions.Caching.Abstractions.dll
+ Microsoft.Extensions.Caching.Memory.dll
+ Microsoft.Extensions.Configuration.Abstractions.dll
+ Microsoft.Extensions.Configuration.Binder.dll
+ Microsoft.Extensions.Configuration.CommandLine.dll
+ Microsoft.Extensions.Configuration.dll
+ Microsoft.Extensions.Configuration.EnvironmentVariables.dll
+ Microsoft.Extensions.Configuration.FileExtensions.dll
+ Microsoft.Extensions.Configuration.Ini.dll
+ Microsoft.Extensions.Configuration.Json.dll
+ Microsoft.Extensions.Configuration.KeyPerFile.dll
+ Microsoft.Extensions.Configuration.UserSecrets.dll
+ Microsoft.Extensions.Configuration.Xml.dll
+ Microsoft.Extensions.DependencyInjection.Abstractions.dll
+ Microsoft.Extensions.DependencyInjection.dll
+ Microsoft.Extensions.Diagnostics.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.dll
+ Microsoft.Extensions.Features.dll
+ Microsoft.Extensions.FileProviders.Abstractions.dll
+ Microsoft.Extensions.FileProviders.Composite.dll
+ Microsoft.Extensions.FileProviders.Embedded.dll
+ Microsoft.Extensions.FileProviders.Physical.dll
+ Microsoft.Extensions.FileSystemGlobbing.dll
+ Microsoft.Extensions.Hosting.Abstractions.dll
+ Microsoft.Extensions.Hosting.dll
+ Microsoft.Extensions.Http.dll
+ Microsoft.Extensions.Identity.Core.dll
+ Microsoft.Extensions.Identity.Stores.dll
+ Microsoft.Extensions.Localization.Abstractions.dll
+ Microsoft.Extensions.Localization.dll
+ Microsoft.Extensions.Logging.Abstractions.dll
+ Microsoft.Extensions.Logging.Configuration.dll
+ Microsoft.Extensions.Logging.Console.dll
+ Microsoft.Extensions.Logging.Debug.dll
+ Microsoft.Extensions.Logging.dll
+ Microsoft.Extensions.Logging.EventLog.dll
+ Microsoft.Extensions.Logging.EventSource.dll
+ Microsoft.Extensions.Logging.TraceSource.dll
+ Microsoft.Extensions.ObjectPool.dll
+ Microsoft.Extensions.Options.ConfigurationExtensions.dll
+ Microsoft.Extensions.Options.DataAnnotations.dll
+ Microsoft.Extensions.Options.dll
+ Microsoft.Extensions.Primitives.dll
+ Microsoft.Extensions.Validation.dll
+ Microsoft.Extensions.WebEncoders.dll
+ Microsoft.JSInterop.dll
+ Microsoft.Net.Http.Headers.dll
+ System.Diagnostics.EventLog.dll
+ System.Formats.Cbor.dll
+ System.Security.Cryptography.Xml.dll
+ System.Threading.RateLimiting.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.CSharp.dll
+ Microsoft.VisualBasic.Core.dll
+ Microsoft.VisualBasic.dll
+ Microsoft.Win32.Primitives.dll
+ Microsoft.Win32.Registry.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.Immutable.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Annotations.dll
+ System.ComponentModel.DataAnnotations.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Configuration.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.DataSetExtensions.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.DiagnosticSource.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Formats.Asn1.dll
+ System.Formats.Tar.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.Brotli.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.AccessControl.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipelines.dll
+ System.IO.Pipes.AccessControl.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.AsyncEnumerable.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.Http.Json.dll
+ System.Net.HttpListener.dll
+ System.Net.Mail.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Quic.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.ServerSentEvents.dll
+ System.Net.ServicePoint.dll
+ System.Net.Sockets.dll
+ System.Net.WebClient.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebProxy.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Metadata.dll
+ System.Reflection.Primitives.dll
+ System.Reflection.TypeExtensions.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.Unsafe.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.JavaScript.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Intrinsics.dll
+ System.Runtime.Loader.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.AccessControl.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Cng.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.OpenSsl.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.dll
+ System.Security.Principal.dll
+ System.Security.Principal.Windows.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.ServiceProcess.dll
+ System.Text.Encoding.CodePages.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.Encodings.Web.dll
+ System.Text.Json.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.AccessControl.dll
+ System.Threading.Channels.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.Dataflow.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.Transactions.Local.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Web.HttpUtility.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+ WindowsBase.dll
+<NUGET>/
+ azure.core.amqp/1.3.1/lib/netstandard2.0/Azure.Core.Amqp.dll
+ azure.core/1.47.1/lib/net8.0/Azure.Core.dll
+ azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
+ azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
+ azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
+ ecommerce.shared/2.14.0/lib/net10.0/ECommerce.Shared.dll
+ google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
+ grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
+ grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll
+ grpc.net.common/2.52.0/lib/net7.0/Grpc.Net.Common.dll
+ microsoft.aspnetcore.authentication.jwtbearer/10.0.5/lib/net10.0/Microsoft.AspNetCore.Authentication.JwtBearer.dll
+ microsoft.azure.amqp/2.6.7/lib/netstandard2.0/Microsoft.Azure.Amqp.dll
+ microsoft.bcl.asyncinterfaces/8.0.0/lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll
+ microsoft.bcl.cryptography/9.0.4/lib/net9.0/Microsoft.Bcl.Cryptography.dll
+ microsoft.data.sqlclient/6.1.1/ref/net9.0/Microsoft.Data.SqlClient.dll
+ microsoft.entityframeworkcore.abstractions/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Abstractions.dll
+ microsoft.entityframeworkcore.relational/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Relational.dll
+ microsoft.entityframeworkcore.sqlserver/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.SqlServer.dll
+ microsoft.entityframeworkcore/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.dll
+ microsoft.identity.client.extensions.msal/4.73.1/lib/net8.0/Microsoft.Identity.Client.Extensions.Msal.dll
+ microsoft.identity.client/4.73.1/lib/net8.0/Microsoft.Identity.Client.dll
+ microsoft.identitymodel.abstractions/8.0.1/lib/net9.0/Microsoft.IdentityModel.Abstractions.dll
+ microsoft.identitymodel.jsonwebtokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.JsonWebTokens.dll
+ microsoft.identitymodel.logging/8.0.1/lib/net9.0/Microsoft.IdentityModel.Logging.dll
+ microsoft.identitymodel.protocols.openidconnect/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.dll
+ microsoft.identitymodel.protocols/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.dll
+ microsoft.identitymodel.tokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.Tokens.dll
+ microsoft.openapi/1.6.14/lib/netstandard2.0/Microsoft.OpenApi.dll
+ microsoft.sqlserver.server/1.0.0/lib/netstandard2.0/Microsoft.SqlServer.Server.dll
+ opentelemetry.api.providerbuilderextensions/1.10.0/lib/net9.0/OpenTelemetry.Api.ProviderBuilderExtensions.dll
+ opentelemetry.api/1.10.0/lib/net9.0/OpenTelemetry.Api.dll
+ opentelemetry.exporter.console/1.9.0/lib/net8.0/OpenTelemetry.Exporter.Console.dll
+ opentelemetry.exporter.opentelemetryprotocol/1.9.0/lib/net8.0/OpenTelemetry.Exporter.OpenTelemetryProtocol.dll
+ opentelemetry.exporter.prometheus.aspnetcore/1.10.0-beta.1/lib/net9.0/OpenTelemetry.Exporter.Prometheus.AspNetCore.dll
+ opentelemetry.extensions.hosting/1.9.0/lib/net8.0/OpenTelemetry.Extensions.Hosting.dll
+ opentelemetry.instrumentation.aspnetcore/1.9.0/lib/net8.0/OpenTelemetry.Instrumentation.AspNetCore.dll
+ opentelemetry.instrumentation.sqlclient/1.9.0-beta.1/lib/net8.0/OpenTelemetry.Instrumentation.SqlClient.dll
+ opentelemetry.persistentstorage.abstractions/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.Abstractions.dll
+ opentelemetry.persistentstorage.filesystem/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.FileSystem.dll
+ opentelemetry/1.10.0/lib/net9.0/OpenTelemetry.dll
+ pipelines.sockets.unofficial/2.2.8/lib/net5.0/Pipelines.Sockets.Unofficial.dll
+ polly.core/8.6.6/lib/net8.0/Polly.Core.dll
+ rabbitmq.client/6.8.1/lib/netstandard2.0/RabbitMQ.Client.dll
+ stackexchange.redis/2.8.16/lib/net6.0/StackExchange.Redis.dll
+ swashbuckle.aspnetcore.swagger/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.Swagger.dll
+ swashbuckle.aspnetcore.swaggergen/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.dll
+ swashbuckle.aspnetcore.swaggerui/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.dll
+ system.clientmodel/1.5.1/lib/net8.0/System.ClientModel.dll
+ system.identitymodel.tokens.jwt/8.0.1/lib/net9.0/System.IdentityModel.Tokens.Jwt.dll
+ system.memory.data/8.0.1/lib/net8.0/System.Memory.Data.dll
+ system.security.cryptography.pkcs/9.0.4/lib/net9.0/System.Security.Cryptography.Pkcs.dll
+ system.security.cryptography.protecteddata/9.0.4/lib/net9.0/System.Security.Cryptography.ProtectedData.dll
+
+[analyzerReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.AspNetCore.App.Analyzers.dll
+ Microsoft.AspNetCore.App.CodeFixes.dll
+ Microsoft.AspNetCore.App.SourceGenerators.dll
+ Microsoft.AspNetCore.Components.Analyzers.dll
+ Microsoft.Extensions.Logging.Generators.dll
+ Microsoft.Extensions.Options.SourceGeneration.dll
+ Microsoft.Extensions.Validation.ValidationsGenerator.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.Interop.ComInterfaceGenerator.dll
+ Microsoft.Interop.JavaScript.JSImportGenerator.dll
+ Microsoft.Interop.LibraryImportGenerator.dll
+ Microsoft.Interop.SourceGeneration.dll
+ System.Text.Json.SourceGeneration.dll
+ System.Text.RegularExpressions.Generator.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk.Razor/source-generators/
+ Microsoft.AspNetCore.Razor.Utilities.Shared.dll
+ Microsoft.CodeAnalysis.Razor.Compiler.dll
+ Microsoft.Extensions.ObjectPool.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk.Web/analyzers/cs/
+ Microsoft.AspNetCore.Analyzers.dll
+ Microsoft.AspNetCore.Mvc.Analyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/
+ Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll
+ Microsoft.CodeAnalysis.NetAnalyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/codestyle/cs/
+ Microsoft.CodeAnalysis.CodeStyle.dll
+ Microsoft.CodeAnalysis.CodeStyle.Fixes.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.dll
+<NUGET>/microsoft.codeanalysis.analyzers/3.11.0/analyzers/dotnet/cs/
+ Microsoft.CodeAnalysis.Analyzers.dll
+ Microsoft.CodeAnalysis.CSharp.Analyzers.dll
+<NUGET>/
+ microsoft.entityframeworkcore.analyzers/10.0.5/analyzers/dotnet/cs/Microsoft.EntityFrameworkCore.Analyzers.dll
+ system.clientmodel/1.5.1/analyzers/dotnet/cs/System.ClientModel.SourceGeneration.dll
+
+[analyzerConfigFiles]
+../../.editorconfig
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_10_recommended.globalconfig
+obj/Debug/net10.0/Auth.Service.GeneratedMSBuildEditorConfig.editorconfig

--- a/auth-microservice/Auth.Tests/Auth.Tests.csproj.lscache
+++ b/auth-microservice/Auth.Tests/Auth.Tests.csproj.lscache
@@ -1,0 +1,487 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[properties]
+AssemblyName=Auth.Tests
+CommandLineArgsForDesignTimeEvaluation=-langversion:14.0 -define:TRACE
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=14.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=Auth.Tests
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../../MicroservicesInDotNet.sln
+TargetFrameworkIdentifier=.NETCoreApp
+TargetPath=<PATH>bin/Debug/net10.0/Auth.Tests.dll
+TargetRefPath=<PATH>obj/Debug/net10.0/ref/Auth.Tests.dll
+TemporaryDependencyNodeTargetIdentifier=net10.0
+
+[commandLineArguments]
+/noconfig
+/unsafe-
+/checked-
+/nowarn:NU1603,NU1902,NU1903,NU5104,CA1711,CA1707,CA1716,1701,1702,8002
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/warn:10
+/define:TRACE;DEBUG;NET;NET10_0;NETCOREAPP;NET5_0_OR_GREATER;NET6_0_OR_GREATER;NET7_0_OR_GREATER;NET8_0_OR_GREATER;NET9_0_OR_GREATER;NET10_0_OR_GREATER;NETCOREAPP1_0_OR_GREATER;NETCOREAPP1_1_OR_GREATER;NETCOREAPP2_0_OR_GREATER;NETCOREAPP2_1_OR_GREATER;NETCOREAPP2_2_OR_GREATER;NETCOREAPP3_0_OR_GREATER;NETCOREAPP3_1_OR_GREATER
+/highentropyva+
+/nullable:enable
+/features:"InterceptorsNamespaces=;Microsoft.Extensions.Validation.Generated"
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\net10.0\Auth.Tests.dll
+/refout:obj\Debug\net10.0\refint\Auth.Tests.dll
+/target:exe
+/warnaserror+
+/utf8output
+/deterministic+
+/langversion:14.0
+/warnaserror+:NU1605,SYSLIB0011
+
+[sourceFiles]
+<NUGET>/microsoft.net.test.sdk/17.14.1/build/net8.0/Microsoft.NET.Test.Sdk.Program.cs
+AuthApiEndpointsTests.cs
+AuthContextVerifyUserLoginTests.cs
+JwksEndpointTests.cs
+JwtTokenServiceTests.cs
+obj/Debug/net10.0/
+ .NETCoreApp,Version=v10.0.AssemblyAttributes.cs
+ Auth.Tests.AssemblyInfo.cs
+ Auth.Tests.GlobalUsings.g.cs
+Qa/AuthQaSeedTests.cs
+ServiceTokenEndpointTests.cs
+ServiceTokenServiceTests.cs
+
+[metadataReferences]
+../Auth.Service/obj/Debug/net10.0/ref/Auth.Service.dll
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.AspNetCore.Antiforgery.dll
+ Microsoft.AspNetCore.Authentication.Abstractions.dll
+ Microsoft.AspNetCore.Authentication.BearerToken.dll
+ Microsoft.AspNetCore.Authentication.Cookies.dll
+ Microsoft.AspNetCore.Authentication.Core.dll
+ Microsoft.AspNetCore.Authentication.dll
+ Microsoft.AspNetCore.Authentication.OAuth.dll
+ Microsoft.AspNetCore.Authorization.dll
+ Microsoft.AspNetCore.Authorization.Policy.dll
+ Microsoft.AspNetCore.Components.Authorization.dll
+ Microsoft.AspNetCore.Components.dll
+ Microsoft.AspNetCore.Components.Endpoints.dll
+ Microsoft.AspNetCore.Components.Forms.dll
+ Microsoft.AspNetCore.Components.Server.dll
+ Microsoft.AspNetCore.Components.Web.dll
+ Microsoft.AspNetCore.Connections.Abstractions.dll
+ Microsoft.AspNetCore.CookiePolicy.dll
+ Microsoft.AspNetCore.Cors.dll
+ Microsoft.AspNetCore.Cryptography.Internal.dll
+ Microsoft.AspNetCore.Cryptography.KeyDerivation.dll
+ Microsoft.AspNetCore.DataProtection.Abstractions.dll
+ Microsoft.AspNetCore.DataProtection.dll
+ Microsoft.AspNetCore.DataProtection.Extensions.dll
+ Microsoft.AspNetCore.Diagnostics.Abstractions.dll
+ Microsoft.AspNetCore.Diagnostics.dll
+ Microsoft.AspNetCore.Diagnostics.HealthChecks.dll
+ Microsoft.AspNetCore.dll
+ Microsoft.AspNetCore.HostFiltering.dll
+ Microsoft.AspNetCore.Hosting.Abstractions.dll
+ Microsoft.AspNetCore.Hosting.dll
+ Microsoft.AspNetCore.Hosting.Server.Abstractions.dll
+ Microsoft.AspNetCore.Html.Abstractions.dll
+ Microsoft.AspNetCore.Http.Abstractions.dll
+ Microsoft.AspNetCore.Http.Connections.Common.dll
+ Microsoft.AspNetCore.Http.Connections.dll
+ Microsoft.AspNetCore.Http.dll
+ Microsoft.AspNetCore.Http.Extensions.dll
+ Microsoft.AspNetCore.Http.Features.dll
+ Microsoft.AspNetCore.Http.Results.dll
+ Microsoft.AspNetCore.HttpLogging.dll
+ Microsoft.AspNetCore.HttpOverrides.dll
+ Microsoft.AspNetCore.HttpsPolicy.dll
+ Microsoft.AspNetCore.Identity.dll
+ Microsoft.AspNetCore.Localization.dll
+ Microsoft.AspNetCore.Localization.Routing.dll
+ Microsoft.AspNetCore.Metadata.dll
+ Microsoft.AspNetCore.Mvc.Abstractions.dll
+ Microsoft.AspNetCore.Mvc.ApiExplorer.dll
+ Microsoft.AspNetCore.Mvc.Core.dll
+ Microsoft.AspNetCore.Mvc.Cors.dll
+ Microsoft.AspNetCore.Mvc.DataAnnotations.dll
+ Microsoft.AspNetCore.Mvc.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Json.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Xml.dll
+ Microsoft.AspNetCore.Mvc.Localization.dll
+ Microsoft.AspNetCore.Mvc.Razor.dll
+ Microsoft.AspNetCore.Mvc.RazorPages.dll
+ Microsoft.AspNetCore.Mvc.TagHelpers.dll
+ Microsoft.AspNetCore.Mvc.ViewFeatures.dll
+ Microsoft.AspNetCore.OutputCaching.dll
+ Microsoft.AspNetCore.RateLimiting.dll
+ Microsoft.AspNetCore.Razor.dll
+ Microsoft.AspNetCore.Razor.Runtime.dll
+ Microsoft.AspNetCore.RequestDecompression.dll
+ Microsoft.AspNetCore.ResponseCaching.Abstractions.dll
+ Microsoft.AspNetCore.ResponseCaching.dll
+ Microsoft.AspNetCore.ResponseCompression.dll
+ Microsoft.AspNetCore.Rewrite.dll
+ Microsoft.AspNetCore.Routing.Abstractions.dll
+ Microsoft.AspNetCore.Routing.dll
+ Microsoft.AspNetCore.Server.HttpSys.dll
+ Microsoft.AspNetCore.Server.IIS.dll
+ Microsoft.AspNetCore.Server.IISIntegration.dll
+ Microsoft.AspNetCore.Server.Kestrel.Core.dll
+ Microsoft.AspNetCore.Server.Kestrel.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll
+ Microsoft.AspNetCore.Session.dll
+ Microsoft.AspNetCore.SignalR.Common.dll
+ Microsoft.AspNetCore.SignalR.Core.dll
+ Microsoft.AspNetCore.SignalR.dll
+ Microsoft.AspNetCore.SignalR.Protocols.Json.dll
+ Microsoft.AspNetCore.StaticAssets.dll
+ Microsoft.AspNetCore.StaticFiles.dll
+ Microsoft.AspNetCore.WebSockets.dll
+ Microsoft.AspNetCore.WebUtilities.dll
+ Microsoft.Extensions.Caching.Abstractions.dll
+ Microsoft.Extensions.Caching.Memory.dll
+ Microsoft.Extensions.Configuration.Abstractions.dll
+ Microsoft.Extensions.Configuration.Binder.dll
+ Microsoft.Extensions.Configuration.CommandLine.dll
+ Microsoft.Extensions.Configuration.dll
+ Microsoft.Extensions.Configuration.EnvironmentVariables.dll
+ Microsoft.Extensions.Configuration.FileExtensions.dll
+ Microsoft.Extensions.Configuration.Ini.dll
+ Microsoft.Extensions.Configuration.Json.dll
+ Microsoft.Extensions.Configuration.KeyPerFile.dll
+ Microsoft.Extensions.Configuration.UserSecrets.dll
+ Microsoft.Extensions.Configuration.Xml.dll
+ Microsoft.Extensions.DependencyInjection.Abstractions.dll
+ Microsoft.Extensions.DependencyInjection.dll
+ Microsoft.Extensions.Diagnostics.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.dll
+ Microsoft.Extensions.Features.dll
+ Microsoft.Extensions.FileProviders.Abstractions.dll
+ Microsoft.Extensions.FileProviders.Composite.dll
+ Microsoft.Extensions.FileProviders.Embedded.dll
+ Microsoft.Extensions.FileProviders.Physical.dll
+ Microsoft.Extensions.FileSystemGlobbing.dll
+ Microsoft.Extensions.Hosting.Abstractions.dll
+ Microsoft.Extensions.Hosting.dll
+ Microsoft.Extensions.Http.dll
+ Microsoft.Extensions.Identity.Core.dll
+ Microsoft.Extensions.Identity.Stores.dll
+ Microsoft.Extensions.Localization.Abstractions.dll
+ Microsoft.Extensions.Localization.dll
+ Microsoft.Extensions.Logging.Abstractions.dll
+ Microsoft.Extensions.Logging.Configuration.dll
+ Microsoft.Extensions.Logging.Console.dll
+ Microsoft.Extensions.Logging.Debug.dll
+ Microsoft.Extensions.Logging.dll
+ Microsoft.Extensions.Logging.EventLog.dll
+ Microsoft.Extensions.Logging.EventSource.dll
+ Microsoft.Extensions.Logging.TraceSource.dll
+ Microsoft.Extensions.ObjectPool.dll
+ Microsoft.Extensions.Options.ConfigurationExtensions.dll
+ Microsoft.Extensions.Options.DataAnnotations.dll
+ Microsoft.Extensions.Options.dll
+ Microsoft.Extensions.Primitives.dll
+ Microsoft.Extensions.Validation.dll
+ Microsoft.Extensions.WebEncoders.dll
+ Microsoft.JSInterop.dll
+ Microsoft.Net.Http.Headers.dll
+ System.Diagnostics.EventLog.dll
+ System.Formats.Cbor.dll
+ System.Security.Cryptography.Xml.dll
+ System.Threading.RateLimiting.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.CSharp.dll
+ Microsoft.VisualBasic.Core.dll
+ Microsoft.VisualBasic.dll
+ Microsoft.Win32.Primitives.dll
+ Microsoft.Win32.Registry.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.Immutable.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Annotations.dll
+ System.ComponentModel.DataAnnotations.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Configuration.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.DataSetExtensions.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.DiagnosticSource.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Formats.Asn1.dll
+ System.Formats.Tar.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.Brotli.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.AccessControl.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipelines.dll
+ System.IO.Pipes.AccessControl.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.AsyncEnumerable.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.Http.Json.dll
+ System.Net.HttpListener.dll
+ System.Net.Mail.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Quic.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.ServerSentEvents.dll
+ System.Net.ServicePoint.dll
+ System.Net.Sockets.dll
+ System.Net.WebClient.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebProxy.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Metadata.dll
+ System.Reflection.Primitives.dll
+ System.Reflection.TypeExtensions.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.Unsafe.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.JavaScript.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Intrinsics.dll
+ System.Runtime.Loader.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.AccessControl.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Cng.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.OpenSsl.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.dll
+ System.Security.Principal.dll
+ System.Security.Principal.Windows.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.ServiceProcess.dll
+ System.Text.Encoding.CodePages.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.Encodings.Web.dll
+ System.Text.Json.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.AccessControl.dll
+ System.Threading.Channels.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.Dataflow.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.Transactions.Local.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Web.HttpUtility.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+ WindowsBase.dll
+<NUGET>/
+ azure.core.amqp/1.3.1/lib/netstandard2.0/Azure.Core.Amqp.dll
+ azure.core/1.47.1/lib/net8.0/Azure.Core.dll
+ azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
+ azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
+ azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
+ castle.core/5.1.1/lib/net6.0/Castle.Core.dll
+ ecommerce.shared/2.14.0/lib/net10.0/ECommerce.Shared.dll
+ google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
+ grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
+ grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll
+ grpc.net.common/2.52.0/lib/net7.0/Grpc.Net.Common.dll
+ microsoft.aspnetcore.authentication.jwtbearer/10.0.5/lib/net10.0/Microsoft.AspNetCore.Authentication.JwtBearer.dll
+ microsoft.azure.amqp/2.6.7/lib/netstandard2.0/Microsoft.Azure.Amqp.dll
+ microsoft.bcl.asyncinterfaces/8.0.0/lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll
+ microsoft.bcl.cryptography/9.0.4/lib/net9.0/Microsoft.Bcl.Cryptography.dll
+ microsoft.codecoverage/17.14.1/lib/net8.0/Microsoft.VisualStudio.CodeCoverage.Shim.dll
+ microsoft.data.sqlclient/6.1.1/ref/net9.0/Microsoft.Data.SqlClient.dll
+ microsoft.entityframeworkcore.abstractions/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Abstractions.dll
+ microsoft.entityframeworkcore.inmemory/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.InMemory.dll
+ microsoft.entityframeworkcore.relational/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Relational.dll
+ microsoft.entityframeworkcore.sqlserver/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.SqlServer.dll
+ microsoft.entityframeworkcore/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.dll
+ microsoft.identity.client.extensions.msal/4.73.1/lib/net8.0/Microsoft.Identity.Client.Extensions.Msal.dll
+ microsoft.identity.client/4.73.1/lib/net8.0/Microsoft.Identity.Client.dll
+ microsoft.identitymodel.abstractions/8.0.1/lib/net9.0/Microsoft.IdentityModel.Abstractions.dll
+ microsoft.identitymodel.jsonwebtokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.JsonWebTokens.dll
+ microsoft.identitymodel.logging/8.0.1/lib/net9.0/Microsoft.IdentityModel.Logging.dll
+ microsoft.identitymodel.protocols.openidconnect/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.dll
+ microsoft.identitymodel.protocols/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.dll
+ microsoft.identitymodel.tokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.Tokens.dll
+ microsoft.openapi/1.6.14/lib/netstandard2.0/Microsoft.OpenApi.dll
+ microsoft.sqlserver.server/1.0.0/lib/netstandard2.0/Microsoft.SqlServer.Server.dll
+ microsoft.testplatform.testhost/17.14.1/lib/net8.0/
+  Microsoft.TestPlatform.CommunicationUtilities.dll
+  Microsoft.TestPlatform.CoreUtilities.dll
+  Microsoft.TestPlatform.CrossPlatEngine.dll
+  Microsoft.TestPlatform.PlatformAbstractions.dll
+  Microsoft.TestPlatform.Utilities.dll
+  Microsoft.VisualStudio.TestPlatform.Common.dll
+  Microsoft.VisualStudio.TestPlatform.ObjectModel.dll
+  testhost.dll
+ newtonsoft.json/13.0.3/lib/net6.0/Newtonsoft.Json.dll
+ nsubstitute/5.3.0/lib/net6.0/NSubstitute.dll
+ opentelemetry.api.providerbuilderextensions/1.10.0/lib/net9.0/OpenTelemetry.Api.ProviderBuilderExtensions.dll
+ opentelemetry.api/1.10.0/lib/net9.0/OpenTelemetry.Api.dll
+ opentelemetry.exporter.console/1.9.0/lib/net8.0/OpenTelemetry.Exporter.Console.dll
+ opentelemetry.exporter.opentelemetryprotocol/1.9.0/lib/net8.0/OpenTelemetry.Exporter.OpenTelemetryProtocol.dll
+ opentelemetry.exporter.prometheus.aspnetcore/1.10.0-beta.1/lib/net9.0/OpenTelemetry.Exporter.Prometheus.AspNetCore.dll
+ opentelemetry.extensions.hosting/1.9.0/lib/net8.0/OpenTelemetry.Extensions.Hosting.dll
+ opentelemetry.instrumentation.aspnetcore/1.9.0/lib/net8.0/OpenTelemetry.Instrumentation.AspNetCore.dll
+ opentelemetry.instrumentation.sqlclient/1.9.0-beta.1/lib/net8.0/OpenTelemetry.Instrumentation.SqlClient.dll
+ opentelemetry.persistentstorage.abstractions/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.Abstractions.dll
+ opentelemetry.persistentstorage.filesystem/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.FileSystem.dll
+ opentelemetry/1.10.0/lib/net9.0/OpenTelemetry.dll
+ pipelines.sockets.unofficial/2.2.8/lib/net5.0/Pipelines.Sockets.Unofficial.dll
+ polly.core/8.6.6/lib/net8.0/Polly.Core.dll
+ rabbitmq.client/6.8.1/lib/netstandard2.0/RabbitMQ.Client.dll
+ stackexchange.redis/2.8.16/lib/net6.0/StackExchange.Redis.dll
+ swashbuckle.aspnetcore.swagger/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.Swagger.dll
+ swashbuckle.aspnetcore.swaggergen/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.dll
+ swashbuckle.aspnetcore.swaggerui/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.dll
+ system.clientmodel/1.5.1/lib/net8.0/System.ClientModel.dll
+ system.identitymodel.tokens.jwt/8.0.1/lib/net9.0/System.IdentityModel.Tokens.Jwt.dll
+ system.memory.data/8.0.1/lib/net8.0/System.Memory.Data.dll
+ system.security.cryptography.pkcs/9.0.4/lib/net9.0/System.Security.Cryptography.Pkcs.dll
+ system.security.cryptography.protecteddata/9.0.4/lib/net9.0/System.Security.Cryptography.ProtectedData.dll
+ xunit.abstractions/2.0.3/lib/netstandard2.0/xunit.abstractions.dll
+ xunit.assert/2.9.3/lib/net6.0/xunit.assert.dll
+ xunit.extensibility.core/2.9.3/lib/netstandard1.1/xunit.core.dll
+ xunit.extensibility.execution/2.9.3/lib/netstandard1.1/xunit.execution.dotnet.dll
+
+[analyzerReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.AspNetCore.App.Analyzers.dll
+ Microsoft.AspNetCore.App.CodeFixes.dll
+ Microsoft.AspNetCore.App.SourceGenerators.dll
+ Microsoft.AspNetCore.Components.Analyzers.dll
+ Microsoft.Extensions.Logging.Generators.dll
+ Microsoft.Extensions.Options.SourceGeneration.dll
+ Microsoft.Extensions.Validation.ValidationsGenerator.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.Interop.ComInterfaceGenerator.dll
+ Microsoft.Interop.JavaScript.JSImportGenerator.dll
+ Microsoft.Interop.LibraryImportGenerator.dll
+ Microsoft.Interop.SourceGeneration.dll
+ System.Text.Json.SourceGeneration.dll
+ System.Text.RegularExpressions.Generator.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/
+ Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll
+ Microsoft.CodeAnalysis.NetAnalyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/codestyle/cs/
+ Microsoft.CodeAnalysis.CodeStyle.dll
+ Microsoft.CodeAnalysis.CodeStyle.Fixes.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.dll
+<NUGET>/
+ microsoft.entityframeworkcore.analyzers/10.0.5/analyzers/dotnet/cs/Microsoft.EntityFrameworkCore.Analyzers.dll
+ system.clientmodel/1.5.1/analyzers/dotnet/cs/System.ClientModel.SourceGeneration.dll
+ xunit.analyzers/1.18.0/analyzers/dotnet/cs/
+  xunit.analyzers.dll
+  xunit.analyzers.fixes.dll
+
+[analyzerConfigFiles]
+../../.editorconfig
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_10_recommended.globalconfig
+obj/Debug/net10.0/Auth.Tests.GeneratedMSBuildEditorConfig.editorconfig

--- a/basket-microservice/Basket.Service/Basket.Service.csproj.lscache
+++ b/basket-microservice/Basket.Service/Basket.Service.csproj.lscache
@@ -1,0 +1,489 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[properties]
+AssemblyName=Basket.Service
+CommandLineArgsForDesignTimeEvaluation=-langversion:14.0 -define:TRACE
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=14.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=Basket.Service
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../../MicroservicesInDotNet.sln
+TargetFrameworkIdentifier=.NETCoreApp
+TargetPath=<PATH>bin/Debug/net10.0/Basket.Service.dll
+TargetRefPath=<PATH>obj/Debug/net10.0/ref/Basket.Service.dll
+TemporaryDependencyNodeTargetIdentifier=net10.0
+
+[commandLineArguments]
+/noconfig
+/unsafe-
+/checked-
+/nowarn:NU1603,NU1902,NU1903,NU5104,CA1711,CA1707,CA1716,1701,1702,8002
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/warn:10
+/define:TRACE;DEBUG;NET;NET10_0;NETCOREAPP;NET5_0_OR_GREATER;NET6_0_OR_GREATER;NET7_0_OR_GREATER;NET8_0_OR_GREATER;NET9_0_OR_GREATER;NET10_0_OR_GREATER;NETCOREAPP1_0_OR_GREATER;NETCOREAPP1_1_OR_GREATER;NETCOREAPP2_0_OR_GREATER;NETCOREAPP2_1_OR_GREATER;NETCOREAPP2_2_OR_GREATER;NETCOREAPP3_0_OR_GREATER;NETCOREAPP3_1_OR_GREATER
+/highentropyva+
+/nullable:enable
+/features:"InterceptorsNamespaces=;Microsoft.Extensions.Validation.Generated"
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\net10.0\Basket.Service.dll
+/refout:obj\Debug\net10.0\refint\Basket.Service.dll
+/target:exe
+/warnaserror+
+/utf8output
+/deterministic+
+/langversion:14.0
+/features:use-roslyn-tokenizer=true
+/warnaserror+:NU1605,SYSLIB0011
+
+[sourceFiles]
+ApiModels/
+ AddBasketProductRequest.cs
+ CreateBasketRequest.cs
+Endpoints/BasketApiEndpoints.cs
+Infrastructure/Data/
+ CustomerBasketCacheModel.cs
+ IBasketStore.cs
+ InMemoryBasketStore.cs
+ Redis/
+  RedisBasketStore.cs
+  RedisExtensions.cs
+  RedisOptions.cs
+Infrastructure/Seeding/RedisQaSeederHostedService.cs
+IntegrationEvents/EventHandlers/
+ OrderCreatedEventHandler.cs
+ ProductPriceUpdatedEventHandler.cs
+IntegrationEvents/
+ OrderCreatedEvent.cs
+ ProductPriceUpdatedEvent.cs
+Models/
+ BasketProduct.cs
+ CustomerBasket.cs
+obj/Debug/net10.0/
+ .NETCoreApp,Version=v10.0.AssemblyAttributes.cs
+ Basket.Service.AssemblyInfo.cs
+ Basket.Service.GlobalUsings.g.cs
+Program.cs
+
+[metadataReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.AspNetCore.Antiforgery.dll
+ Microsoft.AspNetCore.Authentication.Abstractions.dll
+ Microsoft.AspNetCore.Authentication.BearerToken.dll
+ Microsoft.AspNetCore.Authentication.Cookies.dll
+ Microsoft.AspNetCore.Authentication.Core.dll
+ Microsoft.AspNetCore.Authentication.dll
+ Microsoft.AspNetCore.Authentication.OAuth.dll
+ Microsoft.AspNetCore.Authorization.dll
+ Microsoft.AspNetCore.Authorization.Policy.dll
+ Microsoft.AspNetCore.Components.Authorization.dll
+ Microsoft.AspNetCore.Components.dll
+ Microsoft.AspNetCore.Components.Endpoints.dll
+ Microsoft.AspNetCore.Components.Forms.dll
+ Microsoft.AspNetCore.Components.Server.dll
+ Microsoft.AspNetCore.Components.Web.dll
+ Microsoft.AspNetCore.Connections.Abstractions.dll
+ Microsoft.AspNetCore.CookiePolicy.dll
+ Microsoft.AspNetCore.Cors.dll
+ Microsoft.AspNetCore.Cryptography.Internal.dll
+ Microsoft.AspNetCore.Cryptography.KeyDerivation.dll
+ Microsoft.AspNetCore.DataProtection.Abstractions.dll
+ Microsoft.AspNetCore.DataProtection.dll
+ Microsoft.AspNetCore.DataProtection.Extensions.dll
+ Microsoft.AspNetCore.Diagnostics.Abstractions.dll
+ Microsoft.AspNetCore.Diagnostics.dll
+ Microsoft.AspNetCore.Diagnostics.HealthChecks.dll
+ Microsoft.AspNetCore.dll
+ Microsoft.AspNetCore.HostFiltering.dll
+ Microsoft.AspNetCore.Hosting.Abstractions.dll
+ Microsoft.AspNetCore.Hosting.dll
+ Microsoft.AspNetCore.Hosting.Server.Abstractions.dll
+ Microsoft.AspNetCore.Html.Abstractions.dll
+ Microsoft.AspNetCore.Http.Abstractions.dll
+ Microsoft.AspNetCore.Http.Connections.Common.dll
+ Microsoft.AspNetCore.Http.Connections.dll
+ Microsoft.AspNetCore.Http.dll
+ Microsoft.AspNetCore.Http.Extensions.dll
+ Microsoft.AspNetCore.Http.Features.dll
+ Microsoft.AspNetCore.Http.Results.dll
+ Microsoft.AspNetCore.HttpLogging.dll
+ Microsoft.AspNetCore.HttpOverrides.dll
+ Microsoft.AspNetCore.HttpsPolicy.dll
+ Microsoft.AspNetCore.Identity.dll
+ Microsoft.AspNetCore.Localization.dll
+ Microsoft.AspNetCore.Localization.Routing.dll
+ Microsoft.AspNetCore.Metadata.dll
+ Microsoft.AspNetCore.Mvc.Abstractions.dll
+ Microsoft.AspNetCore.Mvc.ApiExplorer.dll
+ Microsoft.AspNetCore.Mvc.Core.dll
+ Microsoft.AspNetCore.Mvc.Cors.dll
+ Microsoft.AspNetCore.Mvc.DataAnnotations.dll
+ Microsoft.AspNetCore.Mvc.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Json.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Xml.dll
+ Microsoft.AspNetCore.Mvc.Localization.dll
+ Microsoft.AspNetCore.Mvc.Razor.dll
+ Microsoft.AspNetCore.Mvc.RazorPages.dll
+ Microsoft.AspNetCore.Mvc.TagHelpers.dll
+ Microsoft.AspNetCore.Mvc.ViewFeatures.dll
+ Microsoft.AspNetCore.OutputCaching.dll
+ Microsoft.AspNetCore.RateLimiting.dll
+ Microsoft.AspNetCore.Razor.dll
+ Microsoft.AspNetCore.Razor.Runtime.dll
+ Microsoft.AspNetCore.RequestDecompression.dll
+ Microsoft.AspNetCore.ResponseCaching.Abstractions.dll
+ Microsoft.AspNetCore.ResponseCaching.dll
+ Microsoft.AspNetCore.ResponseCompression.dll
+ Microsoft.AspNetCore.Rewrite.dll
+ Microsoft.AspNetCore.Routing.Abstractions.dll
+ Microsoft.AspNetCore.Routing.dll
+ Microsoft.AspNetCore.Server.HttpSys.dll
+ Microsoft.AspNetCore.Server.IIS.dll
+ Microsoft.AspNetCore.Server.IISIntegration.dll
+ Microsoft.AspNetCore.Server.Kestrel.Core.dll
+ Microsoft.AspNetCore.Server.Kestrel.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll
+ Microsoft.AspNetCore.Session.dll
+ Microsoft.AspNetCore.SignalR.Common.dll
+ Microsoft.AspNetCore.SignalR.Core.dll
+ Microsoft.AspNetCore.SignalR.dll
+ Microsoft.AspNetCore.SignalR.Protocols.Json.dll
+ Microsoft.AspNetCore.StaticAssets.dll
+ Microsoft.AspNetCore.StaticFiles.dll
+ Microsoft.AspNetCore.WebSockets.dll
+ Microsoft.AspNetCore.WebUtilities.dll
+ Microsoft.Extensions.Caching.Abstractions.dll
+ Microsoft.Extensions.Caching.Memory.dll
+ Microsoft.Extensions.Configuration.Abstractions.dll
+ Microsoft.Extensions.Configuration.Binder.dll
+ Microsoft.Extensions.Configuration.CommandLine.dll
+ Microsoft.Extensions.Configuration.dll
+ Microsoft.Extensions.Configuration.EnvironmentVariables.dll
+ Microsoft.Extensions.Configuration.FileExtensions.dll
+ Microsoft.Extensions.Configuration.Ini.dll
+ Microsoft.Extensions.Configuration.Json.dll
+ Microsoft.Extensions.Configuration.KeyPerFile.dll
+ Microsoft.Extensions.Configuration.UserSecrets.dll
+ Microsoft.Extensions.Configuration.Xml.dll
+ Microsoft.Extensions.DependencyInjection.Abstractions.dll
+ Microsoft.Extensions.DependencyInjection.dll
+ Microsoft.Extensions.Diagnostics.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.dll
+ Microsoft.Extensions.Features.dll
+ Microsoft.Extensions.FileProviders.Abstractions.dll
+ Microsoft.Extensions.FileProviders.Composite.dll
+ Microsoft.Extensions.FileProviders.Embedded.dll
+ Microsoft.Extensions.FileProviders.Physical.dll
+ Microsoft.Extensions.FileSystemGlobbing.dll
+ Microsoft.Extensions.Hosting.Abstractions.dll
+ Microsoft.Extensions.Hosting.dll
+ Microsoft.Extensions.Http.dll
+ Microsoft.Extensions.Identity.Core.dll
+ Microsoft.Extensions.Identity.Stores.dll
+ Microsoft.Extensions.Localization.Abstractions.dll
+ Microsoft.Extensions.Localization.dll
+ Microsoft.Extensions.Logging.Abstractions.dll
+ Microsoft.Extensions.Logging.Configuration.dll
+ Microsoft.Extensions.Logging.Console.dll
+ Microsoft.Extensions.Logging.Debug.dll
+ Microsoft.Extensions.Logging.dll
+ Microsoft.Extensions.Logging.EventLog.dll
+ Microsoft.Extensions.Logging.EventSource.dll
+ Microsoft.Extensions.Logging.TraceSource.dll
+ Microsoft.Extensions.ObjectPool.dll
+ Microsoft.Extensions.Options.ConfigurationExtensions.dll
+ Microsoft.Extensions.Options.DataAnnotations.dll
+ Microsoft.Extensions.Options.dll
+ Microsoft.Extensions.Primitives.dll
+ Microsoft.Extensions.Validation.dll
+ Microsoft.Extensions.WebEncoders.dll
+ Microsoft.JSInterop.dll
+ Microsoft.Net.Http.Headers.dll
+ System.Diagnostics.EventLog.dll
+ System.Formats.Cbor.dll
+ System.Security.Cryptography.Xml.dll
+ System.Threading.RateLimiting.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.CSharp.dll
+ Microsoft.VisualBasic.Core.dll
+ Microsoft.VisualBasic.dll
+ Microsoft.Win32.Primitives.dll
+ Microsoft.Win32.Registry.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.Immutable.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Annotations.dll
+ System.ComponentModel.DataAnnotations.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Configuration.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.DataSetExtensions.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.DiagnosticSource.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Formats.Asn1.dll
+ System.Formats.Tar.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.Brotli.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.AccessControl.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipelines.dll
+ System.IO.Pipes.AccessControl.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.AsyncEnumerable.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.Http.Json.dll
+ System.Net.HttpListener.dll
+ System.Net.Mail.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Quic.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.ServerSentEvents.dll
+ System.Net.ServicePoint.dll
+ System.Net.Sockets.dll
+ System.Net.WebClient.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebProxy.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Metadata.dll
+ System.Reflection.Primitives.dll
+ System.Reflection.TypeExtensions.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.Unsafe.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.JavaScript.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Intrinsics.dll
+ System.Runtime.Loader.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.AccessControl.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Cng.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.OpenSsl.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.dll
+ System.Security.Principal.dll
+ System.Security.Principal.Windows.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.ServiceProcess.dll
+ System.Text.Encoding.CodePages.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.Encodings.Web.dll
+ System.Text.Json.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.AccessControl.dll
+ System.Threading.Channels.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.Dataflow.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.Transactions.Local.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Web.HttpUtility.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+ WindowsBase.dll
+<NUGET>/
+ azure.core.amqp/1.3.1/lib/netstandard2.0/Azure.Core.Amqp.dll
+ azure.core/1.47.1/lib/net8.0/Azure.Core.dll
+ azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
+ azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
+ azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
+ ecommerce.shared/2.14.0/lib/net10.0/ECommerce.Shared.dll
+ google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
+ grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
+ grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll
+ grpc.net.common/2.52.0/lib/net7.0/Grpc.Net.Common.dll
+ microsoft.aspnetcore.authentication.jwtbearer/10.0.5/lib/net10.0/Microsoft.AspNetCore.Authentication.JwtBearer.dll
+ microsoft.azure.amqp/2.6.7/lib/netstandard2.0/Microsoft.Azure.Amqp.dll
+ microsoft.bcl.asyncinterfaces/8.0.0/lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll
+ microsoft.bcl.cryptography/9.0.4/lib/net9.0/Microsoft.Bcl.Cryptography.dll
+ microsoft.data.sqlclient/6.1.1/ref/net9.0/Microsoft.Data.SqlClient.dll
+ microsoft.entityframeworkcore.abstractions/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Abstractions.dll
+ microsoft.entityframeworkcore.relational/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Relational.dll
+ microsoft.entityframeworkcore.sqlserver/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.SqlServer.dll
+ microsoft.entityframeworkcore/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.dll
+ microsoft.extensions.caching.stackexchangeredis/10.0.5/lib/net10.0/Microsoft.Extensions.Caching.StackExchangeRedis.dll
+ microsoft.identity.client.extensions.msal/4.73.1/lib/net8.0/Microsoft.Identity.Client.Extensions.Msal.dll
+ microsoft.identity.client/4.73.1/lib/net8.0/Microsoft.Identity.Client.dll
+ microsoft.identitymodel.abstractions/8.0.1/lib/net9.0/Microsoft.IdentityModel.Abstractions.dll
+ microsoft.identitymodel.jsonwebtokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.JsonWebTokens.dll
+ microsoft.identitymodel.logging/8.0.1/lib/net9.0/Microsoft.IdentityModel.Logging.dll
+ microsoft.identitymodel.protocols.openidconnect/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.dll
+ microsoft.identitymodel.protocols/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.dll
+ microsoft.identitymodel.tokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.Tokens.dll
+ microsoft.openapi/1.6.14/lib/netstandard2.0/Microsoft.OpenApi.dll
+ microsoft.sqlserver.server/1.0.0/lib/netstandard2.0/Microsoft.SqlServer.Server.dll
+ opentelemetry.api.providerbuilderextensions/1.10.0/lib/net9.0/OpenTelemetry.Api.ProviderBuilderExtensions.dll
+ opentelemetry.api/1.10.0/lib/net9.0/OpenTelemetry.Api.dll
+ opentelemetry.exporter.console/1.9.0/lib/net8.0/OpenTelemetry.Exporter.Console.dll
+ opentelemetry.exporter.opentelemetryprotocol/1.9.0/lib/net8.0/OpenTelemetry.Exporter.OpenTelemetryProtocol.dll
+ opentelemetry.exporter.prometheus.aspnetcore/1.10.0-beta.1/lib/net9.0/OpenTelemetry.Exporter.Prometheus.AspNetCore.dll
+ opentelemetry.extensions.hosting/1.9.0/lib/net8.0/OpenTelemetry.Extensions.Hosting.dll
+ opentelemetry.instrumentation.aspnetcore/1.9.0/lib/net8.0/OpenTelemetry.Instrumentation.AspNetCore.dll
+ opentelemetry.instrumentation.sqlclient/1.9.0-beta.1/lib/net8.0/OpenTelemetry.Instrumentation.SqlClient.dll
+ opentelemetry.persistentstorage.abstractions/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.Abstractions.dll
+ opentelemetry.persistentstorage.filesystem/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.FileSystem.dll
+ opentelemetry/1.10.0/lib/net9.0/OpenTelemetry.dll
+ pipelines.sockets.unofficial/2.2.8/lib/net5.0/Pipelines.Sockets.Unofficial.dll
+ polly.core/8.6.6/lib/net8.0/Polly.Core.dll
+ rabbitmq.client/6.8.1/lib/netstandard2.0/RabbitMQ.Client.dll
+ stackexchange.redis/2.8.16/lib/net6.0/StackExchange.Redis.dll
+ swashbuckle.aspnetcore.swagger/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.Swagger.dll
+ swashbuckle.aspnetcore.swaggergen/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.dll
+ swashbuckle.aspnetcore.swaggerui/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.dll
+ system.clientmodel/1.5.1/lib/net8.0/System.ClientModel.dll
+ system.identitymodel.tokens.jwt/8.0.1/lib/net9.0/System.IdentityModel.Tokens.Jwt.dll
+ system.memory.data/8.0.1/lib/net8.0/System.Memory.Data.dll
+ system.security.cryptography.pkcs/9.0.4/lib/net9.0/System.Security.Cryptography.Pkcs.dll
+ system.security.cryptography.protecteddata/9.0.4/lib/net9.0/System.Security.Cryptography.ProtectedData.dll
+
+[analyzerReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.AspNetCore.App.Analyzers.dll
+ Microsoft.AspNetCore.App.CodeFixes.dll
+ Microsoft.AspNetCore.App.SourceGenerators.dll
+ Microsoft.AspNetCore.Components.Analyzers.dll
+ Microsoft.Extensions.Logging.Generators.dll
+ Microsoft.Extensions.Options.SourceGeneration.dll
+ Microsoft.Extensions.Validation.ValidationsGenerator.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.Interop.ComInterfaceGenerator.dll
+ Microsoft.Interop.JavaScript.JSImportGenerator.dll
+ Microsoft.Interop.LibraryImportGenerator.dll
+ Microsoft.Interop.SourceGeneration.dll
+ System.Text.Json.SourceGeneration.dll
+ System.Text.RegularExpressions.Generator.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk.Razor/source-generators/
+ Microsoft.AspNetCore.Razor.Utilities.Shared.dll
+ Microsoft.CodeAnalysis.Razor.Compiler.dll
+ Microsoft.Extensions.ObjectPool.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk.Web/analyzers/cs/
+ Microsoft.AspNetCore.Analyzers.dll
+ Microsoft.AspNetCore.Mvc.Analyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/
+ Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll
+ Microsoft.CodeAnalysis.NetAnalyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/codestyle/cs/
+ Microsoft.CodeAnalysis.CodeStyle.dll
+ Microsoft.CodeAnalysis.CodeStyle.Fixes.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.dll
+<NUGET>/
+ microsoft.entityframeworkcore.analyzers/10.0.5/analyzers/dotnet/cs/Microsoft.EntityFrameworkCore.Analyzers.dll
+ system.clientmodel/1.5.1/analyzers/dotnet/cs/System.ClientModel.SourceGeneration.dll
+
+[analyzerConfigFiles]
+../../.editorconfig
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_10_recommended.globalconfig
+obj/Debug/net10.0/Basket.Service.GeneratedMSBuildEditorConfig.editorconfig

--- a/basket-microservice/Basket.Tests/Basket.Tests.csproj.lscache
+++ b/basket-microservice/Basket.Tests/Basket.Tests.csproj.lscache
@@ -1,0 +1,494 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[properties]
+AssemblyName=Basket.Tests
+CommandLineArgsForDesignTimeEvaluation=-langversion:14.0 -define:TRACE
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=14.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=Basket.Tests
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../../MicroservicesInDotNet.sln
+TargetFrameworkIdentifier=.NETCoreApp
+TargetPath=<PATH>bin/Debug/net10.0/Basket.Tests.dll
+TargetRefPath=<PATH>obj/Debug/net10.0/ref/Basket.Tests.dll
+TemporaryDependencyNodeTargetIdentifier=net10.0
+
+[commandLineArguments]
+/noconfig
+/unsafe-
+/checked-
+/nowarn:NU1603,NU1902,NU1903,NU5104,CA1711,CA1707,CA1716,1701,1702,8002
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/warn:10
+/define:TRACE;DEBUG;NET;NET10_0;NETCOREAPP;NET5_0_OR_GREATER;NET6_0_OR_GREATER;NET7_0_OR_GREATER;NET8_0_OR_GREATER;NET9_0_OR_GREATER;NET10_0_OR_GREATER;NETCOREAPP1_0_OR_GREATER;NETCOREAPP1_1_OR_GREATER;NETCOREAPP2_0_OR_GREATER;NETCOREAPP2_1_OR_GREATER;NETCOREAPP2_2_OR_GREATER;NETCOREAPP3_0_OR_GREATER;NETCOREAPP3_1_OR_GREATER
+/highentropyva+
+/nullable:enable
+/features:"InterceptorsNamespaces=;Microsoft.Extensions.Validation.Generated"
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\net10.0\Basket.Tests.dll
+/refout:obj\Debug\net10.0\refint\Basket.Tests.dll
+/target:exe
+/warnaserror+
+/utf8output
+/deterministic+
+/langversion:14.0
+/warnaserror+:NU1605,SYSLIB0011
+
+[sourceFiles]
+<NUGET>/microsoft.net.test.sdk/17.14.1/build/net8.0/Microsoft.NET.Test.Sdk.Program.cs
+Domain/CustomerBasketTests.cs
+Endpoints/BasketApiEndpointsTests.cs
+IntegrationEvents/MessagingProviderBootTests.cs
+obj/Debug/net10.0/
+ .NETCoreApp,Version=v10.0.AssemblyAttributes.cs
+ Basket.Tests.AssemblyInfo.cs
+ Basket.Tests.GlobalUsings.g.cs
+Qa/BasketQaSeederTests.cs
+
+[metadataReferences]
+../Basket.Service/obj/Debug/net10.0/ref/Basket.Service.dll
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.AspNetCore.Antiforgery.dll
+ Microsoft.AspNetCore.Authentication.Abstractions.dll
+ Microsoft.AspNetCore.Authentication.BearerToken.dll
+ Microsoft.AspNetCore.Authentication.Cookies.dll
+ Microsoft.AspNetCore.Authentication.Core.dll
+ Microsoft.AspNetCore.Authentication.dll
+ Microsoft.AspNetCore.Authentication.OAuth.dll
+ Microsoft.AspNetCore.Authorization.dll
+ Microsoft.AspNetCore.Authorization.Policy.dll
+ Microsoft.AspNetCore.Components.Authorization.dll
+ Microsoft.AspNetCore.Components.dll
+ Microsoft.AspNetCore.Components.Endpoints.dll
+ Microsoft.AspNetCore.Components.Forms.dll
+ Microsoft.AspNetCore.Components.Server.dll
+ Microsoft.AspNetCore.Components.Web.dll
+ Microsoft.AspNetCore.Connections.Abstractions.dll
+ Microsoft.AspNetCore.CookiePolicy.dll
+ Microsoft.AspNetCore.Cors.dll
+ Microsoft.AspNetCore.Cryptography.Internal.dll
+ Microsoft.AspNetCore.Cryptography.KeyDerivation.dll
+ Microsoft.AspNetCore.DataProtection.Abstractions.dll
+ Microsoft.AspNetCore.DataProtection.dll
+ Microsoft.AspNetCore.DataProtection.Extensions.dll
+ Microsoft.AspNetCore.Diagnostics.Abstractions.dll
+ Microsoft.AspNetCore.Diagnostics.dll
+ Microsoft.AspNetCore.Diagnostics.HealthChecks.dll
+ Microsoft.AspNetCore.dll
+ Microsoft.AspNetCore.HostFiltering.dll
+ Microsoft.AspNetCore.Hosting.Abstractions.dll
+ Microsoft.AspNetCore.Hosting.dll
+ Microsoft.AspNetCore.Hosting.Server.Abstractions.dll
+ Microsoft.AspNetCore.Html.Abstractions.dll
+ Microsoft.AspNetCore.Http.Abstractions.dll
+ Microsoft.AspNetCore.Http.Connections.Common.dll
+ Microsoft.AspNetCore.Http.Connections.dll
+ Microsoft.AspNetCore.Http.dll
+ Microsoft.AspNetCore.Http.Extensions.dll
+ Microsoft.AspNetCore.Http.Features.dll
+ Microsoft.AspNetCore.Http.Results.dll
+ Microsoft.AspNetCore.HttpLogging.dll
+ Microsoft.AspNetCore.HttpOverrides.dll
+ Microsoft.AspNetCore.HttpsPolicy.dll
+ Microsoft.AspNetCore.Identity.dll
+ Microsoft.AspNetCore.Localization.dll
+ Microsoft.AspNetCore.Localization.Routing.dll
+ Microsoft.AspNetCore.Metadata.dll
+ Microsoft.AspNetCore.Mvc.Abstractions.dll
+ Microsoft.AspNetCore.Mvc.ApiExplorer.dll
+ Microsoft.AspNetCore.Mvc.Core.dll
+ Microsoft.AspNetCore.Mvc.Cors.dll
+ Microsoft.AspNetCore.Mvc.DataAnnotations.dll
+ Microsoft.AspNetCore.Mvc.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Json.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Xml.dll
+ Microsoft.AspNetCore.Mvc.Localization.dll
+ Microsoft.AspNetCore.Mvc.Razor.dll
+ Microsoft.AspNetCore.Mvc.RazorPages.dll
+ Microsoft.AspNetCore.Mvc.TagHelpers.dll
+ Microsoft.AspNetCore.Mvc.ViewFeatures.dll
+ Microsoft.AspNetCore.OutputCaching.dll
+ Microsoft.AspNetCore.RateLimiting.dll
+ Microsoft.AspNetCore.Razor.dll
+ Microsoft.AspNetCore.Razor.Runtime.dll
+ Microsoft.AspNetCore.RequestDecompression.dll
+ Microsoft.AspNetCore.ResponseCaching.Abstractions.dll
+ Microsoft.AspNetCore.ResponseCaching.dll
+ Microsoft.AspNetCore.ResponseCompression.dll
+ Microsoft.AspNetCore.Rewrite.dll
+ Microsoft.AspNetCore.Routing.Abstractions.dll
+ Microsoft.AspNetCore.Routing.dll
+ Microsoft.AspNetCore.Server.HttpSys.dll
+ Microsoft.AspNetCore.Server.IIS.dll
+ Microsoft.AspNetCore.Server.IISIntegration.dll
+ Microsoft.AspNetCore.Server.Kestrel.Core.dll
+ Microsoft.AspNetCore.Server.Kestrel.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll
+ Microsoft.AspNetCore.Session.dll
+ Microsoft.AspNetCore.SignalR.Common.dll
+ Microsoft.AspNetCore.SignalR.Core.dll
+ Microsoft.AspNetCore.SignalR.dll
+ Microsoft.AspNetCore.SignalR.Protocols.Json.dll
+ Microsoft.AspNetCore.StaticAssets.dll
+ Microsoft.AspNetCore.StaticFiles.dll
+ Microsoft.AspNetCore.WebSockets.dll
+ Microsoft.AspNetCore.WebUtilities.dll
+ Microsoft.Extensions.Caching.Abstractions.dll
+ Microsoft.Extensions.Caching.Memory.dll
+ Microsoft.Extensions.Configuration.Abstractions.dll
+ Microsoft.Extensions.Configuration.Binder.dll
+ Microsoft.Extensions.Configuration.CommandLine.dll
+ Microsoft.Extensions.Configuration.dll
+ Microsoft.Extensions.Configuration.EnvironmentVariables.dll
+ Microsoft.Extensions.Configuration.FileExtensions.dll
+ Microsoft.Extensions.Configuration.Ini.dll
+ Microsoft.Extensions.Configuration.Json.dll
+ Microsoft.Extensions.Configuration.KeyPerFile.dll
+ Microsoft.Extensions.Configuration.UserSecrets.dll
+ Microsoft.Extensions.Configuration.Xml.dll
+ Microsoft.Extensions.DependencyInjection.Abstractions.dll
+ Microsoft.Extensions.DependencyInjection.dll
+ Microsoft.Extensions.Diagnostics.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.dll
+ Microsoft.Extensions.Features.dll
+ Microsoft.Extensions.FileProviders.Abstractions.dll
+ Microsoft.Extensions.FileProviders.Composite.dll
+ Microsoft.Extensions.FileProviders.Embedded.dll
+ Microsoft.Extensions.FileProviders.Physical.dll
+ Microsoft.Extensions.FileSystemGlobbing.dll
+ Microsoft.Extensions.Hosting.Abstractions.dll
+ Microsoft.Extensions.Hosting.dll
+ Microsoft.Extensions.Http.dll
+ Microsoft.Extensions.Identity.Core.dll
+ Microsoft.Extensions.Identity.Stores.dll
+ Microsoft.Extensions.Localization.Abstractions.dll
+ Microsoft.Extensions.Localization.dll
+ Microsoft.Extensions.Logging.Abstractions.dll
+ Microsoft.Extensions.Logging.Configuration.dll
+ Microsoft.Extensions.Logging.Console.dll
+ Microsoft.Extensions.Logging.Debug.dll
+ Microsoft.Extensions.Logging.dll
+ Microsoft.Extensions.Logging.EventLog.dll
+ Microsoft.Extensions.Logging.EventSource.dll
+ Microsoft.Extensions.Logging.TraceSource.dll
+ Microsoft.Extensions.ObjectPool.dll
+ Microsoft.Extensions.Options.ConfigurationExtensions.dll
+ Microsoft.Extensions.Options.DataAnnotations.dll
+ Microsoft.Extensions.Options.dll
+ Microsoft.Extensions.Primitives.dll
+ Microsoft.Extensions.Validation.dll
+ Microsoft.Extensions.WebEncoders.dll
+ Microsoft.JSInterop.dll
+ Microsoft.Net.Http.Headers.dll
+ System.Diagnostics.EventLog.dll
+ System.Formats.Cbor.dll
+ System.Security.Cryptography.Xml.dll
+ System.Threading.RateLimiting.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.CSharp.dll
+ Microsoft.VisualBasic.Core.dll
+ Microsoft.VisualBasic.dll
+ Microsoft.Win32.Primitives.dll
+ Microsoft.Win32.Registry.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.Immutable.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Annotations.dll
+ System.ComponentModel.DataAnnotations.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Configuration.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.DataSetExtensions.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.DiagnosticSource.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Formats.Asn1.dll
+ System.Formats.Tar.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.Brotli.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.AccessControl.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipelines.dll
+ System.IO.Pipes.AccessControl.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.AsyncEnumerable.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.Http.Json.dll
+ System.Net.HttpListener.dll
+ System.Net.Mail.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Quic.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.ServerSentEvents.dll
+ System.Net.ServicePoint.dll
+ System.Net.Sockets.dll
+ System.Net.WebClient.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebProxy.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Metadata.dll
+ System.Reflection.Primitives.dll
+ System.Reflection.TypeExtensions.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.Unsafe.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.JavaScript.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Intrinsics.dll
+ System.Runtime.Loader.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.AccessControl.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Cng.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.OpenSsl.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.dll
+ System.Security.Principal.dll
+ System.Security.Principal.Windows.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.ServiceProcess.dll
+ System.Text.Encoding.CodePages.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.Encodings.Web.dll
+ System.Text.Json.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.AccessControl.dll
+ System.Threading.Channels.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.Dataflow.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.Transactions.Local.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Web.HttpUtility.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+ WindowsBase.dll
+<NUGET>/
+ azure.core.amqp/1.3.1/lib/netstandard2.0/Azure.Core.Amqp.dll
+ azure.core/1.47.1/lib/net8.0/Azure.Core.dll
+ azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
+ azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
+ azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
+ bouncycastle.cryptography/2.6.2/lib/net6.0/BouncyCastle.Cryptography.dll
+ castle.core/5.1.1/lib/net6.0/Castle.Core.dll
+ docker.dotnet.enhanced.x509/3.131.1/lib/net10.0/Docker.DotNet.X509.dll
+ docker.dotnet.enhanced/3.131.1/lib/net10.0/Docker.DotNet.dll
+ ecommerce.shared/2.14.0/lib/net10.0/ECommerce.Shared.dll
+ google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
+ grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
+ grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll
+ grpc.net.common/2.52.0/lib/net7.0/Grpc.Net.Common.dll
+ microsoft.aspnetcore.authentication.jwtbearer/10.0.5/lib/net10.0/Microsoft.AspNetCore.Authentication.JwtBearer.dll
+ microsoft.aspnetcore.mvc.testing/10.0.5/lib/net10.0/Microsoft.AspNetCore.Mvc.Testing.dll
+ microsoft.aspnetcore.testhost/10.0.5/lib/net10.0/Microsoft.AspNetCore.TestHost.dll
+ microsoft.azure.amqp/2.6.7/lib/netstandard2.0/Microsoft.Azure.Amqp.dll
+ microsoft.bcl.asyncinterfaces/8.0.0/lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll
+ microsoft.bcl.cryptography/9.0.4/lib/net9.0/Microsoft.Bcl.Cryptography.dll
+ microsoft.codecoverage/17.14.1/lib/net8.0/Microsoft.VisualStudio.CodeCoverage.Shim.dll
+ microsoft.data.sqlclient/6.1.1/ref/net9.0/Microsoft.Data.SqlClient.dll
+ microsoft.entityframeworkcore.abstractions/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Abstractions.dll
+ microsoft.entityframeworkcore.relational/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Relational.dll
+ microsoft.entityframeworkcore.sqlserver/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.SqlServer.dll
+ microsoft.entityframeworkcore/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.dll
+ microsoft.extensions.caching.stackexchangeredis/10.0.5/lib/net10.0/Microsoft.Extensions.Caching.StackExchangeRedis.dll
+ microsoft.extensions.dependencymodel/10.0.5/lib/net10.0/Microsoft.Extensions.DependencyModel.dll
+ microsoft.identity.client.extensions.msal/4.73.1/lib/net8.0/Microsoft.Identity.Client.Extensions.Msal.dll
+ microsoft.identity.client/4.73.1/lib/net8.0/Microsoft.Identity.Client.dll
+ microsoft.identitymodel.abstractions/8.0.1/lib/net9.0/Microsoft.IdentityModel.Abstractions.dll
+ microsoft.identitymodel.jsonwebtokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.JsonWebTokens.dll
+ microsoft.identitymodel.logging/8.0.1/lib/net9.0/Microsoft.IdentityModel.Logging.dll
+ microsoft.identitymodel.protocols.openidconnect/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.dll
+ microsoft.identitymodel.protocols/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.dll
+ microsoft.identitymodel.tokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.Tokens.dll
+ microsoft.openapi/1.6.14/lib/netstandard2.0/Microsoft.OpenApi.dll
+ microsoft.sqlserver.server/1.0.0/lib/netstandard2.0/Microsoft.SqlServer.Server.dll
+ microsoft.testplatform.testhost/17.14.1/lib/net8.0/
+  Microsoft.TestPlatform.CommunicationUtilities.dll
+  Microsoft.TestPlatform.CoreUtilities.dll
+  Microsoft.TestPlatform.CrossPlatEngine.dll
+  Microsoft.TestPlatform.PlatformAbstractions.dll
+  Microsoft.TestPlatform.Utilities.dll
+  Microsoft.VisualStudio.TestPlatform.Common.dll
+  Microsoft.VisualStudio.TestPlatform.ObjectModel.dll
+  testhost.dll
+ newtonsoft.json/13.0.3/lib/net6.0/Newtonsoft.Json.dll
+ nsubstitute/5.3.0/lib/net6.0/NSubstitute.dll
+ opentelemetry.api.providerbuilderextensions/1.10.0/lib/net9.0/OpenTelemetry.Api.ProviderBuilderExtensions.dll
+ opentelemetry.api/1.10.0/lib/net9.0/OpenTelemetry.Api.dll
+ opentelemetry.exporter.console/1.9.0/lib/net8.0/OpenTelemetry.Exporter.Console.dll
+ opentelemetry.exporter.opentelemetryprotocol/1.9.0/lib/net8.0/OpenTelemetry.Exporter.OpenTelemetryProtocol.dll
+ opentelemetry.exporter.prometheus.aspnetcore/1.10.0-beta.1/lib/net9.0/OpenTelemetry.Exporter.Prometheus.AspNetCore.dll
+ opentelemetry.extensions.hosting/1.9.0/lib/net8.0/OpenTelemetry.Extensions.Hosting.dll
+ opentelemetry.instrumentation.aspnetcore/1.9.0/lib/net8.0/OpenTelemetry.Instrumentation.AspNetCore.dll
+ opentelemetry.instrumentation.sqlclient/1.9.0-beta.1/lib/net8.0/OpenTelemetry.Instrumentation.SqlClient.dll
+ opentelemetry.persistentstorage.abstractions/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.Abstractions.dll
+ opentelemetry.persistentstorage.filesystem/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.FileSystem.dll
+ opentelemetry/1.10.0/lib/net9.0/OpenTelemetry.dll
+ pipelines.sockets.unofficial/2.2.8/lib/net5.0/Pipelines.Sockets.Unofficial.dll
+ polly.core/8.6.6/lib/net8.0/Polly.Core.dll
+ rabbitmq.client/6.8.1/lib/netstandard2.0/RabbitMQ.Client.dll
+ sharpziplib/1.4.2/lib/net6.0/ICSharpCode.SharpZipLib.dll
+ ssh.net/2025.1.0/lib/net9.0/Renci.SshNet.dll
+ stackexchange.redis/2.8.16/lib/net6.0/StackExchange.Redis.dll
+ swashbuckle.aspnetcore.swagger/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.Swagger.dll
+ swashbuckle.aspnetcore.swaggergen/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.dll
+ swashbuckle.aspnetcore.swaggerui/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.dll
+ system.clientmodel/1.5.1/lib/net8.0/System.ClientModel.dll
+ system.identitymodel.tokens.jwt/8.0.1/lib/net9.0/System.IdentityModel.Tokens.Jwt.dll
+ system.memory.data/8.0.1/lib/net8.0/System.Memory.Data.dll
+ system.security.cryptography.pkcs/9.0.4/lib/net9.0/System.Security.Cryptography.Pkcs.dll
+ system.security.cryptography.protecteddata/9.0.4/lib/net9.0/System.Security.Cryptography.ProtectedData.dll
+ testcontainers.redis/4.11.0/lib/net10.0/Testcontainers.Redis.dll
+ testcontainers/4.11.0/lib/net10.0/Testcontainers.dll
+ xunit.abstractions/2.0.3/lib/netstandard2.0/xunit.abstractions.dll
+ xunit.assert/2.9.3/lib/net6.0/xunit.assert.dll
+ xunit.extensibility.core/2.9.3/lib/netstandard1.1/xunit.core.dll
+ xunit.extensibility.execution/2.9.3/lib/netstandard1.1/xunit.execution.dotnet.dll
+
+[analyzerReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.AspNetCore.App.Analyzers.dll
+ Microsoft.AspNetCore.App.CodeFixes.dll
+ Microsoft.AspNetCore.App.SourceGenerators.dll
+ Microsoft.AspNetCore.Components.Analyzers.dll
+ Microsoft.Extensions.Logging.Generators.dll
+ Microsoft.Extensions.Options.SourceGeneration.dll
+ Microsoft.Extensions.Validation.ValidationsGenerator.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.Interop.ComInterfaceGenerator.dll
+ Microsoft.Interop.JavaScript.JSImportGenerator.dll
+ Microsoft.Interop.LibraryImportGenerator.dll
+ Microsoft.Interop.SourceGeneration.dll
+ System.Text.Json.SourceGeneration.dll
+ System.Text.RegularExpressions.Generator.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/
+ Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll
+ Microsoft.CodeAnalysis.NetAnalyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/codestyle/cs/
+ Microsoft.CodeAnalysis.CodeStyle.dll
+ Microsoft.CodeAnalysis.CodeStyle.Fixes.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.dll
+<NUGET>/
+ microsoft.entityframeworkcore.analyzers/10.0.5/analyzers/dotnet/cs/Microsoft.EntityFrameworkCore.Analyzers.dll
+ system.clientmodel/1.5.1/analyzers/dotnet/cs/System.ClientModel.SourceGeneration.dll
+ xunit.analyzers/1.18.0/analyzers/dotnet/cs/
+  xunit.analyzers.dll
+  xunit.analyzers.fixes.dll
+
+[analyzerConfigFiles]
+../../.editorconfig
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_10_recommended.globalconfig
+obj/Debug/net10.0/Basket.Tests.GeneratedMSBuildEditorConfig.editorconfig

--- a/docs/adr/0002-transactional-outbox-per-publishing-service.md
+++ b/docs/adr/0002-transactional-outbox-per-publishing-service.md
@@ -11,7 +11,9 @@ Implemented as shared infrastructure in [`shared-libs/ECommerce.Shared/Infrastru
 
 ## Decision
 
-Every publishing service owns a transactional outbox: integration events are written to an `OutboxContext` table inside the same DbContext transaction as the business state change. A background `OutboxBackgroundService` (also from the shared library) polls unpublished rows and pushes them to RabbitMQ, then marks them sent. Each service runs its own outbox table — there is no shared outbox database.
+Every publishing service owns a transactional outbox: integration events are written to an `OutboxContext` table inside the same DbContext transaction as the business state change. A background `OutboxBackgroundService` (also from the shared library) polls unpublished rows and pushes them to the configured broker, then marks them sent. Each service runs its own outbox table — there is no shared outbox database.
+
+Business call sites publish through the `IOutboxUnitOfWork` seam, which owns the execution-strategy retry loop, the ambient transaction, event enqueuing, and telemetry. It is provider-neutral — callers never reference RabbitMQ- or Azure Service Bus-specific types; delivery stays selected by `Messaging:Provider`. The lower-level `IOutboxStore` primitive is retained (not removed) for the unit-of-work implementation, the outbox poller, and `/internal/outbox` routes. See [`Shared-Library.md` § Preferred caller seam](../wiki/Shared-Library.md#preferred-caller-seam-ioutboxunitofwork).
 
 ## Consequences
 

--- a/docs/prd/PRD-Outbox-UoW-Deep-Seam.md
+++ b/docs/prd/PRD-Outbox-UoW-Deep-Seam.md
@@ -1,0 +1,124 @@
+# PRD — Deepen the shared Outbox unit-of-work seam
+
+> Status: draft, 2026-05-15.
+> Companion / dependent: [PRD-Payment-Depth-Outbox-UoW.md](PRD-Payment-Depth-Outbox-UoW.md). Phases 4–6 of that PRD depend on this one shipping first.
+
+## Problem Statement
+
+The shared `IOutboxUnitOfWork` shipped on the Payment branch (`ECommerce.Shared` 2.15.0) only owns *part* of the transactional-publishing seam. It runs a caller-supplied delegate inside an EF execution strategy + ambient `TransactionScope` and enqueues the events returned by the delegate. It does not own:
+
+- the `DbContext` reference used inside the unit of work,
+- the EF Core `SaveChangesAsync(acceptAllChangesOnSuccess: false)` call,
+- the `ChangeTracker`-based domain-event dequeue used by aggregates,
+- the post-commit `ChangeTracker.AcceptAllChanges()` step.
+
+As a result:
+
+1. `OrderContext.ExecuteAsync` (`order-microservice/Order.Service/Infrastructure/Data/EntityFramework/OrderContext.cs:54`) still hand-rolls the full pattern — `Database.CreateExecutionStrategy()`, `TransactionScope`, ChangeTracker dequeue, `SaveChangesAsync`, `AddOutboxEvent`, `AcceptAllChanges`, `scope.Complete()` — and does **not** call the shared seam.
+2. `PaymentContext.ExecuteAsync` does call the shared seam, but re-implements ChangeTracker dequeue + `SaveChangesAsync` above it. The shared seam alone is not enough for an aggregate-with-domain-events caller.
+3. Inventory and Shipping handlers/endpoints have no aggregate-with-domain-events pattern at all (their stores expose `Reserve/Release/CreateShipmentsForOrder/...` directly), so they would adopt a seam shape that *is* enough for them but inconsistent with how Order and Payment use it.
+
+The deletion test: if you delete `IOutboxUnitOfWork` today, only the Payment Capture/Refund/Authorize/Fail/Void path scatters. Order is unaffected — the seam was never deep enough to absorb Order's pattern. That asymmetry is the bug this PRD fixes.
+
+## Solution
+
+Make `IOutboxUnitOfWork` deep enough that **every** transactional-publishing caller in the repo can call it without re-implementing EF dequeue, `SaveChanges`, or `AcceptAllChanges`. Keep the existing shallow overload for non-aggregate callers (Inventory, Shipping handlers/endpoints), but add a deeper overload that takes the `DbContext` and the aggregate-entity base type and owns the dequeue + persist + accept-changes contract end-to-end.
+
+From a developer's perspective, after this PRD ships:
+
+- A service with an aggregate-and-domain-events pattern (Order, Payment) calls `outboxUoW.ExecuteAsync(myContext, () => { aggregate.Mutate(...); return Task.CompletedTask; }, translator)` and the seam handles everything inside the transaction.
+- A service without that pattern (Inventory, Shipping endpoints/handlers) calls `outboxUoW.ExecuteAsync(strategy, () => { ... do work ...; return events; })` exactly as today.
+- `OrderContext.ExecuteAsync` becomes a thin wrapper that delegates to the deep overload with its translation table; the hand-rolled transaction code is deleted.
+- `PaymentContext.ExecuteAsync` collapses to the same thin shape as `OrderContext.ExecuteAsync`.
+- The next aggregate-bearing service (Shipping, when it gets the deeper refactor — out of scope here) inherits the same shape without writing any transaction code.
+
+## User Stories
+
+1. As a developer working on `ECommerce.Shared`, I want `IOutboxUnitOfWork` to expose a deep overload that takes a `DbContext`, a unit-of-work delegate, and a domain-event translator, so that aggregate-bearing services do not re-implement EF dequeue or `SaveChanges` semantics.
+2. As a developer working on `ECommerce.Shared`, I want the existing shallow overload (strategy + delegate returning events) to remain unchanged, so that Inventory and Shipping handler/endpoint adoption is not blocked on adopting domain events.
+3. As an Order service maintainer, I want `OrderContext.ExecuteAsync` to be a thin wrapper around the deep overload with Order's translation table, so that the saga linchpin shares one seam with Payment.
+4. As a Payment service maintainer, I want `PaymentContext.ExecuteAsync` to collapse to the same thin wrapper shape, so that Order and Payment look like siblings rather than two divergent implementations.
+5. As a developer adopting the seam in a service without an aggregate, I want the shallow overload to keep working with no breaking changes, so that Inventory and Shipping adoption is purely additive.
+6. As an operator, I want both overloads to emit the same OTEL span and the same outbox-transaction outcome metric, so that observability is uniform across aggregate and non-aggregate callers.
+7. As a maintainer of `ECommerce.Shared`, I want the deepened seam shipped as a single shared-package version bump, so that consumer migration in the dependent PRD happens against one stable contract.
+8. As a developer writing tests, I want shared-library tests to cover the deep overload's atomic commit, atomic rollback, ChangeTracker dequeue, and `AcceptAllChanges` semantics, so that Order's and Payment's correctness regression-tests live in one place.
+9. As a developer writing tests, I want Order's existing `OrderContext.ExecuteAsync` integration tests to keep passing after `OrderContext` migrates to the deep overload, so that the migration is observably behaviour-preserving.
+10. As a developer writing tests, I want Payment's existing `PaymentContext.ExecuteAsync` integration tests to keep passing after `PaymentContext` migrates to the deep overload, so that the migration is observably behaviour-preserving.
+11. As a CI maintainer, I want `Directory.Build.props` `TreatWarningsAsErrors` to keep passing across `ECommerce.Shared`, Order, Payment, and `ECommerce.Shared.Tests`, so that the deeper interface introduces no new `NoWarn` exemptions.
+12. As a developer running either supported broker provider, I want the deepened seam to remain transport-neutral, so that `Messaging:Provider` switching keeps working unchanged.
+
+## Implementation Decisions
+
+### Modules
+
+**Modified — `ECommerce.Shared` Outbox seam (`shared-libs/ECommerce.Shared/Infrastructure/Outbox`)**
+- `IOutboxUnitOfWork` keeps the existing `ExecuteAsync(IExecutionStrategy, Func<Task<IReadOnlyList<Event>>>)` overload for non-aggregate callers.
+- `IOutboxUnitOfWork` gains a new overload for aggregate-bearing callers that takes (1) a `DbContext` whose `Database.CreateExecutionStrategy()` is used, (2) a `Func<Task>` unit of work that mutates aggregates tracked by the context, and (3) a translator from the caller's domain-event base interface to `Event`. The implementation owns the `TransactionScope`, calls `unitOfWork()`, dequeues domain events from `ChangeTracker.Entries<TEntity>()`, calls `SaveChangesAsync(acceptAllChangesOnSuccess: false)`, enqueues translated events via `IOutboxStore.AddOutboxEvent`, calls `ChangeTracker.AcceptAllChanges()`, then `scope.Complete()`.
+- The entity base type (today `Order.Service.Models.Entity` and `Payment.Service.Models.Entity`) is a generic parameter so each caller's existing base survives. If those two `Entity` types are byte-identical and a shared base in `ECommerce.Shared` is justified, that promotion is a separate decision and is **out of scope** here.
+- OTEL span and outcome metric are emitted by both overloads through a shared helper so observability is uniform.
+
+**Modified — `Order.Service` `OrderContext`**
+- `OrderContext.ExecuteAsync` becomes: `return _outboxUoW.ExecuteAsync<Models.Entity>(this, unitOfWork, Translate);` — no more local `CreateExecutionStrategy`, no more `TransactionScope`, no more manual `SaveChangesAsync` / `AcceptAllChanges`. The translation table (`OrderCreatedDomainEvent → OrderCreatedEvent`, etc.) stays in `OrderContext`.
+- The `OrderContext` design-time constructor that omits `IOutboxStore`/`IOutboxUnitOfWork` is preserved (EF Core tooling needs it). Calling `ExecuteAsync` without the runtime constructor still throws as today.
+
+**Modified — `Payment.Service` `PaymentContext`**
+- `PaymentContext.ExecuteAsync` is rewritten the same way against the deep overload. Payment's translation table for `PaymentAuthorizedDomainEvent`, `PaymentCapturedDomainEvent`, `PaymentFailedDomainEvent`, `PaymentRefundedDomainEvent` stays in `PaymentContext`.
+
+**Unchanged — Inventory, Shipping**
+- No changes in this PRD. They continue to call `IOutboxStore` directly today and migrate to the shallow `IOutboxUnitOfWork` overload in the companion Payment PRD (Phases 4–6 there).
+
+### Architectural decisions
+
+- **No removal of the shallow overload.** Inventory and Shipping (no aggregate yet) need it. Removal would force adoption of a domain-event base they do not have.
+- **Translator is per-context.** Domain-event-to-Integration-event mapping stays in each service's context. Shared library has no knowledge of Order, Payment, or any future service's event types.
+- **No new persistent schema.** Outbox tables (ADR-0002) unchanged.
+- **Provider-neutral.** Outbox rows remain provider-neutral; `OutboxBackgroundService` publishes via `IEventBus`. `Messaging:Provider` (RabbitMQ default, Azure Service Bus when selected) is unaffected.
+- **`ECommerce.Shared` version is bumped from `2.15.0` to `2.16.0`** when the deep overload ships. Per ADR-0005, consumers (Order, Payment) upgrade `<PackageReference>` explicitly and a fresh `.nupkg` is pushed to `local-nuget-packages/`. Inventory and Shipping do not need the upgrade until the companion Payment PRD migrates them.
+- **DLQ behaviour is unchanged in scope here.** Subscriber-pipeline exceptions inside handlers using the shallow overload bubble out exactly as they do today; the deep overload is invoked from contexts called by HTTP endpoints, where exceptions return errors to the caller rather than dead-letter. The interaction between handler exceptions and the recently-landed provider-agnostic DLQ capture is owned by the companion Payment PRD's DLQ contract section.
+
+### API contracts
+
+- No public HTTP route changes.
+- Order, Payment Integration Event payloads unchanged.
+
+### Schema changes
+
+- None.
+
+## Testing Decisions
+
+`Given_When_Then` naming.
+
+### Modules to test
+
+**`OutboxUnitOfWork` deep overload (`ECommerce.Shared.Tests`)**
+- New: with a representative `DbContext` containing an entity that raises domain events, assert atomic commit (state + translated events together), atomic rollback when the unit of work throws, atomic rollback when `SaveChangesAsync` throws, `AcceptAllChanges` is called only on the success path, and translated events match the translator output.
+- Prior art: existing `OutboxUnitOfWorkTests` in `shared-libs/ECommerce.Shared.Tests/`.
+
+**`OutboxUnitOfWork` shallow overload (`ECommerce.Shared.Tests`)**
+- Regression: existing tests must keep passing unchanged.
+
+**`OrderContext.ExecuteAsync` (Order integration tests)**
+- Regression: existing Order context tests in `order-microservice/Order.Tests/` must keep passing without modification. Any failure indicates the deep overload diverges from the hand-rolled pattern.
+
+**`PaymentContext.ExecuteAsync` (Payment integration tests)**
+- Regression: existing Payment context tests in `payment-microservice/Payment.Tests/` must keep passing without modification.
+
+### What we are NOT testing
+
+- We are not retesting EF execution strategy or `TransactionScope`.
+- We are not adding broker-delivery tests; that path is identical to today.
+- We are not testing the Inventory/Shipping shallow-overload adoption (that lives in the companion Payment PRD).
+
+## Out of Scope
+
+- **Migrating Inventory or Shipping to either overload.** Owned by the companion Payment PRD (Phases 4–6 after this seam ships).
+- **Promoting `Entity` / `IDomainEvent` from Order/Payment into `ECommerce.Shared`.** Separate decision; the generic parameter on the deep overload avoids forcing it now.
+- **DLQ / subscriber-pipeline exception contract.** Owned by the companion Payment PRD.
+- **OTEL span attribute schema** beyond "uniform across overloads" — exact attribute names are an instrumentation refinement decided during implementation.
+
+## Further Notes
+
+- Sequencing: this PRD must ship before the companion Payment PRD's Phase 4 starts. Phase 4 of that PRD migrates Inventory and Shipping using the **shallow** overload, which is unchanged here; but Phase 5 (observability) of that PRD piggybacks on the uniform OTEL helper introduced here.
+- Pre-commit only runs Basket tests. After the package version bump, Order, Payment, and `ECommerce.Shared.Tests` must be run manually before pushing.
+- `Directory.Build.props` enforces `TreatWarningsAsErrors`; no new `NoWarn` is acceptable.

--- a/docs/prd/PRD-Payment-Depth-Outbox-UoW.md
+++ b/docs/prd/PRD-Payment-Depth-Outbox-UoW.md
@@ -1,5 +1,7 @@
 # PRD — Payment domain-event depth + shared Outbox unit-of-work
 
+> Depends on: [PRD-Outbox-UoW-Deep-Seam.md](PRD-Outbox-UoW-Deep-Seam.md). Phases 4–6 below require that PRD's deep-overload seam (and its `ECommerce.Shared` 2.16.0 bump) to have shipped first; Phase 5 here also relies on its uniform OTEL helper.
+
 ## Problem Statement
 
 As a developer working in this repo, I have to repeat the same transactional ceremony every time I publish an Integration Event. The PR branch has started removing this ceremony for Payment Capture, but the broader problem remains: Payment Refund, Payment event handlers, **Inventory** event handlers, and **Shipping** publishing endpoints still expose some combination of `TransactionScope`, EF Core execution strategy calls, manual Integration Event construction, `IOutboxStore.AddOutboxEvent`, and `scope.Complete()`.
@@ -51,6 +53,11 @@ From a developer's perspective:
 21. As a maintainer of `ECommerce.Shared`, I want the package version to be bumped when the deepened Outbox seam is shipped, so that consumers explicitly opt into the new interface per the local-NuGet-feed workflow (ADR-0005).
 22. As a CI maintainer, I want `dotnet format` and `TreatWarningsAsErrors` to keep passing, so that nothing in this refactor relies on style or warning exemptions beyond what the repo already documents.
 23. As a developer running either supported broker provider, I want the Outbox unit-of-work to remain independent of RabbitMQ and Azure Service Bus adapter details, so that `Messaging:Provider` can change the delivery transport without changing domain or transactional publishing code.
+24. As an Order service maintainer, I want `OrderContext.ExecuteAsync` to call the shared deep overload rather than re-implement transaction + dequeue + `SaveChanges` locally, so that Order and Payment share one transactional-publishing implementation and the "Order is the worked example" claim is true.
+25. As an Inventory service maintainer, I want every ceremony site in Inventory (`OrderCreatedEventHandler`, `OrderCancelledEventHandler`, `OrderConfirmedEventHandler`, and the `restock`/`threshold`/`reserve` endpoints in `InventoryApiEndpoints`) to adopt the shallow overload, so that no `CreateExecutionStrategy + TransactionScope` block remains in Inventory.
+26. As a Shipping service maintainer, I want every ceremony site in Shipping (`OrderCancelledEventHandler`, `OrderConfirmedEventHandler`, `StockCommittedEventHandler`, the `dispatch`/`webhook`/`ApplyTransitionAsync` paths in `ShippingApiEndpoints`, and `CarrierPollingService.PollOnceAsync`) plus the `CarrierStatusApplier` helper to adopt the shallow overload, so that no `CreateExecutionStrategy + TransactionScope` block remains in Shipping.
+27. As a saga operator, I want every migrated subscriber handler to preserve the existing exception-propagation contract that the provider-agnostic DLQ capture relies on, so that retries and dead-letter routing continue to work for both RabbitMQ and Azure Service Bus after the migration.
+28. As a QA owner, I want the saga happy-path and compensation smoke tests re-verified end-to-end after each migration phase, so that regressions across Order ↔ Inventory ↔ Payment ↔ Shipping are caught before the package version is bumped again.
 
 ## Implementation Decisions
 
@@ -81,11 +88,26 @@ From a developer's perspective:
 - Capture and Refund endpoints lose their `outboxStore.CreateExecutionStrategy().ExecuteAsync(...)` blocks and their direct `AddOutboxEvent` calls. They become: load aggregate → check state / call gateway → call `paymentContext.ExecuteAsync(() => { aggregate.Transition(...); return Task.CompletedTask; })` → record metrics → return response.
 - Authorize is in scope to fit the same shape as Capture and Refund (today the Payment service may construct Payments outside the aggregate transition pattern; this PRD aligns it).
 
-**Modified — Inventory `OrderCreatedEventHandler` and any other handler/endpoint that currently uses the `CreateExecutionStrategy + TransactionScope + AddOutboxEvent` pattern**
-- Migrated to the new Outbox unit-of-work module so the deepened seam has at least two real adopters in addition to Payment (proof the seam is real, not hypothetical).
+**Modified — Order `OrderContext.ExecuteAsync`**
+- Today `OrderContext.ExecuteAsync` (`order-microservice/Order.Service/Infrastructure/Data/EntityFramework/OrderContext.cs:54`) hand-rolls the full ceremony in parallel with the shared seam. It migrates to the deep overload introduced by [PRD-Outbox-UoW-Deep-Seam.md](PRD-Outbox-UoW-Deep-Seam.md) so Order and Payment share one transactional-publishing implementation. Without this migration, the PRD claim that "Order is the worked example" is misleading — the two services would call two different code paths.
 
-**Modified — Shipping endpoints that publish events**
-- Migrated to the new Outbox unit-of-work module. Shipping does not get the full domain-event-translation treatment in this PRD (that is a separate, larger refactor — see *Out of Scope*); it just adopts the deepened Outbox seam.
+**Modified — Inventory ceremony sites (full list)**
+All four files migrate to the shallow `IOutboxUnitOfWork` overload:
+- `inventory-microservice/Inventory.Service/IntegrationEvents/EventHandlers/OrderCreatedEventHandler.cs`
+- `inventory-microservice/Inventory.Service/IntegrationEvents/EventHandlers/OrderCancelledEventHandler.cs`
+- `inventory-microservice/Inventory.Service/IntegrationEvents/EventHandlers/OrderConfirmedEventHandler.cs`
+- `inventory-microservice/Inventory.Service/Endpoints/InventoryApiEndpoints.cs` — the `restock`, `threshold`, and `reserve` POST/PUT handlers each contain a `CreateExecutionStrategy + TransactionScope` block.
+
+**Modified — Shipping ceremony sites (full list)**
+All five files migrate to the shallow `IOutboxUnitOfWork` overload. Shipping does **not** get the aggregate-with-domain-events refactor in this PRD; it only adopts the seam:
+- `shipping-microservice/Shipping.Service/IntegrationEvents/EventHandlers/OrderCancelledEventHandler.cs`
+- `shipping-microservice/Shipping.Service/IntegrationEvents/EventHandlers/OrderConfirmedEventHandler.cs`
+- `shipping-microservice/Shipping.Service/IntegrationEvents/EventHandlers/StockCommittedEventHandler.cs`
+- `shipping-microservice/Shipping.Service/Endpoints/ShippingApiEndpoints.cs` — the `dispatch` and `webhooks/carrier/{carrierKey}` routes plus the `ApplyTransitionAsync` helper used by `pick`/`pack`/`cancel`/`deliver`/`fail`/`return`.
+- `shipping-microservice/Shipping.Service/Carriers/CarrierPollingService.cs` — `PollOnceAsync` wraps a `CreateExecutionStrategy + TransactionScope` block.
+
+**Modified — `CarrierStatusApplier` helper**
+- `shipping-microservice/Shipping.Service/Carriers/CarrierStatusApplier.ApplyAsync` currently accepts `IOutboxStore` and enqueues directly. It is called from both `CarrierPollingService` and the carrier webhook route. The migration must either keep the helper outbox-aware via the deep seam's events-from-result shape, or change the helper to return the events to enqueue and let the caller pass them to `IOutboxUnitOfWork.ExecuteAsync`. The change to this helper is in-scope.
 
 ### Architectural decisions
 
@@ -97,6 +119,8 @@ From a developer's perspective:
 - **Domain events are an internal concern.** `IDomainEvent` and the dequeueing machinery are not exposed to event subscribers. Only Integration Events cross service boundaries.
 - **Aggregate translation tables are per-service.** Each context (Order today, Payment now, Shipping later) owns its own domain-event-to-Integration-event translation; `ECommerce.Shared` provides the dequeue/translate plumbing but not the mapping.
 - **Failure semantics are preserved.** If the gateway call (`gateway.CaptureAsync`, `gateway.RefundAsync`) is currently outside the transaction, it stays outside. The unit-of-work covers the database state change and the outbox enqueue; gateway side effects remain the endpoint's responsibility to sequence.
+- **Subscriber-pipeline exception contract is preserved.** Inventory and Shipping event handlers are invoked by the platform subscriber under the recently-landed provider-agnostic DLQ capture (RabbitMQ + Azure Service Bus). Migrating those handlers from `outboxStore.CreateExecutionStrategy().ExecuteAsync(... TransactionScope ...)` to `IOutboxUnitOfWork.ExecuteAsync(strategy, work)` must preserve the existing exception-propagation behaviour: an exception thrown inside the unit of work rolls back the transaction and bubbles to the subscriber, which then drives retry → DLQ exactly as today. Wrapping or swallowing those exceptions in the seam is **not** allowed. A regression test per migrated handler asserts that a thrown exception inside the work delegate produces the same outward observable behaviour (DB rollback, no outbox row, exception visible to the subscriber) as the pre-migration code.
+- **Order is part of this PRD's scope.** Phase 4 migrates `OrderContext.ExecuteAsync` to the deep overload from [PRD-Outbox-UoW-Deep-Seam.md](PRD-Outbox-UoW-Deep-Seam.md) so Order and Payment converge on one implementation. This is a behaviour-preserving refactor with no Integration Event payload changes.
 
 ### API contracts
 
@@ -132,6 +156,24 @@ A good test in this repo asserts on **external behaviour** through the seam the 
 **Inventory `OrderCreatedEventHandler` and Shipping endpoints (regression)**
 - Existing handler/endpoint tests are expected to keep passing after migration to the new Outbox unit-of-work, with no behaviour change at the seam they assert on. If a test fails because it was asserting on internal `TransactionScope` or `CreateExecutionStrategy` calls, that test was over-specifying and gets rewritten to assert on outcomes.
 
+**Inventory `OrderCancelledEventHandler` / `OrderConfirmedEventHandler` (regression)**
+- Same regression contract as `OrderCreatedEventHandler`: existing tests must keep passing or be rewritten to assert reservation/commit/release outcomes and resulting Integration Events.
+
+**Inventory `InventoryApiEndpoints` (`restock` / `threshold` / `reserve`)**
+- Existing endpoint tests covering low-stock and depleted crossing events must keep passing. Migration must not change which events fire under which threshold transitions.
+
+**Shipping `OrderCancelledEventHandler` / `OrderConfirmedEventHandler` / `StockCommittedEventHandler` (regression)**
+- Existing handler tests must keep passing. `StockCommittedEventHandler`'s "OrderConfirmed-must-precede" guard is preserved by the migration.
+
+**Shipping `CarrierPollingService.PollOnceAsync` and `CarrierStatusApplier`**
+- New: assert that migrating the helper does not change which milestone events (`ShipmentDelivered`, `ShipmentFailed`) and which `ShipmentStatusChangedEvent` are emitted for each `CarrierStatus` code. Test from both call sites (polling background service and webhook endpoint) to cover the helper's two adopters.
+
+**Subscriber-pipeline DLQ regression**
+- For each migrated subscriber handler, a single test asserts that throwing inside the work delegate (e.g. `_inventoryStore.Reserve` throws) results in: no Outbox row enqueued, DB state unchanged, and the exception observable to the subscriber (so DLQ capture continues to work). This proves the seam preserves the exception contract the provider-agnostic DLQ poller relies on.
+
+**Saga smoke-test re-verification**
+- After each phase that migrates a subscriber handler or publishing endpoint, the existing saga happy-path and compensation smoke tests are re-run end-to-end (locally, against the docker-compose stack or the equivalent in-repo harness). The migration is not behaviour-preserving on paper alone.
+
 ### What we are NOT testing
 
 - We are not testing EF Core's execution strategy or `TransactionScope` itself.
@@ -140,6 +182,8 @@ A good test in this repo asserts on **external behaviour** through the seam the 
 
 ## Out of Scope
 
+- **The deep overload of `IOutboxUnitOfWork` itself.** Designing and shipping the deep (DbContext + dequeue + SaveChanges) overload is owned by [PRD-Outbox-UoW-Deep-Seam.md](PRD-Outbox-UoW-Deep-Seam.md). This PRD only consumes that overload (in `OrderContext` and `PaymentContext`) and the existing shallow overload (in Inventory and Shipping).
+- **Promoting `Entity` / `IDomainEvent` into `ECommerce.Shared`.** If duplicated between Order and Payment, that consolidation is a separate decision.
 - **Shipping `IShipmentStore` deepening to saga-aware operations.** Item #3 from the architecture review is deliberately deferred. Shipping adopts the new Outbox seam in this PRD but does not get its own aggregate-with-domain-events refactor.
 - **A passive Saga state-machine module** (item #5 from the review). ADR-0008 stands; this PRD does not introduce any saga coordinator.
 - **Removing or refactoring the API Gateway dual-provider abstraction.** ADR-0001 stands.

--- a/docs/wiki/Shared-Library.md
+++ b/docs/wiki/Shared-Library.md
@@ -49,7 +49,8 @@ graph LR
 | `IRabbitMqConnection` | RabbitMQ adapter connection used when `Messaging:Provider=RabbitMq` |
 | `IDeadLetterCapture` | Provider-selected broker dead-letter capture hosted by the gateway |
 | `IDeadLetterPublisher` | Provider-selected replay publisher used by the gateway operator API |
-| `IOutboxStore` | Atomic "persist + enqueue event" primitive |
+| `IOutboxUnitOfWork` | **Preferred caller-facing seam** for transactional publishing — runs business work under the execution strategy + ambient transaction and enqueues the returned events in the same scope |
+| `IOutboxStore` | Low-level "persist + enqueue event" primitive; backs `IOutboxUnitOfWork` and stays available for infrastructure, outbox polling, and `/internal/outbox` routes |
 | `MetricFactory` | Cached creation of Counters and Histograms |
 
 ## Authorization policies
@@ -71,6 +72,32 @@ Without the outbox, a service that writes its domain row and publishes its event
 2. Broker publish succeeds, DB rolls back → phantom event.
 
 With the outbox, the business row and the outbox row are written in the **same** transaction. A background service periodically polls the outbox and publishes. At-least-once delivery + idempotent handlers = exactly-once effect.
+
+### Preferred caller seam: `IOutboxUnitOfWork`
+
+Business call sites should publish through `IOutboxUnitOfWork`, not by hand-rolling the
+`CreateExecutionStrategy + TransactionScope + AddOutboxEvent + Complete` ceremony:
+
+```csharp
+await outboxUnitOfWork.ExecuteAsync(outboxStore.CreateExecutionStrategy(), async () =>
+{
+    await store.SaveChangesAsync();           // business state change
+    return new Event[] { new SomethingHappenedEvent(...) };  // enqueued in the same transaction
+});
+```
+
+The seam owns the execution strategy retry loop, the ambient transaction, enqueuing the
+returned events, and outbox telemetry. Returning an empty list commits the business work
+with no events.
+
+This seam is **provider-neutral**: callers never reference RabbitMQ- or Azure Service
+Bus-specific types. Delivery of the enqueued rows is still selected by `Messaging:Provider`
+(see [Canonical messaging wiring](#canonical-messaging-wiring)), so switching brokers needs
+no call-site changes.
+
+`IOutboxStore` is **not removed** — it remains the low-level primitive that backs
+`IOutboxUnitOfWork` and is still used directly by infrastructure, the outbox poller, and
+`/internal/outbox` routes. New business code should prefer the unit-of-work seam.
 
 ## Observability wiring
 

--- a/inventory-microservice/Inventory.Service/Endpoints/InventoryApiEndpoints.cs
+++ b/inventory-microservice/Inventory.Service/Endpoints/InventoryApiEndpoints.cs
@@ -1,4 +1,4 @@
-using System.Transactions;
+using ECommerce.Shared.Infrastructure.EventBus;
 using ECommerce.Shared.Infrastructure.Outbox;
 using ECommerce.Shared.Observability.Metrics;
 using Inventory.Service.ApiModels;
@@ -87,6 +87,7 @@ public static class InventoryApiEndpoints
         routeBuilder.MapPost("/{productId:int}/restock", async Task<IResult> (
             [FromServices] IInventoryStore inventoryStore,
             [FromServices] IOutboxStore outboxStore,
+            [FromServices] IOutboxUnitOfWork outboxUnitOfWork,
             [FromServices] MetricFactory metricFactory,
             int productId,
             RestockRequest request) =>
@@ -98,22 +99,23 @@ public static class InventoryApiEndpoints
 
             RestockResult? result = null;
 
-            await outboxStore.CreateExecutionStrategy().ExecuteAsync(async () =>
+            await outboxUnitOfWork.ExecuteAsync(outboxStore.CreateExecutionStrategy(), async () =>
             {
-                using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-
                 result = await inventoryStore.Restock(productId, request.Quantity);
 
                 if (result is null)
                 {
-                    return;
+                    return [];
                 }
 
-                await outboxStore.AddOutboxEvent(new StockAdjustedEvent(
-                    productId,
-                    result.WarehouseId,
-                    request.Quantity,
-                    result.NewOnHand));
+                var events = new List<Event>
+                {
+                    new StockAdjustedEvent(
+                        productId,
+                        result.WarehouseId,
+                        request.Quantity,
+                        result.NewOnHand),
+                };
 
                 var lowStock = StockLevelMonitor.TryLowStockCrossing(
                     productId,
@@ -124,7 +126,7 @@ public static class InventoryApiEndpoints
                     result.Threshold);
                 if (lowStock is not null)
                 {
-                    await outboxStore.AddOutboxEvent(lowStock);
+                    events.Add(lowStock);
                 }
 
                 var depleted = StockLevelMonitor.TryDepletedCrossing(
@@ -134,11 +136,11 @@ public static class InventoryApiEndpoints
                     result.AvailableAfter);
                 if (depleted is not null)
                 {
-                    await outboxStore.AddOutboxEvent(depleted);
+                    events.Add(depleted);
                     metricFactory.Counter("stock-depleted", "events").Add(1);
                 }
 
-                scope.Complete();
+                return events;
             });
 
             if (result is null)
@@ -152,6 +154,7 @@ public static class InventoryApiEndpoints
         routeBuilder.MapPut("/{productId:int}/threshold", async Task<IResult> (
             [FromServices] IInventoryStore inventoryStore,
             [FromServices] IOutboxStore outboxStore,
+            [FromServices] IOutboxUnitOfWork outboxUnitOfWork,
             int productId,
             SetThresholdRequest request) =>
         {
@@ -162,15 +165,13 @@ public static class InventoryApiEndpoints
 
             SetThresholdResult? result = null;
 
-            await outboxStore.CreateExecutionStrategy().ExecuteAsync(async () =>
+            await outboxUnitOfWork.ExecuteAsync(outboxStore.CreateExecutionStrategy(), async () =>
             {
-                using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-
                 result = await inventoryStore.SetThreshold(productId, request.Threshold);
 
                 if (result is null)
                 {
-                    return;
+                    return [];
                 }
 
                 var lowStock = StockLevelMonitor.TryLowStockCrossing(
@@ -180,12 +181,13 @@ public static class InventoryApiEndpoints
                     result.Available,
                     result.ThresholdBefore,
                     result.ThresholdAfter);
-                if (lowStock is not null)
+
+                if (lowStock is null)
                 {
-                    await outboxStore.AddOutboxEvent(lowStock);
+                    return [];
                 }
 
-                scope.Complete();
+                return new List<Event> { lowStock };
             });
 
             if (result is null)
@@ -199,6 +201,7 @@ public static class InventoryApiEndpoints
         routeBuilder.MapPost("/{productId:int}/reserve", async Task<IResult> (
             [FromServices] IInventoryStore inventoryStore,
             [FromServices] IOutboxStore outboxStore,
+            [FromServices] IOutboxUnitOfWork outboxUnitOfWork,
             int productId,
             ReserveRequest request) =>
         {
@@ -214,24 +217,22 @@ public static class InventoryApiEndpoints
 
             ReserveResult? outcome = null;
 
-            await outboxStore.CreateExecutionStrategy().ExecuteAsync(async () =>
+            await outboxUnitOfWork.ExecuteAsync(outboxStore.CreateExecutionStrategy(), async () =>
             {
-                using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-
                 outcome = await inventoryStore.Reserve(
                     request.OrderId,
                     [new ReserveLine(productId, request.Quantity)]);
 
-                if (outcome.Reserved && !outcome.AlreadyProcessed)
+                if (!outcome.Reserved || outcome.AlreadyProcessed)
                 {
-                    var published = outcome.Lines
-                        .Select(l => new ReservedItem(l.ProductId, l.WarehouseId, l.Quantity))
-                        .ToList();
-
-                    await outboxStore.AddOutboxEvent(new StockReservedEvent(request.OrderId, published));
+                    return [];
                 }
 
-                scope.Complete();
+                var published = outcome.Lines
+                    .Select(l => new ReservedItem(l.ProductId, l.WarehouseId, l.Quantity))
+                    .ToList();
+
+                return new List<Event> { new StockReservedEvent(request.OrderId, published) };
             });
 
             if (outcome is null || !outcome.Reserved)

--- a/inventory-microservice/Inventory.Service/Endpoints/InventoryApiEndpoints.cs
+++ b/inventory-microservice/Inventory.Service/Endpoints/InventoryApiEndpoints.cs
@@ -86,7 +86,6 @@ public static class InventoryApiEndpoints
 
         routeBuilder.MapPost("/{productId:int}/restock", async Task<IResult> (
             [FromServices] IInventoryStore inventoryStore,
-            [FromServices] IOutboxStore outboxStore,
             [FromServices] IOutboxUnitOfWork outboxUnitOfWork,
             [FromServices] MetricFactory metricFactory,
             int productId,
@@ -99,7 +98,7 @@ public static class InventoryApiEndpoints
 
             RestockResult? result = null;
 
-            await outboxUnitOfWork.ExecuteAsync(outboxStore.CreateExecutionStrategy(), async () =>
+            await outboxUnitOfWork.ExecuteAsync(async () =>
             {
                 result = await inventoryStore.Restock(productId, request.Quantity);
 
@@ -153,7 +152,6 @@ public static class InventoryApiEndpoints
 
         routeBuilder.MapPut("/{productId:int}/threshold", async Task<IResult> (
             [FromServices] IInventoryStore inventoryStore,
-            [FromServices] IOutboxStore outboxStore,
             [FromServices] IOutboxUnitOfWork outboxUnitOfWork,
             int productId,
             SetThresholdRequest request) =>
@@ -165,7 +163,7 @@ public static class InventoryApiEndpoints
 
             SetThresholdResult? result = null;
 
-            await outboxUnitOfWork.ExecuteAsync(outboxStore.CreateExecutionStrategy(), async () =>
+            await outboxUnitOfWork.ExecuteAsync(async () =>
             {
                 result = await inventoryStore.SetThreshold(productId, request.Threshold);
 
@@ -200,7 +198,6 @@ public static class InventoryApiEndpoints
 
         routeBuilder.MapPost("/{productId:int}/reserve", async Task<IResult> (
             [FromServices] IInventoryStore inventoryStore,
-            [FromServices] IOutboxStore outboxStore,
             [FromServices] IOutboxUnitOfWork outboxUnitOfWork,
             int productId,
             ReserveRequest request) =>
@@ -217,7 +214,7 @@ public static class InventoryApiEndpoints
 
             ReserveResult? outcome = null;
 
-            await outboxUnitOfWork.ExecuteAsync(outboxStore.CreateExecutionStrategy(), async () =>
+            await outboxUnitOfWork.ExecuteAsync(async () =>
             {
                 outcome = await inventoryStore.Reserve(
                     request.OrderId,

--- a/inventory-microservice/Inventory.Service/IntegrationEvents/EventHandlers/OrderCancelledEventHandler.cs
+++ b/inventory-microservice/Inventory.Service/IntegrationEvents/EventHandlers/OrderCancelledEventHandler.cs
@@ -1,10 +1,8 @@
-using System.Transactions;
 using ECommerce.Shared.Infrastructure.EventBus.Abstractions;
 using ECommerce.Shared.Infrastructure.Outbox;
 using ECommerce.Shared.Observability.Metrics;
 using Inventory.Service.Infrastructure.Data;
 using Inventory.Service.Models;
-using Microsoft.EntityFrameworkCore;
 
 namespace Inventory.Service.IntegrationEvents.EventHandlers;
 
@@ -12,27 +10,30 @@ internal class OrderCancelledEventHandler : IEventHandler<OrderCancelledEvent>
 {
     private readonly IInventoryStore _inventoryStore;
     private readonly IOutboxStore _outboxStore;
+    private readonly IOutboxUnitOfWork _outboxUnitOfWork;
     private readonly MetricFactory _metricFactory;
 
-    public OrderCancelledEventHandler(IInventoryStore inventoryStore, IOutboxStore outboxStore, MetricFactory metricFactory)
+    public OrderCancelledEventHandler(
+        IInventoryStore inventoryStore,
+        IOutboxStore outboxStore,
+        IOutboxUnitOfWork outboxUnitOfWork,
+        MetricFactory metricFactory)
     {
         _inventoryStore = inventoryStore;
         _outboxStore = outboxStore;
+        _outboxUnitOfWork = outboxUnitOfWork;
         _metricFactory = metricFactory;
     }
 
     public async Task Handle(OrderCancelledEvent @event)
     {
-        await _outboxStore.CreateExecutionStrategy().ExecuteAsync(async () =>
+        await _outboxUnitOfWork.ExecuteAsync(_outboxStore.CreateExecutionStrategy(), async () =>
         {
-            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-
             var result = await _inventoryStore.ReleaseReservations(@event.OrderId);
 
             if (!result.Released || result.AlreadyProcessed)
             {
-                scope.Complete();
-                return;
+                return [];
             }
 
             var published = result.Lines
@@ -45,9 +46,7 @@ internal class OrderCancelledEventHandler : IEventHandler<OrderCancelledEvent>
                     .Add(1, new KeyValuePair<string, object?>("movement_type", nameof(MovementType.Release)));
             }
 
-            await _outboxStore.AddOutboxEvent(new StockReleasedEvent(@event.OrderId, published));
-
-            scope.Complete();
+            return [new StockReleasedEvent(@event.OrderId, published)];
         });
     }
 }

--- a/inventory-microservice/Inventory.Service/IntegrationEvents/EventHandlers/OrderCancelledEventHandler.cs
+++ b/inventory-microservice/Inventory.Service/IntegrationEvents/EventHandlers/OrderCancelledEventHandler.cs
@@ -9,25 +9,22 @@ namespace Inventory.Service.IntegrationEvents.EventHandlers;
 internal class OrderCancelledEventHandler : IEventHandler<OrderCancelledEvent>
 {
     private readonly IInventoryStore _inventoryStore;
-    private readonly IOutboxStore _outboxStore;
     private readonly IOutboxUnitOfWork _outboxUnitOfWork;
     private readonly MetricFactory _metricFactory;
 
     public OrderCancelledEventHandler(
         IInventoryStore inventoryStore,
-        IOutboxStore outboxStore,
         IOutboxUnitOfWork outboxUnitOfWork,
         MetricFactory metricFactory)
     {
         _inventoryStore = inventoryStore;
-        _outboxStore = outboxStore;
         _outboxUnitOfWork = outboxUnitOfWork;
         _metricFactory = metricFactory;
     }
 
     public async Task Handle(OrderCancelledEvent @event)
     {
-        await _outboxUnitOfWork.ExecuteAsync(_outboxStore.CreateExecutionStrategy(), async () =>
+        await _outboxUnitOfWork.ExecuteAsync(async () =>
         {
             var result = await _inventoryStore.ReleaseReservations(@event.OrderId);
 

--- a/inventory-microservice/Inventory.Service/IntegrationEvents/EventHandlers/OrderConfirmedEventHandler.cs
+++ b/inventory-microservice/Inventory.Service/IntegrationEvents/EventHandlers/OrderConfirmedEventHandler.cs
@@ -1,10 +1,8 @@
-using System.Transactions;
 using ECommerce.Shared.Infrastructure.EventBus.Abstractions;
 using ECommerce.Shared.Infrastructure.Outbox;
 using ECommerce.Shared.Observability.Metrics;
 using Inventory.Service.Infrastructure.Data;
 using Inventory.Service.Models;
-using Microsoft.EntityFrameworkCore;
 
 namespace Inventory.Service.IntegrationEvents.EventHandlers;
 
@@ -12,32 +10,30 @@ internal class OrderConfirmedEventHandler : IEventHandler<OrderConfirmedEvent>
 {
     private readonly IInventoryStore _inventoryStore;
     private readonly IOutboxStore _outboxStore;
+    private readonly IOutboxUnitOfWork _outboxUnitOfWork;
     private readonly MetricFactory _metricFactory;
 
-    public OrderConfirmedEventHandler(IInventoryStore inventoryStore, IOutboxStore outboxStore, MetricFactory metricFactory)
+    public OrderConfirmedEventHandler(
+        IInventoryStore inventoryStore,
+        IOutboxStore outboxStore,
+        IOutboxUnitOfWork outboxUnitOfWork,
+        MetricFactory metricFactory)
     {
         _inventoryStore = inventoryStore;
         _outboxStore = outboxStore;
+        _outboxUnitOfWork = outboxUnitOfWork;
         _metricFactory = metricFactory;
     }
 
     public async Task Handle(OrderConfirmedEvent @event)
     {
-        await _outboxStore.CreateExecutionStrategy().ExecuteAsync(async () =>
+        await _outboxUnitOfWork.ExecuteAsync(_outboxStore.CreateExecutionStrategy(), async () =>
         {
-            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-
             var result = await _inventoryStore.CommitReservations(@event.OrderId);
 
-            if (!result.Committed)
+            if (!result.Committed || result.AlreadyProcessed)
             {
-                return;
-            }
-
-            if (result.AlreadyProcessed)
-            {
-                scope.Complete();
-                return;
+                return [];
             }
 
             var published = result.Lines
@@ -50,9 +46,7 @@ internal class OrderConfirmedEventHandler : IEventHandler<OrderConfirmedEvent>
                     .Add(1, new KeyValuePair<string, object?>("movement_type", nameof(MovementType.Commit)));
             }
 
-            await _outboxStore.AddOutboxEvent(new StockCommittedEvent(@event.OrderId, published));
-
-            scope.Complete();
+            return [new StockCommittedEvent(@event.OrderId, published)];
         });
     }
 }

--- a/inventory-microservice/Inventory.Service/IntegrationEvents/EventHandlers/OrderConfirmedEventHandler.cs
+++ b/inventory-microservice/Inventory.Service/IntegrationEvents/EventHandlers/OrderConfirmedEventHandler.cs
@@ -9,31 +9,34 @@ namespace Inventory.Service.IntegrationEvents.EventHandlers;
 internal class OrderConfirmedEventHandler : IEventHandler<OrderConfirmedEvent>
 {
     private readonly IInventoryStore _inventoryStore;
-    private readonly IOutboxStore _outboxStore;
     private readonly IOutboxUnitOfWork _outboxUnitOfWork;
     private readonly MetricFactory _metricFactory;
 
     public OrderConfirmedEventHandler(
         IInventoryStore inventoryStore,
-        IOutboxStore outboxStore,
         IOutboxUnitOfWork outboxUnitOfWork,
         MetricFactory metricFactory)
     {
         _inventoryStore = inventoryStore;
-        _outboxStore = outboxStore;
         _outboxUnitOfWork = outboxUnitOfWork;
         _metricFactory = metricFactory;
     }
 
     public async Task Handle(OrderConfirmedEvent @event)
     {
-        await _outboxUnitOfWork.ExecuteAsync(_outboxStore.CreateExecutionStrategy(), async () =>
+        await _outboxUnitOfWork.ExecuteAsync(async () =>
         {
             var result = await _inventoryStore.CommitReservations(@event.OrderId);
 
-            if (!result.Committed || result.AlreadyProcessed)
+            if (result.AlreadyProcessed)
             {
                 return [];
+            }
+
+            if (!result.Committed)
+            {
+                throw new InvalidOperationException(
+                    $"Commit failed for order {@event.OrderId} — rolling back transaction.");
             }
 
             var published = result.Lines

--- a/inventory-microservice/Inventory.Service/IntegrationEvents/EventHandlers/OrderCreatedEventHandler.cs
+++ b/inventory-microservice/Inventory.Service/IntegrationEvents/EventHandlers/OrderCreatedEventHandler.cs
@@ -11,18 +11,15 @@ namespace Inventory.Service.IntegrationEvents.EventHandlers;
 internal class OrderCreatedEventHandler : IEventHandler<OrderCreatedEvent>
 {
     private readonly IInventoryStore _inventoryStore;
-    private readonly IOutboxStore _outboxStore;
     private readonly IOutboxUnitOfWork _outboxUnitOfWork;
     private readonly MetricFactory _metricFactory;
 
     public OrderCreatedEventHandler(
         IInventoryStore inventoryStore,
-        IOutboxStore outboxStore,
         IOutboxUnitOfWork outboxUnitOfWork,
         MetricFactory metricFactory)
     {
         _inventoryStore = inventoryStore;
-        _outboxStore = outboxStore;
         _outboxUnitOfWork = outboxUnitOfWork;
         _metricFactory = metricFactory;
     }
@@ -53,7 +50,7 @@ internal class OrderCreatedEventHandler : IEventHandler<OrderCreatedEvent>
             .Select(i => new ReserveLine(int.Parse(i.ProductId, CultureInfo.InvariantCulture), i.Quantity))
             .ToList();
 
-        await _outboxUnitOfWork.ExecuteAsync(_outboxStore.CreateExecutionStrategy(), async () =>
+        await _outboxUnitOfWork.ExecuteAsync(async () =>
         {
             var result = await _inventoryStore.Reserve(@event.OrderId, lines);
 

--- a/inventory-microservice/Inventory.Service/IntegrationEvents/EventHandlers/OrderCreatedEventHandler.cs
+++ b/inventory-microservice/Inventory.Service/IntegrationEvents/EventHandlers/OrderCreatedEventHandler.cs
@@ -1,12 +1,10 @@
 using System.Diagnostics;
 using System.Globalization;
-using System.Transactions;
 using ECommerce.Shared.Infrastructure.EventBus.Abstractions;
 using ECommerce.Shared.Infrastructure.Outbox;
 using ECommerce.Shared.Observability.Metrics;
 using Inventory.Service.Infrastructure.Data;
 using Inventory.Service.Models;
-using Microsoft.EntityFrameworkCore;
 
 namespace Inventory.Service.IntegrationEvents.EventHandlers;
 
@@ -14,12 +12,18 @@ internal class OrderCreatedEventHandler : IEventHandler<OrderCreatedEvent>
 {
     private readonly IInventoryStore _inventoryStore;
     private readonly IOutboxStore _outboxStore;
+    private readonly IOutboxUnitOfWork _outboxUnitOfWork;
     private readonly MetricFactory _metricFactory;
 
-    public OrderCreatedEventHandler(IInventoryStore inventoryStore, IOutboxStore outboxStore, MetricFactory metricFactory)
+    public OrderCreatedEventHandler(
+        IInventoryStore inventoryStore,
+        IOutboxStore outboxStore,
+        IOutboxUnitOfWork outboxUnitOfWork,
+        MetricFactory metricFactory)
     {
         _inventoryStore = inventoryStore;
         _outboxStore = outboxStore;
+        _outboxUnitOfWork = outboxUnitOfWork;
         _metricFactory = metricFactory;
     }
 
@@ -49,16 +53,13 @@ internal class OrderCreatedEventHandler : IEventHandler<OrderCreatedEvent>
             .Select(i => new ReserveLine(int.Parse(i.ProductId, CultureInfo.InvariantCulture), i.Quantity))
             .ToList();
 
-        await _outboxStore.CreateExecutionStrategy().ExecuteAsync(async () =>
+        await _outboxUnitOfWork.ExecuteAsync(_outboxStore.CreateExecutionStrategy(), async () =>
         {
-            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-
             var result = await _inventoryStore.Reserve(@event.OrderId, lines);
 
             if (result.AlreadyProcessed)
             {
-                scope.Complete();
-                return;
+                return [];
             }
 
             if (!result.Reserved)
@@ -67,12 +68,9 @@ internal class OrderCreatedEventHandler : IEventHandler<OrderCreatedEvent>
                     .Select(l => new FailedItem(l.ProductId, l.Requested, l.Available))
                     .ToList();
 
-                await _outboxStore.AddOutboxEvent(new StockReservationFailedEvent(@event.OrderId, failed));
-
                 _metricFactory.Counter("stock-reservations-failed", "reservations").Add(1);
 
-                scope.Complete();
-                return;
+                return [new StockReservationFailedEvent(@event.OrderId, failed)];
             }
 
             var published = result.Lines
@@ -87,10 +85,7 @@ internal class OrderCreatedEventHandler : IEventHandler<OrderCreatedEvent>
 
             var amount = @event.Items.Sum(i => i.UnitPrice * i.Quantity);
 
-            await _outboxStore.AddOutboxEvent(
-                new StockReservedEvent(@event.OrderId, published, amount, @event.Currency));
-
-            scope.Complete();
+            return [new StockReservedEvent(@event.OrderId, published, amount, @event.Currency)];
         });
     }
 }

--- a/inventory-microservice/Inventory.Service/Inventory.Service.csproj
+++ b/inventory-microservice/Inventory.Service/Inventory.Service.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ECommerce.Shared" Version="2.16.0" />
+    <PackageReference Include="ECommerce.Shared" Version="2.17.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>

--- a/inventory-microservice/Inventory.Service/Inventory.Service.csproj
+++ b/inventory-microservice/Inventory.Service/Inventory.Service.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ECommerce.Shared" Version="2.14.0" />
+    <PackageReference Include="ECommerce.Shared" Version="2.15.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>

--- a/inventory-microservice/Inventory.Service/Inventory.Service.csproj
+++ b/inventory-microservice/Inventory.Service/Inventory.Service.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ECommerce.Shared" Version="2.15.0" />
+    <PackageReference Include="ECommerce.Shared" Version="2.16.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>

--- a/inventory-microservice/Inventory.Service/Inventory.Service.csproj.lscache
+++ b/inventory-microservice/Inventory.Service/Inventory.Service.csproj.lscache
@@ -448,7 +448,7 @@ Program.cs
  azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
  azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
  azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
- ecommerce.shared/2.15.0/lib/net10.0/ECommerce.Shared.dll
+ ecommerce.shared/2.16.0/lib/net10.0/ECommerce.Shared.dll
  google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
  grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
  grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll

--- a/inventory-microservice/Inventory.Service/Inventory.Service.csproj.lscache
+++ b/inventory-microservice/Inventory.Service/Inventory.Service.csproj.lscache
@@ -1,0 +1,540 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[properties]
+AssemblyName=Inventory.Service
+CommandLineArgsForDesignTimeEvaluation=-langversion:14.0 -define:TRACE
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=14.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=Inventory.Service
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../../MicroservicesInDotNet.sln
+TargetFrameworkIdentifier=.NETCoreApp
+TargetPath=<PATH>bin/Debug/net10.0/Inventory.Service.dll
+TargetRefPath=<PATH>obj/Debug/net10.0/ref/Inventory.Service.dll
+TemporaryDependencyNodeTargetIdentifier=net10.0
+
+[commandLineArguments]
+/noconfig
+/unsafe-
+/checked-
+/nowarn:NU1603,NU1902,NU1903,NU5104,CA1711,CA1707,CA1716,1701,1702,8002
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/warn:10
+/define:TRACE;DEBUG;NET;NET10_0;NETCOREAPP;NET5_0_OR_GREATER;NET6_0_OR_GREATER;NET7_0_OR_GREATER;NET8_0_OR_GREATER;NET9_0_OR_GREATER;NET10_0_OR_GREATER;NETCOREAPP1_0_OR_GREATER;NETCOREAPP1_1_OR_GREATER;NETCOREAPP2_0_OR_GREATER;NETCOREAPP2_1_OR_GREATER;NETCOREAPP2_2_OR_GREATER;NETCOREAPP3_0_OR_GREATER;NETCOREAPP3_1_OR_GREATER
+/highentropyva+
+/nullable:enable
+/features:"InterceptorsNamespaces=;Microsoft.Extensions.Validation.Generated"
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\net10.0\Inventory.Service.dll
+/refout:obj\Debug\net10.0\refint\Inventory.Service.dll
+/target:exe
+/warnaserror+
+/utf8output
+/deterministic+
+/langversion:14.0
+/features:use-roslyn-tokenizer=true
+/warnaserror+:NU1605,SYSLIB0011
+
+[sourceFiles]
+ApiModels/
+ BackorderRequestDto.cs
+ GetStockItemResponse.cs
+ ReserveRequest.cs
+ ReserveResponse.cs
+ RestockRequest.cs
+ RestockResponse.cs
+ SetThresholdRequest.cs
+ SetThresholdResponse.cs
+ StockItemSummaryDto.cs
+ StockMovementDto.cs
+Endpoints/
+ InternalOutboxEndpoints.cs
+ InventoryApiEndpoints.cs
+Infrastructure/Data/EntityFramework/
+ BackorderRequestConfiguration.cs
+ EntityFrameworkExtensions.cs
+ InventoryContext.cs
+ InventoryContextDesignTimeFactory.cs
+ InventoryContextSeed.cs
+ StockItemConfiguration.cs
+ StockLevelConfiguration.cs
+ StockMovementConfiguration.cs
+ StockReservationConfiguration.cs
+ WarehouseConfiguration.cs
+Infrastructure/Data/IInventoryStore.cs
+IntegrationEvents/EventHandlers/
+ OrderCancelledEventHandler.cs
+ OrderConfirmedEventHandler.cs
+ OrderCreatedEventHandler.cs
+ ProductCreatedEventHandler.cs
+IntegrationEvents/
+ LowStockEvent.cs
+ OrderCancelledEvent.cs
+ OrderConfirmedEvent.cs
+ OrderCreatedEvent.cs
+ ProductCreatedEvent.cs
+ StockAdjustedEvent.cs
+ StockCommittedEvent.cs
+ StockDepletedEvent.cs
+ StockReleasedEvent.cs
+ StockReservationFailedEvent.cs
+ StockReservedEvent.cs
+Migrations/
+ 20260419120000_InitialCreate.cs
+ 20260419120000_InitialCreate.Designer.cs
+ 20260419130000_AddStockMovements.cs
+ 20260419130000_AddStockMovements.Designer.cs
+ 20260420130000_AddStockReservations.cs
+ 20260420130000_AddStockReservations.Designer.cs
+ 20260420140000_Phase5Sync.cs
+ 20260420140000_Phase5Sync.Designer.cs
+ 20260421120000_AddBackorderRequests.cs
+ 20260421120000_AddBackorderRequests.Designer.cs
+ 20260506132153_20260506_SeedQaData_Inventory.cs
+ 20260506132153_20260506_SeedQaData_Inventory.Designer.cs
+ 20260507000000_20260507_SeedQaPhase2_Inventory.cs
+ 20260507000000_20260507_SeedQaPhase2_Inventory.Designer.cs
+ 20260507010000_20260507_SeedQaPhase3c_Inventory.cs
+ 20260507010000_20260507_SeedQaPhase3c_Inventory.Designer.cs
+ InventoryContextModelSnapshot.cs
+Models/
+ BackorderRequest.cs
+ MovementType.cs
+ ReservationStatus.cs
+ StockItem.cs
+ StockLevel.cs
+ StockLevelMonitor.cs
+ StockMovement.cs
+ StockReservation.cs
+ Warehouse.cs
+obj/Debug/net10.0/
+ .NETCoreApp,Version=v10.0.AssemblyAttributes.cs
+ Inventory.Service.AssemblyInfo.cs
+ Inventory.Service.GlobalUsings.g.cs
+Program.cs
+
+[metadataReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.AspNetCore.Antiforgery.dll
+ Microsoft.AspNetCore.Authentication.Abstractions.dll
+ Microsoft.AspNetCore.Authentication.BearerToken.dll
+ Microsoft.AspNetCore.Authentication.Cookies.dll
+ Microsoft.AspNetCore.Authentication.Core.dll
+ Microsoft.AspNetCore.Authentication.dll
+ Microsoft.AspNetCore.Authentication.OAuth.dll
+ Microsoft.AspNetCore.Authorization.dll
+ Microsoft.AspNetCore.Authorization.Policy.dll
+ Microsoft.AspNetCore.Components.Authorization.dll
+ Microsoft.AspNetCore.Components.dll
+ Microsoft.AspNetCore.Components.Endpoints.dll
+ Microsoft.AspNetCore.Components.Forms.dll
+ Microsoft.AspNetCore.Components.Server.dll
+ Microsoft.AspNetCore.Components.Web.dll
+ Microsoft.AspNetCore.Connections.Abstractions.dll
+ Microsoft.AspNetCore.CookiePolicy.dll
+ Microsoft.AspNetCore.Cors.dll
+ Microsoft.AspNetCore.Cryptography.Internal.dll
+ Microsoft.AspNetCore.Cryptography.KeyDerivation.dll
+ Microsoft.AspNetCore.DataProtection.Abstractions.dll
+ Microsoft.AspNetCore.DataProtection.dll
+ Microsoft.AspNetCore.DataProtection.Extensions.dll
+ Microsoft.AspNetCore.Diagnostics.Abstractions.dll
+ Microsoft.AspNetCore.Diagnostics.dll
+ Microsoft.AspNetCore.Diagnostics.HealthChecks.dll
+ Microsoft.AspNetCore.dll
+ Microsoft.AspNetCore.HostFiltering.dll
+ Microsoft.AspNetCore.Hosting.Abstractions.dll
+ Microsoft.AspNetCore.Hosting.dll
+ Microsoft.AspNetCore.Hosting.Server.Abstractions.dll
+ Microsoft.AspNetCore.Html.Abstractions.dll
+ Microsoft.AspNetCore.Http.Abstractions.dll
+ Microsoft.AspNetCore.Http.Connections.Common.dll
+ Microsoft.AspNetCore.Http.Connections.dll
+ Microsoft.AspNetCore.Http.dll
+ Microsoft.AspNetCore.Http.Extensions.dll
+ Microsoft.AspNetCore.Http.Features.dll
+ Microsoft.AspNetCore.Http.Results.dll
+ Microsoft.AspNetCore.HttpLogging.dll
+ Microsoft.AspNetCore.HttpOverrides.dll
+ Microsoft.AspNetCore.HttpsPolicy.dll
+ Microsoft.AspNetCore.Identity.dll
+ Microsoft.AspNetCore.Localization.dll
+ Microsoft.AspNetCore.Localization.Routing.dll
+ Microsoft.AspNetCore.Metadata.dll
+ Microsoft.AspNetCore.Mvc.Abstractions.dll
+ Microsoft.AspNetCore.Mvc.ApiExplorer.dll
+ Microsoft.AspNetCore.Mvc.Core.dll
+ Microsoft.AspNetCore.Mvc.Cors.dll
+ Microsoft.AspNetCore.Mvc.DataAnnotations.dll
+ Microsoft.AspNetCore.Mvc.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Json.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Xml.dll
+ Microsoft.AspNetCore.Mvc.Localization.dll
+ Microsoft.AspNetCore.Mvc.Razor.dll
+ Microsoft.AspNetCore.Mvc.RazorPages.dll
+ Microsoft.AspNetCore.Mvc.TagHelpers.dll
+ Microsoft.AspNetCore.Mvc.ViewFeatures.dll
+ Microsoft.AspNetCore.OutputCaching.dll
+ Microsoft.AspNetCore.RateLimiting.dll
+ Microsoft.AspNetCore.Razor.dll
+ Microsoft.AspNetCore.Razor.Runtime.dll
+ Microsoft.AspNetCore.RequestDecompression.dll
+ Microsoft.AspNetCore.ResponseCaching.Abstractions.dll
+ Microsoft.AspNetCore.ResponseCaching.dll
+ Microsoft.AspNetCore.ResponseCompression.dll
+ Microsoft.AspNetCore.Rewrite.dll
+ Microsoft.AspNetCore.Routing.Abstractions.dll
+ Microsoft.AspNetCore.Routing.dll
+ Microsoft.AspNetCore.Server.HttpSys.dll
+ Microsoft.AspNetCore.Server.IIS.dll
+ Microsoft.AspNetCore.Server.IISIntegration.dll
+ Microsoft.AspNetCore.Server.Kestrel.Core.dll
+ Microsoft.AspNetCore.Server.Kestrel.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll
+ Microsoft.AspNetCore.Session.dll
+ Microsoft.AspNetCore.SignalR.Common.dll
+ Microsoft.AspNetCore.SignalR.Core.dll
+ Microsoft.AspNetCore.SignalR.dll
+ Microsoft.AspNetCore.SignalR.Protocols.Json.dll
+ Microsoft.AspNetCore.StaticAssets.dll
+ Microsoft.AspNetCore.StaticFiles.dll
+ Microsoft.AspNetCore.WebSockets.dll
+ Microsoft.AspNetCore.WebUtilities.dll
+ Microsoft.Extensions.Caching.Abstractions.dll
+ Microsoft.Extensions.Caching.Memory.dll
+ Microsoft.Extensions.Configuration.Abstractions.dll
+ Microsoft.Extensions.Configuration.Binder.dll
+ Microsoft.Extensions.Configuration.CommandLine.dll
+ Microsoft.Extensions.Configuration.dll
+ Microsoft.Extensions.Configuration.EnvironmentVariables.dll
+ Microsoft.Extensions.Configuration.FileExtensions.dll
+ Microsoft.Extensions.Configuration.Ini.dll
+ Microsoft.Extensions.Configuration.Json.dll
+ Microsoft.Extensions.Configuration.KeyPerFile.dll
+ Microsoft.Extensions.Configuration.UserSecrets.dll
+ Microsoft.Extensions.Configuration.Xml.dll
+ Microsoft.Extensions.DependencyInjection.Abstractions.dll
+ Microsoft.Extensions.DependencyInjection.dll
+ Microsoft.Extensions.Diagnostics.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.dll
+ Microsoft.Extensions.Features.dll
+ Microsoft.Extensions.FileProviders.Abstractions.dll
+ Microsoft.Extensions.FileProviders.Composite.dll
+ Microsoft.Extensions.FileProviders.Embedded.dll
+ Microsoft.Extensions.FileProviders.Physical.dll
+ Microsoft.Extensions.FileSystemGlobbing.dll
+ Microsoft.Extensions.Hosting.Abstractions.dll
+ Microsoft.Extensions.Hosting.dll
+ Microsoft.Extensions.Http.dll
+ Microsoft.Extensions.Identity.Core.dll
+ Microsoft.Extensions.Identity.Stores.dll
+ Microsoft.Extensions.Localization.Abstractions.dll
+ Microsoft.Extensions.Localization.dll
+ Microsoft.Extensions.Logging.Abstractions.dll
+ Microsoft.Extensions.Logging.Configuration.dll
+ Microsoft.Extensions.Logging.Console.dll
+ Microsoft.Extensions.Logging.Debug.dll
+ Microsoft.Extensions.Logging.dll
+ Microsoft.Extensions.Logging.EventLog.dll
+ Microsoft.Extensions.Logging.EventSource.dll
+ Microsoft.Extensions.Logging.TraceSource.dll
+ Microsoft.Extensions.ObjectPool.dll
+ Microsoft.Extensions.Options.ConfigurationExtensions.dll
+ Microsoft.Extensions.Options.DataAnnotations.dll
+ Microsoft.Extensions.Options.dll
+ Microsoft.Extensions.Primitives.dll
+ Microsoft.Extensions.Validation.dll
+ Microsoft.Extensions.WebEncoders.dll
+ Microsoft.JSInterop.dll
+ Microsoft.Net.Http.Headers.dll
+ System.Diagnostics.EventLog.dll
+ System.Formats.Cbor.dll
+ System.Security.Cryptography.Xml.dll
+ System.Threading.RateLimiting.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.CSharp.dll
+ Microsoft.VisualBasic.Core.dll
+ Microsoft.VisualBasic.dll
+ Microsoft.Win32.Primitives.dll
+ Microsoft.Win32.Registry.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.Immutable.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Annotations.dll
+ System.ComponentModel.DataAnnotations.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Configuration.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.DataSetExtensions.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.DiagnosticSource.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Formats.Asn1.dll
+ System.Formats.Tar.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.Brotli.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.AccessControl.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipelines.dll
+ System.IO.Pipes.AccessControl.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.AsyncEnumerable.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.Http.Json.dll
+ System.Net.HttpListener.dll
+ System.Net.Mail.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Quic.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.ServerSentEvents.dll
+ System.Net.ServicePoint.dll
+ System.Net.Sockets.dll
+ System.Net.WebClient.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebProxy.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Metadata.dll
+ System.Reflection.Primitives.dll
+ System.Reflection.TypeExtensions.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.Unsafe.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.JavaScript.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Intrinsics.dll
+ System.Runtime.Loader.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.AccessControl.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Cng.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.OpenSsl.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.dll
+ System.Security.Principal.dll
+ System.Security.Principal.Windows.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.ServiceProcess.dll
+ System.Text.Encoding.CodePages.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.Encodings.Web.dll
+ System.Text.Json.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.AccessControl.dll
+ System.Threading.Channels.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.Dataflow.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.Transactions.Local.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Web.HttpUtility.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+ WindowsBase.dll
+<NUGET>/
+ azure.core.amqp/1.3.1/lib/netstandard2.0/Azure.Core.Amqp.dll
+ azure.core/1.47.1/lib/net8.0/Azure.Core.dll
+ azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
+ azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
+ azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
+ ecommerce.shared/2.15.0/lib/net10.0/ECommerce.Shared.dll
+ google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
+ grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
+ grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll
+ grpc.net.common/2.52.0/lib/net7.0/Grpc.Net.Common.dll
+ microsoft.aspnetcore.authentication.jwtbearer/10.0.5/lib/net10.0/Microsoft.AspNetCore.Authentication.JwtBearer.dll
+ microsoft.azure.amqp/2.6.7/lib/netstandard2.0/Microsoft.Azure.Amqp.dll
+ microsoft.bcl.asyncinterfaces/8.0.0/lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll
+ microsoft.bcl.cryptography/9.0.4/lib/net9.0/Microsoft.Bcl.Cryptography.dll
+ microsoft.data.sqlclient/6.1.1/ref/net9.0/Microsoft.Data.SqlClient.dll
+ microsoft.entityframeworkcore.abstractions/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Abstractions.dll
+ microsoft.entityframeworkcore.relational/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Relational.dll
+ microsoft.entityframeworkcore.sqlserver/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.SqlServer.dll
+ microsoft.entityframeworkcore/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.dll
+ microsoft.identity.client.extensions.msal/4.73.1/lib/net8.0/Microsoft.Identity.Client.Extensions.Msal.dll
+ microsoft.identity.client/4.73.1/lib/net8.0/Microsoft.Identity.Client.dll
+ microsoft.identitymodel.abstractions/8.0.1/lib/net9.0/Microsoft.IdentityModel.Abstractions.dll
+ microsoft.identitymodel.jsonwebtokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.JsonWebTokens.dll
+ microsoft.identitymodel.logging/8.0.1/lib/net9.0/Microsoft.IdentityModel.Logging.dll
+ microsoft.identitymodel.protocols.openidconnect/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.dll
+ microsoft.identitymodel.protocols/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.dll
+ microsoft.identitymodel.tokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.Tokens.dll
+ microsoft.openapi/1.6.14/lib/netstandard2.0/Microsoft.OpenApi.dll
+ microsoft.sqlserver.server/1.0.0/lib/netstandard2.0/Microsoft.SqlServer.Server.dll
+ opentelemetry.api.providerbuilderextensions/1.10.0/lib/net9.0/OpenTelemetry.Api.ProviderBuilderExtensions.dll
+ opentelemetry.api/1.10.0/lib/net9.0/OpenTelemetry.Api.dll
+ opentelemetry.exporter.console/1.9.0/lib/net8.0/OpenTelemetry.Exporter.Console.dll
+ opentelemetry.exporter.opentelemetryprotocol/1.9.0/lib/net8.0/OpenTelemetry.Exporter.OpenTelemetryProtocol.dll
+ opentelemetry.exporter.prometheus.aspnetcore/1.10.0-beta.1/lib/net9.0/OpenTelemetry.Exporter.Prometheus.AspNetCore.dll
+ opentelemetry.extensions.hosting/1.9.0/lib/net8.0/OpenTelemetry.Extensions.Hosting.dll
+ opentelemetry.instrumentation.aspnetcore/1.9.0/lib/net8.0/OpenTelemetry.Instrumentation.AspNetCore.dll
+ opentelemetry.instrumentation.sqlclient/1.9.0-beta.1/lib/net8.0/OpenTelemetry.Instrumentation.SqlClient.dll
+ opentelemetry.persistentstorage.abstractions/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.Abstractions.dll
+ opentelemetry.persistentstorage.filesystem/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.FileSystem.dll
+ opentelemetry/1.10.0/lib/net9.0/OpenTelemetry.dll
+ pipelines.sockets.unofficial/2.2.8/lib/net5.0/Pipelines.Sockets.Unofficial.dll
+ polly.core/8.6.6/lib/net8.0/Polly.Core.dll
+ rabbitmq.client/6.8.1/lib/netstandard2.0/RabbitMQ.Client.dll
+ stackexchange.redis/2.8.16/lib/net6.0/StackExchange.Redis.dll
+ swashbuckle.aspnetcore.swagger/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.Swagger.dll
+ swashbuckle.aspnetcore.swaggergen/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.dll
+ swashbuckle.aspnetcore.swaggerui/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.dll
+ system.clientmodel/1.5.1/lib/net8.0/System.ClientModel.dll
+ system.identitymodel.tokens.jwt/8.0.1/lib/net9.0/System.IdentityModel.Tokens.Jwt.dll
+ system.memory.data/8.0.1/lib/net8.0/System.Memory.Data.dll
+ system.security.cryptography.pkcs/9.0.4/lib/net9.0/System.Security.Cryptography.Pkcs.dll
+ system.security.cryptography.protecteddata/9.0.4/lib/net9.0/System.Security.Cryptography.ProtectedData.dll
+
+[analyzerReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.AspNetCore.App.Analyzers.dll
+ Microsoft.AspNetCore.App.CodeFixes.dll
+ Microsoft.AspNetCore.App.SourceGenerators.dll
+ Microsoft.AspNetCore.Components.Analyzers.dll
+ Microsoft.Extensions.Logging.Generators.dll
+ Microsoft.Extensions.Options.SourceGeneration.dll
+ Microsoft.Extensions.Validation.ValidationsGenerator.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.Interop.ComInterfaceGenerator.dll
+ Microsoft.Interop.JavaScript.JSImportGenerator.dll
+ Microsoft.Interop.LibraryImportGenerator.dll
+ Microsoft.Interop.SourceGeneration.dll
+ System.Text.Json.SourceGeneration.dll
+ System.Text.RegularExpressions.Generator.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk.Razor/source-generators/
+ Microsoft.AspNetCore.Razor.Utilities.Shared.dll
+ Microsoft.CodeAnalysis.Razor.Compiler.dll
+ Microsoft.Extensions.ObjectPool.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk.Web/analyzers/cs/
+ Microsoft.AspNetCore.Analyzers.dll
+ Microsoft.AspNetCore.Mvc.Analyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/
+ Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll
+ Microsoft.CodeAnalysis.NetAnalyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/codestyle/cs/
+ Microsoft.CodeAnalysis.CodeStyle.dll
+ Microsoft.CodeAnalysis.CodeStyle.Fixes.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.dll
+<NUGET>/microsoft.codeanalysis.analyzers/3.11.0/analyzers/dotnet/cs/
+ Microsoft.CodeAnalysis.Analyzers.dll
+ Microsoft.CodeAnalysis.CSharp.Analyzers.dll
+<NUGET>/
+ microsoft.entityframeworkcore.analyzers/10.0.5/analyzers/dotnet/cs/Microsoft.EntityFrameworkCore.Analyzers.dll
+ system.clientmodel/1.5.1/analyzers/dotnet/cs/System.ClientModel.SourceGeneration.dll
+
+[analyzerConfigFiles]
+../../.editorconfig
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_10_recommended.globalconfig
+obj/Debug/net10.0/Inventory.Service.GeneratedMSBuildEditorConfig.editorconfig

--- a/inventory-microservice/Inventory.Tests/Api/ReleaseReservationsTests.cs
+++ b/inventory-microservice/Inventory.Tests/Api/ReleaseReservationsTests.cs
@@ -59,6 +59,74 @@ public class ReleaseReservationsTests : IntegrationTestBase
 
         Assert.Contains(InventoryContext.StockMovements,
             m => m.OrderId == orderId && m.Type == MovementType.Release);
+
+        SpinWait.SpinUntil(
+            () => ReceivedEvents.ToArray().OfType<StockReleasedEvent>().Any(e => e.OrderId == orderId),
+            TimeSpan.FromSeconds(5));
+        var published = Assert.Single(ReceivedEvents.ToArray().OfType<StockReleasedEvent>(), e => e.OrderId == orderId);
+        Assert.Equal(orderId, published.OrderId);
+        var itemPublished = Assert.Single(published.Items);
+        Assert.Equal(productId, itemPublished.ProductId);
+        Assert.Equal(1, itemPublished.WarehouseId);
+        Assert.Equal(4, itemPublished.Quantity);
+    }
+
+    [Fact]
+    public async Task Given_HeldReservation_When_OrderConfirmed_Then_CommitsAndPublishesStockCommitted()
+    {
+        const int productId = 605;
+        var orderId = Guid.NewGuid();
+
+        InventoryContext.StockItems.Add(new StockItem
+        {
+            ProductId = productId,
+            TotalOnHand = 10,
+            TotalReserved = 4,
+        });
+        InventoryContext.StockLevels.Add(new StockLevel
+        {
+            ProductId = productId,
+            WarehouseId = 1,
+            OnHand = 10,
+            Reserved = 4,
+        });
+        InventoryContext.StockReservations.Add(new StockReservation
+        {
+            OrderId = orderId,
+            ProductId = productId,
+            WarehouseId = 1,
+            Quantity = 4,
+            Status = ReservationStatus.Held,
+            CreatedAt = DateTime.UtcNow,
+        });
+        await InventoryContext.SaveChangesAsync();
+
+        Subscribe<StockCommittedEvent>();
+
+        await DispatchConfirmAsync(new OrderConfirmedEvent(orderId, "c-1"));
+
+        InventoryContext.ChangeTracker.Clear();
+
+        var reservation = InventoryContext.StockReservations.Single(r => r.OrderId == orderId);
+        Assert.Equal(ReservationStatus.Committed, reservation.Status);
+
+        var item = InventoryContext.StockItems.Single(s => s.ProductId == productId);
+        Assert.Equal(6, item.TotalOnHand);
+        Assert.Equal(0, item.TotalReserved);
+        Assert.Equal(6, item.Available);
+
+        Assert.Contains(InventoryContext.StockMovements,
+            m => m.OrderId == orderId && m.Type == MovementType.Commit);
+
+        SpinWait.SpinUntil(
+            () => ReceivedEvents.ToArray().OfType<StockCommittedEvent>().Any(e => e.OrderId == orderId),
+            TimeSpan.FromSeconds(5));
+        var published = Assert.Single(ReceivedEvents.ToArray().OfType<StockCommittedEvent>(), e => e.OrderId == orderId);
+        Assert.Equal(orderId, published.OrderId);
+        var itemPublished = Assert.Single(published.Items);
+        Assert.Equal(productId, itemPublished.ProductId);
+        Assert.Equal(1, itemPublished.WarehouseId);
+        Assert.Equal(4, itemPublished.Quantity);
     }
 
     [Fact]

--- a/inventory-microservice/Inventory.Tests/Inventory.Tests.csproj.lscache
+++ b/inventory-microservice/Inventory.Tests/Inventory.Tests.csproj.lscache
@@ -1,0 +1,501 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[properties]
+AssemblyName=Inventory.Tests
+CommandLineArgsForDesignTimeEvaluation=-langversion:14.0 -define:TRACE
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=14.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=Inventory.Tests
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../../MicroservicesInDotNet.sln
+TargetFrameworkIdentifier=.NETCoreApp
+TargetPath=<PATH>bin/Debug/net10.0/Inventory.Tests.dll
+TargetRefPath=<PATH>obj/Debug/net10.0/ref/Inventory.Tests.dll
+TemporaryDependencyNodeTargetIdentifier=net10.0
+
+[commandLineArguments]
+/noconfig
+/unsafe-
+/checked-
+/nowarn:NU1603,NU1902,NU1903,NU5104,CA1711,CA1707,CA1716,1701,1702,8002
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/warn:10
+/define:TRACE;DEBUG;NET;NET10_0;NETCOREAPP;NET5_0_OR_GREATER;NET6_0_OR_GREATER;NET7_0_OR_GREATER;NET8_0_OR_GREATER;NET9_0_OR_GREATER;NET10_0_OR_GREATER;NETCOREAPP1_0_OR_GREATER;NETCOREAPP1_1_OR_GREATER;NETCOREAPP2_0_OR_GREATER;NETCOREAPP2_1_OR_GREATER;NETCOREAPP2_2_OR_GREATER;NETCOREAPP3_0_OR_GREATER;NETCOREAPP3_1_OR_GREATER
+/highentropyva+
+/nullable:enable
+/features:"InterceptorsNamespaces=;Microsoft.Extensions.Validation.Generated"
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\net10.0\Inventory.Tests.dll
+/refout:obj\Debug\net10.0\refint\Inventory.Tests.dll
+/target:exe
+/warnaserror+
+/utf8output
+/deterministic+
+/langversion:14.0
+/warnaserror+:NU1605,SYSLIB0011
+
+[sourceFiles]
+<NUGET>/microsoft.net.test.sdk/17.14.1/build/net8.0/Microsoft.NET.Test.Sdk.Program.cs
+Api/
+ BackorderApiTests.cs
+ HealthChecksTests.cs
+ InternalOutboxEndpointsTests.cs
+ InventoryApiTests.cs
+ InventoryListApiTests.cs
+ MovementsApiTests.cs
+ ObservabilityTests.cs
+ ReleaseReservationsTests.cs
+ ReserveApiTests.cs
+ RestockApiTests.cs
+ ThresholdApiTests.cs
+Authentication/TestAuthHandler.cs
+Domain/
+ StockItemTests.cs
+ StockLevelMonitorTests.cs
+IntegrationEvents/MessagingProviderBootTests.cs
+IntegrationTestBase.cs
+InventoryWebApplicationFactory.cs
+obj/Debug/net10.0/
+ .NETCoreApp,Version=v10.0.AssemblyAttributes.cs
+ Inventory.Tests.AssemblyInfo.cs
+ Inventory.Tests.GlobalUsings.g.cs
+Qa/InventoryQaSeedTests.cs
+
+[metadataReferences]
+../Inventory.Service/obj/Debug/net10.0/ref/Inventory.Service.dll
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.AspNetCore.Antiforgery.dll
+ Microsoft.AspNetCore.Authentication.Abstractions.dll
+ Microsoft.AspNetCore.Authentication.BearerToken.dll
+ Microsoft.AspNetCore.Authentication.Cookies.dll
+ Microsoft.AspNetCore.Authentication.Core.dll
+ Microsoft.AspNetCore.Authentication.dll
+ Microsoft.AspNetCore.Authentication.OAuth.dll
+ Microsoft.AspNetCore.Authorization.dll
+ Microsoft.AspNetCore.Authorization.Policy.dll
+ Microsoft.AspNetCore.Components.Authorization.dll
+ Microsoft.AspNetCore.Components.dll
+ Microsoft.AspNetCore.Components.Endpoints.dll
+ Microsoft.AspNetCore.Components.Forms.dll
+ Microsoft.AspNetCore.Components.Server.dll
+ Microsoft.AspNetCore.Components.Web.dll
+ Microsoft.AspNetCore.Connections.Abstractions.dll
+ Microsoft.AspNetCore.CookiePolicy.dll
+ Microsoft.AspNetCore.Cors.dll
+ Microsoft.AspNetCore.Cryptography.Internal.dll
+ Microsoft.AspNetCore.Cryptography.KeyDerivation.dll
+ Microsoft.AspNetCore.DataProtection.Abstractions.dll
+ Microsoft.AspNetCore.DataProtection.dll
+ Microsoft.AspNetCore.DataProtection.Extensions.dll
+ Microsoft.AspNetCore.Diagnostics.Abstractions.dll
+ Microsoft.AspNetCore.Diagnostics.dll
+ Microsoft.AspNetCore.Diagnostics.HealthChecks.dll
+ Microsoft.AspNetCore.dll
+ Microsoft.AspNetCore.HostFiltering.dll
+ Microsoft.AspNetCore.Hosting.Abstractions.dll
+ Microsoft.AspNetCore.Hosting.dll
+ Microsoft.AspNetCore.Hosting.Server.Abstractions.dll
+ Microsoft.AspNetCore.Html.Abstractions.dll
+ Microsoft.AspNetCore.Http.Abstractions.dll
+ Microsoft.AspNetCore.Http.Connections.Common.dll
+ Microsoft.AspNetCore.Http.Connections.dll
+ Microsoft.AspNetCore.Http.dll
+ Microsoft.AspNetCore.Http.Extensions.dll
+ Microsoft.AspNetCore.Http.Features.dll
+ Microsoft.AspNetCore.Http.Results.dll
+ Microsoft.AspNetCore.HttpLogging.dll
+ Microsoft.AspNetCore.HttpOverrides.dll
+ Microsoft.AspNetCore.HttpsPolicy.dll
+ Microsoft.AspNetCore.Identity.dll
+ Microsoft.AspNetCore.Localization.dll
+ Microsoft.AspNetCore.Localization.Routing.dll
+ Microsoft.AspNetCore.Metadata.dll
+ Microsoft.AspNetCore.Mvc.Abstractions.dll
+ Microsoft.AspNetCore.Mvc.ApiExplorer.dll
+ Microsoft.AspNetCore.Mvc.Core.dll
+ Microsoft.AspNetCore.Mvc.Cors.dll
+ Microsoft.AspNetCore.Mvc.DataAnnotations.dll
+ Microsoft.AspNetCore.Mvc.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Json.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Xml.dll
+ Microsoft.AspNetCore.Mvc.Localization.dll
+ Microsoft.AspNetCore.Mvc.Razor.dll
+ Microsoft.AspNetCore.Mvc.RazorPages.dll
+ Microsoft.AspNetCore.Mvc.TagHelpers.dll
+ Microsoft.AspNetCore.Mvc.ViewFeatures.dll
+ Microsoft.AspNetCore.OutputCaching.dll
+ Microsoft.AspNetCore.RateLimiting.dll
+ Microsoft.AspNetCore.Razor.dll
+ Microsoft.AspNetCore.Razor.Runtime.dll
+ Microsoft.AspNetCore.RequestDecompression.dll
+ Microsoft.AspNetCore.ResponseCaching.Abstractions.dll
+ Microsoft.AspNetCore.ResponseCaching.dll
+ Microsoft.AspNetCore.ResponseCompression.dll
+ Microsoft.AspNetCore.Rewrite.dll
+ Microsoft.AspNetCore.Routing.Abstractions.dll
+ Microsoft.AspNetCore.Routing.dll
+ Microsoft.AspNetCore.Server.HttpSys.dll
+ Microsoft.AspNetCore.Server.IIS.dll
+ Microsoft.AspNetCore.Server.IISIntegration.dll
+ Microsoft.AspNetCore.Server.Kestrel.Core.dll
+ Microsoft.AspNetCore.Server.Kestrel.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll
+ Microsoft.AspNetCore.Session.dll
+ Microsoft.AspNetCore.SignalR.Common.dll
+ Microsoft.AspNetCore.SignalR.Core.dll
+ Microsoft.AspNetCore.SignalR.dll
+ Microsoft.AspNetCore.SignalR.Protocols.Json.dll
+ Microsoft.AspNetCore.StaticAssets.dll
+ Microsoft.AspNetCore.StaticFiles.dll
+ Microsoft.AspNetCore.WebSockets.dll
+ Microsoft.AspNetCore.WebUtilities.dll
+ Microsoft.Extensions.Caching.Abstractions.dll
+ Microsoft.Extensions.Caching.Memory.dll
+ Microsoft.Extensions.Configuration.Abstractions.dll
+ Microsoft.Extensions.Configuration.Binder.dll
+ Microsoft.Extensions.Configuration.CommandLine.dll
+ Microsoft.Extensions.Configuration.dll
+ Microsoft.Extensions.Configuration.EnvironmentVariables.dll
+ Microsoft.Extensions.Configuration.FileExtensions.dll
+ Microsoft.Extensions.Configuration.Ini.dll
+ Microsoft.Extensions.Configuration.Json.dll
+ Microsoft.Extensions.Configuration.KeyPerFile.dll
+ Microsoft.Extensions.Configuration.UserSecrets.dll
+ Microsoft.Extensions.Configuration.Xml.dll
+ Microsoft.Extensions.DependencyInjection.Abstractions.dll
+ Microsoft.Extensions.DependencyInjection.dll
+ Microsoft.Extensions.Diagnostics.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.dll
+ Microsoft.Extensions.Features.dll
+ Microsoft.Extensions.FileProviders.Abstractions.dll
+ Microsoft.Extensions.FileProviders.Composite.dll
+ Microsoft.Extensions.FileProviders.Embedded.dll
+ Microsoft.Extensions.FileProviders.Physical.dll
+ Microsoft.Extensions.FileSystemGlobbing.dll
+ Microsoft.Extensions.Hosting.Abstractions.dll
+ Microsoft.Extensions.Hosting.dll
+ Microsoft.Extensions.Http.dll
+ Microsoft.Extensions.Identity.Core.dll
+ Microsoft.Extensions.Identity.Stores.dll
+ Microsoft.Extensions.Localization.Abstractions.dll
+ Microsoft.Extensions.Localization.dll
+ Microsoft.Extensions.Logging.Abstractions.dll
+ Microsoft.Extensions.Logging.Configuration.dll
+ Microsoft.Extensions.Logging.Console.dll
+ Microsoft.Extensions.Logging.Debug.dll
+ Microsoft.Extensions.Logging.dll
+ Microsoft.Extensions.Logging.EventLog.dll
+ Microsoft.Extensions.Logging.EventSource.dll
+ Microsoft.Extensions.Logging.TraceSource.dll
+ Microsoft.Extensions.ObjectPool.dll
+ Microsoft.Extensions.Options.ConfigurationExtensions.dll
+ Microsoft.Extensions.Options.DataAnnotations.dll
+ Microsoft.Extensions.Options.dll
+ Microsoft.Extensions.Primitives.dll
+ Microsoft.Extensions.Validation.dll
+ Microsoft.Extensions.WebEncoders.dll
+ Microsoft.JSInterop.dll
+ Microsoft.Net.Http.Headers.dll
+ System.Diagnostics.EventLog.dll
+ System.Formats.Cbor.dll
+ System.Security.Cryptography.Xml.dll
+ System.Threading.RateLimiting.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.CSharp.dll
+ Microsoft.VisualBasic.Core.dll
+ Microsoft.VisualBasic.dll
+ Microsoft.Win32.Primitives.dll
+ Microsoft.Win32.Registry.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.Immutable.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Annotations.dll
+ System.ComponentModel.DataAnnotations.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Configuration.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.DataSetExtensions.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.DiagnosticSource.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Formats.Asn1.dll
+ System.Formats.Tar.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.Brotli.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.AccessControl.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipelines.dll
+ System.IO.Pipes.AccessControl.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.AsyncEnumerable.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.Http.Json.dll
+ System.Net.HttpListener.dll
+ System.Net.Mail.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Quic.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.ServerSentEvents.dll
+ System.Net.ServicePoint.dll
+ System.Net.Sockets.dll
+ System.Net.WebClient.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebProxy.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Metadata.dll
+ System.Reflection.Primitives.dll
+ System.Reflection.TypeExtensions.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.Unsafe.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.JavaScript.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Intrinsics.dll
+ System.Runtime.Loader.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.AccessControl.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Cng.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.OpenSsl.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.dll
+ System.Security.Principal.dll
+ System.Security.Principal.Windows.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.ServiceProcess.dll
+ System.Text.Encoding.CodePages.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.Encodings.Web.dll
+ System.Text.Json.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.AccessControl.dll
+ System.Threading.Channels.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.Dataflow.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.Transactions.Local.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Web.HttpUtility.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+ WindowsBase.dll
+<NUGET>/
+ azure.core.amqp/1.3.1/lib/netstandard2.0/Azure.Core.Amqp.dll
+ azure.core/1.47.1/lib/net8.0/Azure.Core.dll
+ azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
+ azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
+ azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
+ ecommerce.shared/2.15.0/lib/net10.0/ECommerce.Shared.dll
+ google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
+ grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
+ grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll
+ grpc.net.common/2.52.0/lib/net7.0/Grpc.Net.Common.dll
+ microsoft.aspnetcore.authentication.jwtbearer/10.0.5/lib/net10.0/Microsoft.AspNetCore.Authentication.JwtBearer.dll
+ microsoft.aspnetcore.mvc.testing/10.0.5/lib/net10.0/Microsoft.AspNetCore.Mvc.Testing.dll
+ microsoft.aspnetcore.testhost/10.0.5/lib/net10.0/Microsoft.AspNetCore.TestHost.dll
+ microsoft.azure.amqp/2.6.7/lib/netstandard2.0/Microsoft.Azure.Amqp.dll
+ microsoft.bcl.asyncinterfaces/8.0.0/lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll
+ microsoft.bcl.cryptography/9.0.4/lib/net9.0/Microsoft.Bcl.Cryptography.dll
+ microsoft.codecoverage/17.14.1/lib/net8.0/Microsoft.VisualStudio.CodeCoverage.Shim.dll
+ microsoft.data.sqlclient/6.1.1/ref/net9.0/Microsoft.Data.SqlClient.dll
+ microsoft.entityframeworkcore.abstractions/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Abstractions.dll
+ microsoft.entityframeworkcore.inmemory/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.InMemory.dll
+ microsoft.entityframeworkcore.relational/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Relational.dll
+ microsoft.entityframeworkcore.sqlserver/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.SqlServer.dll
+ microsoft.entityframeworkcore/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.dll
+ microsoft.extensions.dependencymodel/10.0.5/lib/net10.0/Microsoft.Extensions.DependencyModel.dll
+ microsoft.identity.client.extensions.msal/4.73.1/lib/net8.0/Microsoft.Identity.Client.Extensions.Msal.dll
+ microsoft.identity.client/4.73.1/lib/net8.0/Microsoft.Identity.Client.dll
+ microsoft.identitymodel.abstractions/8.0.1/lib/net9.0/Microsoft.IdentityModel.Abstractions.dll
+ microsoft.identitymodel.jsonwebtokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.JsonWebTokens.dll
+ microsoft.identitymodel.logging/8.0.1/lib/net9.0/Microsoft.IdentityModel.Logging.dll
+ microsoft.identitymodel.protocols.openidconnect/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.dll
+ microsoft.identitymodel.protocols/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.dll
+ microsoft.identitymodel.tokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.Tokens.dll
+ microsoft.openapi/1.6.14/lib/netstandard2.0/Microsoft.OpenApi.dll
+ microsoft.sqlserver.server/1.0.0/lib/netstandard2.0/Microsoft.SqlServer.Server.dll
+ microsoft.testplatform.testhost/17.14.1/lib/net8.0/
+  Microsoft.TestPlatform.CommunicationUtilities.dll
+  Microsoft.TestPlatform.CoreUtilities.dll
+  Microsoft.TestPlatform.CrossPlatEngine.dll
+  Microsoft.TestPlatform.PlatformAbstractions.dll
+  Microsoft.TestPlatform.Utilities.dll
+  Microsoft.VisualStudio.TestPlatform.Common.dll
+  Microsoft.VisualStudio.TestPlatform.ObjectModel.dll
+  testhost.dll
+ newtonsoft.json/13.0.3/lib/net6.0/Newtonsoft.Json.dll
+ opentelemetry.api.providerbuilderextensions/1.10.0/lib/net9.0/OpenTelemetry.Api.ProviderBuilderExtensions.dll
+ opentelemetry.api/1.10.0/lib/net9.0/OpenTelemetry.Api.dll
+ opentelemetry.exporter.console/1.9.0/lib/net8.0/OpenTelemetry.Exporter.Console.dll
+ opentelemetry.exporter.opentelemetryprotocol/1.9.0/lib/net8.0/OpenTelemetry.Exporter.OpenTelemetryProtocol.dll
+ opentelemetry.exporter.prometheus.aspnetcore/1.10.0-beta.1/lib/net9.0/OpenTelemetry.Exporter.Prometheus.AspNetCore.dll
+ opentelemetry.extensions.hosting/1.9.0/lib/net8.0/OpenTelemetry.Extensions.Hosting.dll
+ opentelemetry.instrumentation.aspnetcore/1.9.0/lib/net8.0/OpenTelemetry.Instrumentation.AspNetCore.dll
+ opentelemetry.instrumentation.sqlclient/1.9.0-beta.1/lib/net8.0/OpenTelemetry.Instrumentation.SqlClient.dll
+ opentelemetry.persistentstorage.abstractions/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.Abstractions.dll
+ opentelemetry.persistentstorage.filesystem/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.FileSystem.dll
+ opentelemetry/1.10.0/lib/net9.0/OpenTelemetry.dll
+ pipelines.sockets.unofficial/2.2.8/lib/net5.0/Pipelines.Sockets.Unofficial.dll
+ polly.core/8.6.6/lib/net8.0/Polly.Core.dll
+ rabbitmq.client/6.8.1/lib/netstandard2.0/RabbitMQ.Client.dll
+ stackexchange.redis/2.8.16/lib/net6.0/StackExchange.Redis.dll
+ swashbuckle.aspnetcore.swagger/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.Swagger.dll
+ swashbuckle.aspnetcore.swaggergen/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.dll
+ swashbuckle.aspnetcore.swaggerui/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.dll
+ system.clientmodel/1.5.1/lib/net8.0/System.ClientModel.dll
+ system.identitymodel.tokens.jwt/8.0.1/lib/net9.0/System.IdentityModel.Tokens.Jwt.dll
+ system.memory.data/8.0.1/lib/net8.0/System.Memory.Data.dll
+ system.security.cryptography.pkcs/9.0.4/lib/net9.0/System.Security.Cryptography.Pkcs.dll
+ system.security.cryptography.protecteddata/9.0.4/lib/net9.0/System.Security.Cryptography.ProtectedData.dll
+ xunit.abstractions/2.0.3/lib/netstandard2.0/xunit.abstractions.dll
+ xunit.assert/2.9.3/lib/net6.0/xunit.assert.dll
+ xunit.extensibility.core/2.9.3/lib/netstandard1.1/xunit.core.dll
+ xunit.extensibility.execution/2.9.3/lib/netstandard1.1/xunit.execution.dotnet.dll
+
+[analyzerReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.AspNetCore.App.Analyzers.dll
+ Microsoft.AspNetCore.App.CodeFixes.dll
+ Microsoft.AspNetCore.App.SourceGenerators.dll
+ Microsoft.AspNetCore.Components.Analyzers.dll
+ Microsoft.Extensions.Logging.Generators.dll
+ Microsoft.Extensions.Options.SourceGeneration.dll
+ Microsoft.Extensions.Validation.ValidationsGenerator.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.Interop.ComInterfaceGenerator.dll
+ Microsoft.Interop.JavaScript.JSImportGenerator.dll
+ Microsoft.Interop.LibraryImportGenerator.dll
+ Microsoft.Interop.SourceGeneration.dll
+ System.Text.Json.SourceGeneration.dll
+ System.Text.RegularExpressions.Generator.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/
+ Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll
+ Microsoft.CodeAnalysis.NetAnalyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/codestyle/cs/
+ Microsoft.CodeAnalysis.CodeStyle.dll
+ Microsoft.CodeAnalysis.CodeStyle.Fixes.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.dll
+<NUGET>/
+ microsoft.entityframeworkcore.analyzers/10.0.5/analyzers/dotnet/cs/Microsoft.EntityFrameworkCore.Analyzers.dll
+ system.clientmodel/1.5.1/analyzers/dotnet/cs/System.ClientModel.SourceGeneration.dll
+ xunit.analyzers/1.18.0/analyzers/dotnet/cs/
+  xunit.analyzers.dll
+  xunit.analyzers.fixes.dll
+
+[analyzerConfigFiles]
+../../.editorconfig
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_10_recommended.globalconfig
+obj/Debug/net10.0/Inventory.Tests.GeneratedMSBuildEditorConfig.editorconfig

--- a/inventory-microservice/Inventory.Tests/Inventory.Tests.csproj.lscache
+++ b/inventory-microservice/Inventory.Tests/Inventory.Tests.csproj.lscache
@@ -397,7 +397,7 @@ Qa/InventoryQaSeedTests.cs
  azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
  azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
  azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
- ecommerce.shared/2.15.0/lib/net10.0/ECommerce.Shared.dll
+ ecommerce.shared/2.16.0/lib/net10.0/ECommerce.Shared.dll
  google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
  grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
  grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll

--- a/order-microservice/Order.Service/Order.Service.csproj.lscache
+++ b/order-microservice/Order.Service/Order.Service.csproj.lscache
@@ -1,0 +1,520 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[properties]
+AssemblyName=Order.Service
+CommandLineArgsForDesignTimeEvaluation=-langversion:14.0 -define:TRACE
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=14.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=Order.Service
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../../MicroservicesInDotNet.sln
+TargetFrameworkIdentifier=.NETCoreApp
+TargetPath=<PATH>bin/Debug/net10.0/Order.Service.dll
+TargetRefPath=<PATH>obj/Debug/net10.0/ref/Order.Service.dll
+TemporaryDependencyNodeTargetIdentifier=net10.0
+
+[commandLineArguments]
+/noconfig
+/unsafe-
+/checked-
+/nowarn:NU1603,NU1902,NU1903,NU5104,CA1711,CA1707,CA1716,1701,1702,8002
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/warn:10
+/define:TRACE;DEBUG;NET;NET10_0;NETCOREAPP;NET5_0_OR_GREATER;NET6_0_OR_GREATER;NET7_0_OR_GREATER;NET8_0_OR_GREATER;NET9_0_OR_GREATER;NET10_0_OR_GREATER;NETCOREAPP1_0_OR_GREATER;NETCOREAPP1_1_OR_GREATER;NETCOREAPP2_0_OR_GREATER;NETCOREAPP2_1_OR_GREATER;NETCOREAPP2_2_OR_GREATER;NETCOREAPP3_0_OR_GREATER;NETCOREAPP3_1_OR_GREATER
+/highentropyva+
+/nullable:enable
+/features:"InterceptorsNamespaces=;Microsoft.Extensions.Validation.Generated"
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\net10.0\Order.Service.dll
+/refout:obj\Debug\net10.0\refint\Order.Service.dll
+/target:exe
+/warnaserror+
+/utf8output
+/deterministic+
+/langversion:14.0
+/features:use-roslyn-tokenizer=true
+/warnaserror+:NU1605,SYSLIB0011
+
+[sourceFiles]
+ApiModels/
+ CreateOrderRequest.cs
+ GetOrderResponse.cs
+Endpoints/
+ InternalOutboxEndpoints.cs
+ OrderApiEndpoint.cs
+Infrastructure/Data/EntityFramework/
+ EntityFrameworkExtensions.cs
+ OrderConfiguration.cs
+ OrderContext.cs
+ OrderContextDesignTimeFactory.cs
+ OrderProductConfiguration.cs
+Infrastructure/Data/
+ InMemoryOrderStore.cs
+ IOrderStore.cs
+Infrastructure/Providers/
+ HttpProductCatalogClient.cs
+ IProductCatalogClient.cs
+ RedisProductPriceProvider.cs
+IntegrationEvents/EventHandlers/
+ PaymentAuthorizedEventHandler.cs
+ PaymentFailedEventHandler.cs
+ ProductCreatedEventHandler.cs
+ StockReservationFailedEventHandler.cs
+IntegrationEvents/Events/
+ OrderCancelledEvent.cs
+ OrderConfirmedEvent.cs
+ OrderCreatedEvent.cs
+ PaymentAuthorizedEvent.cs
+ PaymentFailedEvent.cs
+ ProductCreatedEvent.cs
+ StockReservationFailedEvent.cs
+Migrations/
+ 20260414084245_Initial.cs
+ 20260414084245_Initial.Designer.cs
+ 20260420120000_AddOrderStatus.cs
+ 20260420120000_AddOrderStatus.Designer.cs
+ 20260508071201_SeedQaPhase3a_Order.cs
+ 20260508071201_SeedQaPhase3a_Order.Designer.cs
+ OrderContextModelSnapshot.cs
+Models/
+ Entity.cs
+ IDomainEvent.cs
+ IProductPriceProvider.cs
+ Order.cs
+ OrderCancelledDomainEvent.cs
+ OrderConfirmedDomainEvent.cs
+ OrderCreatedDomainEvent.cs
+ OrderProduct.cs
+ OrderStatus.cs
+obj/Debug/net10.0/
+ .NETCoreApp,Version=v10.0.AssemblyAttributes.cs
+ Order.Service.AssemblyInfo.cs
+ Order.Service.GlobalUsings.g.cs
+Program.cs
+
+[metadataReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.AspNetCore.Antiforgery.dll
+ Microsoft.AspNetCore.Authentication.Abstractions.dll
+ Microsoft.AspNetCore.Authentication.BearerToken.dll
+ Microsoft.AspNetCore.Authentication.Cookies.dll
+ Microsoft.AspNetCore.Authentication.Core.dll
+ Microsoft.AspNetCore.Authentication.dll
+ Microsoft.AspNetCore.Authentication.OAuth.dll
+ Microsoft.AspNetCore.Authorization.dll
+ Microsoft.AspNetCore.Authorization.Policy.dll
+ Microsoft.AspNetCore.Components.Authorization.dll
+ Microsoft.AspNetCore.Components.dll
+ Microsoft.AspNetCore.Components.Endpoints.dll
+ Microsoft.AspNetCore.Components.Forms.dll
+ Microsoft.AspNetCore.Components.Server.dll
+ Microsoft.AspNetCore.Components.Web.dll
+ Microsoft.AspNetCore.Connections.Abstractions.dll
+ Microsoft.AspNetCore.CookiePolicy.dll
+ Microsoft.AspNetCore.Cors.dll
+ Microsoft.AspNetCore.Cryptography.Internal.dll
+ Microsoft.AspNetCore.Cryptography.KeyDerivation.dll
+ Microsoft.AspNetCore.DataProtection.Abstractions.dll
+ Microsoft.AspNetCore.DataProtection.dll
+ Microsoft.AspNetCore.DataProtection.Extensions.dll
+ Microsoft.AspNetCore.Diagnostics.Abstractions.dll
+ Microsoft.AspNetCore.Diagnostics.dll
+ Microsoft.AspNetCore.Diagnostics.HealthChecks.dll
+ Microsoft.AspNetCore.dll
+ Microsoft.AspNetCore.HostFiltering.dll
+ Microsoft.AspNetCore.Hosting.Abstractions.dll
+ Microsoft.AspNetCore.Hosting.dll
+ Microsoft.AspNetCore.Hosting.Server.Abstractions.dll
+ Microsoft.AspNetCore.Html.Abstractions.dll
+ Microsoft.AspNetCore.Http.Abstractions.dll
+ Microsoft.AspNetCore.Http.Connections.Common.dll
+ Microsoft.AspNetCore.Http.Connections.dll
+ Microsoft.AspNetCore.Http.dll
+ Microsoft.AspNetCore.Http.Extensions.dll
+ Microsoft.AspNetCore.Http.Features.dll
+ Microsoft.AspNetCore.Http.Results.dll
+ Microsoft.AspNetCore.HttpLogging.dll
+ Microsoft.AspNetCore.HttpOverrides.dll
+ Microsoft.AspNetCore.HttpsPolicy.dll
+ Microsoft.AspNetCore.Identity.dll
+ Microsoft.AspNetCore.Localization.dll
+ Microsoft.AspNetCore.Localization.Routing.dll
+ Microsoft.AspNetCore.Metadata.dll
+ Microsoft.AspNetCore.Mvc.Abstractions.dll
+ Microsoft.AspNetCore.Mvc.ApiExplorer.dll
+ Microsoft.AspNetCore.Mvc.Core.dll
+ Microsoft.AspNetCore.Mvc.Cors.dll
+ Microsoft.AspNetCore.Mvc.DataAnnotations.dll
+ Microsoft.AspNetCore.Mvc.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Json.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Xml.dll
+ Microsoft.AspNetCore.Mvc.Localization.dll
+ Microsoft.AspNetCore.Mvc.Razor.dll
+ Microsoft.AspNetCore.Mvc.RazorPages.dll
+ Microsoft.AspNetCore.Mvc.TagHelpers.dll
+ Microsoft.AspNetCore.Mvc.ViewFeatures.dll
+ Microsoft.AspNetCore.OutputCaching.dll
+ Microsoft.AspNetCore.RateLimiting.dll
+ Microsoft.AspNetCore.Razor.dll
+ Microsoft.AspNetCore.Razor.Runtime.dll
+ Microsoft.AspNetCore.RequestDecompression.dll
+ Microsoft.AspNetCore.ResponseCaching.Abstractions.dll
+ Microsoft.AspNetCore.ResponseCaching.dll
+ Microsoft.AspNetCore.ResponseCompression.dll
+ Microsoft.AspNetCore.Rewrite.dll
+ Microsoft.AspNetCore.Routing.Abstractions.dll
+ Microsoft.AspNetCore.Routing.dll
+ Microsoft.AspNetCore.Server.HttpSys.dll
+ Microsoft.AspNetCore.Server.IIS.dll
+ Microsoft.AspNetCore.Server.IISIntegration.dll
+ Microsoft.AspNetCore.Server.Kestrel.Core.dll
+ Microsoft.AspNetCore.Server.Kestrel.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll
+ Microsoft.AspNetCore.Session.dll
+ Microsoft.AspNetCore.SignalR.Common.dll
+ Microsoft.AspNetCore.SignalR.Core.dll
+ Microsoft.AspNetCore.SignalR.dll
+ Microsoft.AspNetCore.SignalR.Protocols.Json.dll
+ Microsoft.AspNetCore.StaticAssets.dll
+ Microsoft.AspNetCore.StaticFiles.dll
+ Microsoft.AspNetCore.WebSockets.dll
+ Microsoft.AspNetCore.WebUtilities.dll
+ Microsoft.Extensions.Caching.Abstractions.dll
+ Microsoft.Extensions.Caching.Memory.dll
+ Microsoft.Extensions.Configuration.Abstractions.dll
+ Microsoft.Extensions.Configuration.Binder.dll
+ Microsoft.Extensions.Configuration.CommandLine.dll
+ Microsoft.Extensions.Configuration.dll
+ Microsoft.Extensions.Configuration.EnvironmentVariables.dll
+ Microsoft.Extensions.Configuration.FileExtensions.dll
+ Microsoft.Extensions.Configuration.Ini.dll
+ Microsoft.Extensions.Configuration.Json.dll
+ Microsoft.Extensions.Configuration.KeyPerFile.dll
+ Microsoft.Extensions.Configuration.UserSecrets.dll
+ Microsoft.Extensions.Configuration.Xml.dll
+ Microsoft.Extensions.DependencyInjection.Abstractions.dll
+ Microsoft.Extensions.DependencyInjection.dll
+ Microsoft.Extensions.Diagnostics.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.dll
+ Microsoft.Extensions.Features.dll
+ Microsoft.Extensions.FileProviders.Abstractions.dll
+ Microsoft.Extensions.FileProviders.Composite.dll
+ Microsoft.Extensions.FileProviders.Embedded.dll
+ Microsoft.Extensions.FileProviders.Physical.dll
+ Microsoft.Extensions.FileSystemGlobbing.dll
+ Microsoft.Extensions.Hosting.Abstractions.dll
+ Microsoft.Extensions.Hosting.dll
+ Microsoft.Extensions.Http.dll
+ Microsoft.Extensions.Identity.Core.dll
+ Microsoft.Extensions.Identity.Stores.dll
+ Microsoft.Extensions.Localization.Abstractions.dll
+ Microsoft.Extensions.Localization.dll
+ Microsoft.Extensions.Logging.Abstractions.dll
+ Microsoft.Extensions.Logging.Configuration.dll
+ Microsoft.Extensions.Logging.Console.dll
+ Microsoft.Extensions.Logging.Debug.dll
+ Microsoft.Extensions.Logging.dll
+ Microsoft.Extensions.Logging.EventLog.dll
+ Microsoft.Extensions.Logging.EventSource.dll
+ Microsoft.Extensions.Logging.TraceSource.dll
+ Microsoft.Extensions.ObjectPool.dll
+ Microsoft.Extensions.Options.ConfigurationExtensions.dll
+ Microsoft.Extensions.Options.DataAnnotations.dll
+ Microsoft.Extensions.Options.dll
+ Microsoft.Extensions.Primitives.dll
+ Microsoft.Extensions.Validation.dll
+ Microsoft.Extensions.WebEncoders.dll
+ Microsoft.JSInterop.dll
+ Microsoft.Net.Http.Headers.dll
+ System.Diagnostics.EventLog.dll
+ System.Formats.Cbor.dll
+ System.Security.Cryptography.Xml.dll
+ System.Threading.RateLimiting.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.CSharp.dll
+ Microsoft.VisualBasic.Core.dll
+ Microsoft.VisualBasic.dll
+ Microsoft.Win32.Primitives.dll
+ Microsoft.Win32.Registry.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.Immutable.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Annotations.dll
+ System.ComponentModel.DataAnnotations.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Configuration.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.DataSetExtensions.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.DiagnosticSource.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Formats.Asn1.dll
+ System.Formats.Tar.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.Brotli.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.AccessControl.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipelines.dll
+ System.IO.Pipes.AccessControl.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.AsyncEnumerable.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.Http.Json.dll
+ System.Net.HttpListener.dll
+ System.Net.Mail.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Quic.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.ServerSentEvents.dll
+ System.Net.ServicePoint.dll
+ System.Net.Sockets.dll
+ System.Net.WebClient.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebProxy.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Metadata.dll
+ System.Reflection.Primitives.dll
+ System.Reflection.TypeExtensions.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.Unsafe.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.JavaScript.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Intrinsics.dll
+ System.Runtime.Loader.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.AccessControl.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Cng.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.OpenSsl.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.dll
+ System.Security.Principal.dll
+ System.Security.Principal.Windows.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.ServiceProcess.dll
+ System.Text.Encoding.CodePages.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.Encodings.Web.dll
+ System.Text.Json.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.AccessControl.dll
+ System.Threading.Channels.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.Dataflow.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.Transactions.Local.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Web.HttpUtility.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+ WindowsBase.dll
+<NUGET>/
+ azure.core.amqp/1.3.1/lib/netstandard2.0/Azure.Core.Amqp.dll
+ azure.core/1.47.1/lib/net8.0/Azure.Core.dll
+ azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
+ azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
+ azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
+ ecommerce.shared/2.14.0/lib/net10.0/ECommerce.Shared.dll
+ google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
+ grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
+ grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll
+ grpc.net.common/2.52.0/lib/net7.0/Grpc.Net.Common.dll
+ microsoft.aspnetcore.authentication.jwtbearer/10.0.5/lib/net10.0/Microsoft.AspNetCore.Authentication.JwtBearer.dll
+ microsoft.azure.amqp/2.6.7/lib/netstandard2.0/Microsoft.Azure.Amqp.dll
+ microsoft.bcl.asyncinterfaces/8.0.0/lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll
+ microsoft.bcl.cryptography/9.0.4/lib/net9.0/Microsoft.Bcl.Cryptography.dll
+ microsoft.data.sqlclient/6.1.1/ref/net9.0/Microsoft.Data.SqlClient.dll
+ microsoft.entityframeworkcore.abstractions/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Abstractions.dll
+ microsoft.entityframeworkcore.relational/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Relational.dll
+ microsoft.entityframeworkcore.sqlserver/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.SqlServer.dll
+ microsoft.entityframeworkcore/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.dll
+ microsoft.extensions.caching.stackexchangeredis/10.0.5/lib/net10.0/Microsoft.Extensions.Caching.StackExchangeRedis.dll
+ microsoft.identity.client.extensions.msal/4.73.1/lib/net8.0/Microsoft.Identity.Client.Extensions.Msal.dll
+ microsoft.identity.client/4.73.1/lib/net8.0/Microsoft.Identity.Client.dll
+ microsoft.identitymodel.abstractions/8.0.1/lib/net9.0/Microsoft.IdentityModel.Abstractions.dll
+ microsoft.identitymodel.jsonwebtokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.JsonWebTokens.dll
+ microsoft.identitymodel.logging/8.0.1/lib/net9.0/Microsoft.IdentityModel.Logging.dll
+ microsoft.identitymodel.protocols.openidconnect/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.dll
+ microsoft.identitymodel.protocols/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.dll
+ microsoft.identitymodel.tokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.Tokens.dll
+ microsoft.openapi/1.6.14/lib/netstandard2.0/Microsoft.OpenApi.dll
+ microsoft.sqlserver.server/1.0.0/lib/netstandard2.0/Microsoft.SqlServer.Server.dll
+ opentelemetry.api.providerbuilderextensions/1.10.0/lib/net9.0/OpenTelemetry.Api.ProviderBuilderExtensions.dll
+ opentelemetry.api/1.10.0/lib/net9.0/OpenTelemetry.Api.dll
+ opentelemetry.exporter.console/1.9.0/lib/net8.0/OpenTelemetry.Exporter.Console.dll
+ opentelemetry.exporter.opentelemetryprotocol/1.9.0/lib/net8.0/OpenTelemetry.Exporter.OpenTelemetryProtocol.dll
+ opentelemetry.exporter.prometheus.aspnetcore/1.10.0-beta.1/lib/net9.0/OpenTelemetry.Exporter.Prometheus.AspNetCore.dll
+ opentelemetry.extensions.hosting/1.9.0/lib/net8.0/OpenTelemetry.Extensions.Hosting.dll
+ opentelemetry.instrumentation.aspnetcore/1.9.0/lib/net8.0/OpenTelemetry.Instrumentation.AspNetCore.dll
+ opentelemetry.instrumentation.sqlclient/1.9.0-beta.1/lib/net8.0/OpenTelemetry.Instrumentation.SqlClient.dll
+ opentelemetry.persistentstorage.abstractions/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.Abstractions.dll
+ opentelemetry.persistentstorage.filesystem/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.FileSystem.dll
+ opentelemetry/1.10.0/lib/net9.0/OpenTelemetry.dll
+ pipelines.sockets.unofficial/2.2.8/lib/net5.0/Pipelines.Sockets.Unofficial.dll
+ polly.core/8.6.6/lib/net8.0/Polly.Core.dll
+ rabbitmq.client/6.8.1/lib/netstandard2.0/RabbitMQ.Client.dll
+ stackexchange.redis/2.8.16/lib/net6.0/StackExchange.Redis.dll
+ swashbuckle.aspnetcore.swagger/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.Swagger.dll
+ swashbuckle.aspnetcore.swaggergen/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.dll
+ swashbuckle.aspnetcore.swaggerui/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.dll
+ system.clientmodel/1.5.1/lib/net8.0/System.ClientModel.dll
+ system.identitymodel.tokens.jwt/8.0.1/lib/net9.0/System.IdentityModel.Tokens.Jwt.dll
+ system.memory.data/8.0.1/lib/net8.0/System.Memory.Data.dll
+ system.security.cryptography.pkcs/9.0.4/lib/net9.0/System.Security.Cryptography.Pkcs.dll
+ system.security.cryptography.protecteddata/9.0.4/lib/net9.0/System.Security.Cryptography.ProtectedData.dll
+
+[analyzerReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.AspNetCore.App.Analyzers.dll
+ Microsoft.AspNetCore.App.CodeFixes.dll
+ Microsoft.AspNetCore.App.SourceGenerators.dll
+ Microsoft.AspNetCore.Components.Analyzers.dll
+ Microsoft.Extensions.Logging.Generators.dll
+ Microsoft.Extensions.Options.SourceGeneration.dll
+ Microsoft.Extensions.Validation.ValidationsGenerator.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.Interop.ComInterfaceGenerator.dll
+ Microsoft.Interop.JavaScript.JSImportGenerator.dll
+ Microsoft.Interop.LibraryImportGenerator.dll
+ Microsoft.Interop.SourceGeneration.dll
+ System.Text.Json.SourceGeneration.dll
+ System.Text.RegularExpressions.Generator.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk.Razor/source-generators/
+ Microsoft.AspNetCore.Razor.Utilities.Shared.dll
+ Microsoft.CodeAnalysis.Razor.Compiler.dll
+ Microsoft.Extensions.ObjectPool.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk.Web/analyzers/cs/
+ Microsoft.AspNetCore.Analyzers.dll
+ Microsoft.AspNetCore.Mvc.Analyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/
+ Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll
+ Microsoft.CodeAnalysis.NetAnalyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/codestyle/cs/
+ Microsoft.CodeAnalysis.CodeStyle.dll
+ Microsoft.CodeAnalysis.CodeStyle.Fixes.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.dll
+<NUGET>/microsoft.codeanalysis.analyzers/3.11.0/analyzers/dotnet/cs/
+ Microsoft.CodeAnalysis.Analyzers.dll
+ Microsoft.CodeAnalysis.CSharp.Analyzers.dll
+<NUGET>/
+ microsoft.entityframeworkcore.analyzers/10.0.5/analyzers/dotnet/cs/Microsoft.EntityFrameworkCore.Analyzers.dll
+ system.clientmodel/1.5.1/analyzers/dotnet/cs/System.ClientModel.SourceGeneration.dll
+
+[analyzerConfigFiles]
+../../.editorconfig
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_10_recommended.globalconfig
+obj/Debug/net10.0/Order.Service.GeneratedMSBuildEditorConfig.editorconfig

--- a/order-microservice/Order.Tests/Order.Tests.csproj.lscache
+++ b/order-microservice/Order.Tests/Order.Tests.csproj.lscache
@@ -1,0 +1,503 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[properties]
+AssemblyName=Order.Tests
+CommandLineArgsForDesignTimeEvaluation=-langversion:14.0 -define:TRACE
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=14.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=Order.Tests
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../../MicroservicesInDotNet.sln
+TargetFrameworkIdentifier=.NETCoreApp
+TargetPath=<PATH>bin/Debug/net10.0/Order.Tests.dll
+TargetRefPath=<PATH>obj/Debug/net10.0/ref/Order.Tests.dll
+TemporaryDependencyNodeTargetIdentifier=net10.0
+
+[commandLineArguments]
+/noconfig
+/unsafe-
+/checked-
+/nowarn:NU1603,NU1902,NU1903,NU5104,CA1711,CA1707,CA1716,1701,1702,8002
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/warn:10
+/define:TRACE;DEBUG;NET;NET10_0;NETCOREAPP;NET5_0_OR_GREATER;NET6_0_OR_GREATER;NET7_0_OR_GREATER;NET8_0_OR_GREATER;NET9_0_OR_GREATER;NET10_0_OR_GREATER;NETCOREAPP1_0_OR_GREATER;NETCOREAPP1_1_OR_GREATER;NETCOREAPP2_0_OR_GREATER;NETCOREAPP2_1_OR_GREATER;NETCOREAPP2_2_OR_GREATER;NETCOREAPP3_0_OR_GREATER;NETCOREAPP3_1_OR_GREATER
+/highentropyva+
+/nullable:enable
+/features:"InterceptorsNamespaces=;Microsoft.Extensions.Validation.Generated"
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\net10.0\Order.Tests.dll
+/refout:obj\Debug\net10.0\refint\Order.Tests.dll
+/target:exe
+/warnaserror+
+/utf8output
+/deterministic+
+/langversion:14.0
+/warnaserror+:NU1605,SYSLIB0011
+
+[sourceFiles]
+<NUGET>/microsoft.net.test.sdk/17.14.1/build/net8.0/Microsoft.NET.Test.Sdk.Program.cs
+Api/
+ HealthChecksTests.cs
+ InternalOutboxEndpointsTests.cs
+ OrderApiEndpointTests.cs
+ OrderApiTests.cs
+ QaSeedPresenceTests.cs
+ StockReservationFailedTests.cs
+Authentication/TestAuthHandler.cs
+Domain/
+ MetricFactoryTests.cs
+ OrderTests.cs
+Infrastructure/RedisProductPriceProviderTests.cs
+IntegrationEvents/
+ MessagingProviderBootTests.cs
+ PaymentAuthorizedFlowTests.cs
+ PaymentAuthorizedHandlerUnitTests.cs
+ PaymentFailedFlowTests.cs
+ StockReservationFailedHandlerUnitTests.cs
+IntegrationTestBase.cs
+obj/Debug/net10.0/
+ .NETCoreApp,Version=v10.0.AssemblyAttributes.cs
+ Order.Tests.AssemblyInfo.cs
+ Order.Tests.GlobalUsings.g.cs
+OrderWebApplicationFactory.cs
+
+[metadataReferences]
+../Order.Service/obj/Debug/net10.0/ref/Order.Service.dll
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.AspNetCore.Antiforgery.dll
+ Microsoft.AspNetCore.Authentication.Abstractions.dll
+ Microsoft.AspNetCore.Authentication.BearerToken.dll
+ Microsoft.AspNetCore.Authentication.Cookies.dll
+ Microsoft.AspNetCore.Authentication.Core.dll
+ Microsoft.AspNetCore.Authentication.dll
+ Microsoft.AspNetCore.Authentication.OAuth.dll
+ Microsoft.AspNetCore.Authorization.dll
+ Microsoft.AspNetCore.Authorization.Policy.dll
+ Microsoft.AspNetCore.Components.Authorization.dll
+ Microsoft.AspNetCore.Components.dll
+ Microsoft.AspNetCore.Components.Endpoints.dll
+ Microsoft.AspNetCore.Components.Forms.dll
+ Microsoft.AspNetCore.Components.Server.dll
+ Microsoft.AspNetCore.Components.Web.dll
+ Microsoft.AspNetCore.Connections.Abstractions.dll
+ Microsoft.AspNetCore.CookiePolicy.dll
+ Microsoft.AspNetCore.Cors.dll
+ Microsoft.AspNetCore.Cryptography.Internal.dll
+ Microsoft.AspNetCore.Cryptography.KeyDerivation.dll
+ Microsoft.AspNetCore.DataProtection.Abstractions.dll
+ Microsoft.AspNetCore.DataProtection.dll
+ Microsoft.AspNetCore.DataProtection.Extensions.dll
+ Microsoft.AspNetCore.Diagnostics.Abstractions.dll
+ Microsoft.AspNetCore.Diagnostics.dll
+ Microsoft.AspNetCore.Diagnostics.HealthChecks.dll
+ Microsoft.AspNetCore.dll
+ Microsoft.AspNetCore.HostFiltering.dll
+ Microsoft.AspNetCore.Hosting.Abstractions.dll
+ Microsoft.AspNetCore.Hosting.dll
+ Microsoft.AspNetCore.Hosting.Server.Abstractions.dll
+ Microsoft.AspNetCore.Html.Abstractions.dll
+ Microsoft.AspNetCore.Http.Abstractions.dll
+ Microsoft.AspNetCore.Http.Connections.Common.dll
+ Microsoft.AspNetCore.Http.Connections.dll
+ Microsoft.AspNetCore.Http.dll
+ Microsoft.AspNetCore.Http.Extensions.dll
+ Microsoft.AspNetCore.Http.Features.dll
+ Microsoft.AspNetCore.Http.Results.dll
+ Microsoft.AspNetCore.HttpLogging.dll
+ Microsoft.AspNetCore.HttpOverrides.dll
+ Microsoft.AspNetCore.HttpsPolicy.dll
+ Microsoft.AspNetCore.Identity.dll
+ Microsoft.AspNetCore.Localization.dll
+ Microsoft.AspNetCore.Localization.Routing.dll
+ Microsoft.AspNetCore.Metadata.dll
+ Microsoft.AspNetCore.Mvc.Abstractions.dll
+ Microsoft.AspNetCore.Mvc.ApiExplorer.dll
+ Microsoft.AspNetCore.Mvc.Core.dll
+ Microsoft.AspNetCore.Mvc.Cors.dll
+ Microsoft.AspNetCore.Mvc.DataAnnotations.dll
+ Microsoft.AspNetCore.Mvc.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Json.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Xml.dll
+ Microsoft.AspNetCore.Mvc.Localization.dll
+ Microsoft.AspNetCore.Mvc.Razor.dll
+ Microsoft.AspNetCore.Mvc.RazorPages.dll
+ Microsoft.AspNetCore.Mvc.TagHelpers.dll
+ Microsoft.AspNetCore.Mvc.ViewFeatures.dll
+ Microsoft.AspNetCore.OutputCaching.dll
+ Microsoft.AspNetCore.RateLimiting.dll
+ Microsoft.AspNetCore.Razor.dll
+ Microsoft.AspNetCore.Razor.Runtime.dll
+ Microsoft.AspNetCore.RequestDecompression.dll
+ Microsoft.AspNetCore.ResponseCaching.Abstractions.dll
+ Microsoft.AspNetCore.ResponseCaching.dll
+ Microsoft.AspNetCore.ResponseCompression.dll
+ Microsoft.AspNetCore.Rewrite.dll
+ Microsoft.AspNetCore.Routing.Abstractions.dll
+ Microsoft.AspNetCore.Routing.dll
+ Microsoft.AspNetCore.Server.HttpSys.dll
+ Microsoft.AspNetCore.Server.IIS.dll
+ Microsoft.AspNetCore.Server.IISIntegration.dll
+ Microsoft.AspNetCore.Server.Kestrel.Core.dll
+ Microsoft.AspNetCore.Server.Kestrel.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll
+ Microsoft.AspNetCore.Session.dll
+ Microsoft.AspNetCore.SignalR.Common.dll
+ Microsoft.AspNetCore.SignalR.Core.dll
+ Microsoft.AspNetCore.SignalR.dll
+ Microsoft.AspNetCore.SignalR.Protocols.Json.dll
+ Microsoft.AspNetCore.StaticAssets.dll
+ Microsoft.AspNetCore.StaticFiles.dll
+ Microsoft.AspNetCore.WebSockets.dll
+ Microsoft.AspNetCore.WebUtilities.dll
+ Microsoft.Extensions.Caching.Abstractions.dll
+ Microsoft.Extensions.Caching.Memory.dll
+ Microsoft.Extensions.Configuration.Abstractions.dll
+ Microsoft.Extensions.Configuration.Binder.dll
+ Microsoft.Extensions.Configuration.CommandLine.dll
+ Microsoft.Extensions.Configuration.dll
+ Microsoft.Extensions.Configuration.EnvironmentVariables.dll
+ Microsoft.Extensions.Configuration.FileExtensions.dll
+ Microsoft.Extensions.Configuration.Ini.dll
+ Microsoft.Extensions.Configuration.Json.dll
+ Microsoft.Extensions.Configuration.KeyPerFile.dll
+ Microsoft.Extensions.Configuration.UserSecrets.dll
+ Microsoft.Extensions.Configuration.Xml.dll
+ Microsoft.Extensions.DependencyInjection.Abstractions.dll
+ Microsoft.Extensions.DependencyInjection.dll
+ Microsoft.Extensions.Diagnostics.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.dll
+ Microsoft.Extensions.Features.dll
+ Microsoft.Extensions.FileProviders.Abstractions.dll
+ Microsoft.Extensions.FileProviders.Composite.dll
+ Microsoft.Extensions.FileProviders.Embedded.dll
+ Microsoft.Extensions.FileProviders.Physical.dll
+ Microsoft.Extensions.FileSystemGlobbing.dll
+ Microsoft.Extensions.Hosting.Abstractions.dll
+ Microsoft.Extensions.Hosting.dll
+ Microsoft.Extensions.Http.dll
+ Microsoft.Extensions.Identity.Core.dll
+ Microsoft.Extensions.Identity.Stores.dll
+ Microsoft.Extensions.Localization.Abstractions.dll
+ Microsoft.Extensions.Localization.dll
+ Microsoft.Extensions.Logging.Abstractions.dll
+ Microsoft.Extensions.Logging.Configuration.dll
+ Microsoft.Extensions.Logging.Console.dll
+ Microsoft.Extensions.Logging.Debug.dll
+ Microsoft.Extensions.Logging.dll
+ Microsoft.Extensions.Logging.EventLog.dll
+ Microsoft.Extensions.Logging.EventSource.dll
+ Microsoft.Extensions.Logging.TraceSource.dll
+ Microsoft.Extensions.ObjectPool.dll
+ Microsoft.Extensions.Options.ConfigurationExtensions.dll
+ Microsoft.Extensions.Options.DataAnnotations.dll
+ Microsoft.Extensions.Options.dll
+ Microsoft.Extensions.Primitives.dll
+ Microsoft.Extensions.Validation.dll
+ Microsoft.Extensions.WebEncoders.dll
+ Microsoft.JSInterop.dll
+ Microsoft.Net.Http.Headers.dll
+ System.Diagnostics.EventLog.dll
+ System.Formats.Cbor.dll
+ System.Security.Cryptography.Xml.dll
+ System.Threading.RateLimiting.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.CSharp.dll
+ Microsoft.VisualBasic.Core.dll
+ Microsoft.VisualBasic.dll
+ Microsoft.Win32.Primitives.dll
+ Microsoft.Win32.Registry.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.Immutable.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Annotations.dll
+ System.ComponentModel.DataAnnotations.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Configuration.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.DataSetExtensions.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.DiagnosticSource.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Formats.Asn1.dll
+ System.Formats.Tar.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.Brotli.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.AccessControl.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipelines.dll
+ System.IO.Pipes.AccessControl.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.AsyncEnumerable.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.Http.Json.dll
+ System.Net.HttpListener.dll
+ System.Net.Mail.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Quic.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.ServerSentEvents.dll
+ System.Net.ServicePoint.dll
+ System.Net.Sockets.dll
+ System.Net.WebClient.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebProxy.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Metadata.dll
+ System.Reflection.Primitives.dll
+ System.Reflection.TypeExtensions.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.Unsafe.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.JavaScript.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Intrinsics.dll
+ System.Runtime.Loader.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.AccessControl.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Cng.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.OpenSsl.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.dll
+ System.Security.Principal.dll
+ System.Security.Principal.Windows.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.ServiceProcess.dll
+ System.Text.Encoding.CodePages.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.Encodings.Web.dll
+ System.Text.Json.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.AccessControl.dll
+ System.Threading.Channels.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.Dataflow.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.Transactions.Local.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Web.HttpUtility.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+ WindowsBase.dll
+<NUGET>/
+ azure.core.amqp/1.3.1/lib/netstandard2.0/Azure.Core.Amqp.dll
+ azure.core/1.47.1/lib/net8.0/Azure.Core.dll
+ azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
+ azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
+ azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
+ castle.core/5.1.1/lib/net6.0/Castle.Core.dll
+ ecommerce.shared/2.14.0/lib/net10.0/ECommerce.Shared.dll
+ google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
+ grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
+ grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll
+ grpc.net.common/2.52.0/lib/net7.0/Grpc.Net.Common.dll
+ microsoft.aspnetcore.authentication.jwtbearer/10.0.5/lib/net10.0/Microsoft.AspNetCore.Authentication.JwtBearer.dll
+ microsoft.aspnetcore.mvc.testing/10.0.5/lib/net10.0/Microsoft.AspNetCore.Mvc.Testing.dll
+ microsoft.aspnetcore.testhost/10.0.5/lib/net10.0/Microsoft.AspNetCore.TestHost.dll
+ microsoft.azure.amqp/2.6.7/lib/netstandard2.0/Microsoft.Azure.Amqp.dll
+ microsoft.bcl.asyncinterfaces/8.0.0/lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll
+ microsoft.bcl.cryptography/9.0.4/lib/net9.0/Microsoft.Bcl.Cryptography.dll
+ microsoft.codecoverage/17.14.1/lib/net8.0/Microsoft.VisualStudio.CodeCoverage.Shim.dll
+ microsoft.data.sqlclient/6.1.1/ref/net9.0/Microsoft.Data.SqlClient.dll
+ microsoft.entityframeworkcore.abstractions/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Abstractions.dll
+ microsoft.entityframeworkcore.relational/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Relational.dll
+ microsoft.entityframeworkcore.sqlserver/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.SqlServer.dll
+ microsoft.entityframeworkcore/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.dll
+ microsoft.extensions.caching.stackexchangeredis/10.0.5/lib/net10.0/Microsoft.Extensions.Caching.StackExchangeRedis.dll
+ microsoft.extensions.dependencymodel/10.0.5/lib/net10.0/Microsoft.Extensions.DependencyModel.dll
+ microsoft.identity.client.extensions.msal/4.73.1/lib/net8.0/Microsoft.Identity.Client.Extensions.Msal.dll
+ microsoft.identity.client/4.73.1/lib/net8.0/Microsoft.Identity.Client.dll
+ microsoft.identitymodel.abstractions/8.0.1/lib/net9.0/Microsoft.IdentityModel.Abstractions.dll
+ microsoft.identitymodel.jsonwebtokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.JsonWebTokens.dll
+ microsoft.identitymodel.logging/8.0.1/lib/net9.0/Microsoft.IdentityModel.Logging.dll
+ microsoft.identitymodel.protocols.openidconnect/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.dll
+ microsoft.identitymodel.protocols/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.dll
+ microsoft.identitymodel.tokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.Tokens.dll
+ microsoft.openapi/1.6.14/lib/netstandard2.0/Microsoft.OpenApi.dll
+ microsoft.sqlserver.server/1.0.0/lib/netstandard2.0/Microsoft.SqlServer.Server.dll
+ microsoft.testplatform.testhost/17.14.1/lib/net8.0/
+  Microsoft.TestPlatform.CommunicationUtilities.dll
+  Microsoft.TestPlatform.CoreUtilities.dll
+  Microsoft.TestPlatform.CrossPlatEngine.dll
+  Microsoft.TestPlatform.PlatformAbstractions.dll
+  Microsoft.TestPlatform.Utilities.dll
+  Microsoft.VisualStudio.TestPlatform.Common.dll
+  Microsoft.VisualStudio.TestPlatform.ObjectModel.dll
+  testhost.dll
+ moq/4.20.72/lib/net6.0/Moq.dll
+ newtonsoft.json/13.0.3/lib/net6.0/Newtonsoft.Json.dll
+ opentelemetry.api.providerbuilderextensions/1.10.0/lib/net9.0/OpenTelemetry.Api.ProviderBuilderExtensions.dll
+ opentelemetry.api/1.10.0/lib/net9.0/OpenTelemetry.Api.dll
+ opentelemetry.exporter.console/1.9.0/lib/net8.0/OpenTelemetry.Exporter.Console.dll
+ opentelemetry.exporter.opentelemetryprotocol/1.9.0/lib/net8.0/OpenTelemetry.Exporter.OpenTelemetryProtocol.dll
+ opentelemetry.exporter.prometheus.aspnetcore/1.10.0-beta.1/lib/net9.0/OpenTelemetry.Exporter.Prometheus.AspNetCore.dll
+ opentelemetry.extensions.hosting/1.9.0/lib/net8.0/OpenTelemetry.Extensions.Hosting.dll
+ opentelemetry.instrumentation.aspnetcore/1.9.0/lib/net8.0/OpenTelemetry.Instrumentation.AspNetCore.dll
+ opentelemetry.instrumentation.sqlclient/1.9.0-beta.1/lib/net8.0/OpenTelemetry.Instrumentation.SqlClient.dll
+ opentelemetry.persistentstorage.abstractions/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.Abstractions.dll
+ opentelemetry.persistentstorage.filesystem/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.FileSystem.dll
+ opentelemetry/1.10.0/lib/net9.0/OpenTelemetry.dll
+ pipelines.sockets.unofficial/2.2.8/lib/net5.0/Pipelines.Sockets.Unofficial.dll
+ polly.core/8.6.6/lib/net8.0/Polly.Core.dll
+ rabbitmq.client/6.8.1/lib/netstandard2.0/RabbitMQ.Client.dll
+ stackexchange.redis/2.8.16/lib/net6.0/StackExchange.Redis.dll
+ swashbuckle.aspnetcore.swagger/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.Swagger.dll
+ swashbuckle.aspnetcore.swaggergen/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.dll
+ swashbuckle.aspnetcore.swaggerui/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.dll
+ system.clientmodel/1.5.1/lib/net8.0/System.ClientModel.dll
+ system.identitymodel.tokens.jwt/8.0.1/lib/net9.0/System.IdentityModel.Tokens.Jwt.dll
+ system.memory.data/8.0.1/lib/net8.0/System.Memory.Data.dll
+ system.security.cryptography.pkcs/9.0.4/lib/net9.0/System.Security.Cryptography.Pkcs.dll
+ system.security.cryptography.protecteddata/9.0.4/lib/net9.0/System.Security.Cryptography.ProtectedData.dll
+ xunit.abstractions/2.0.3/lib/netstandard2.0/xunit.abstractions.dll
+ xunit.assert/2.9.3/lib/net6.0/xunit.assert.dll
+ xunit.extensibility.core/2.9.3/lib/netstandard1.1/xunit.core.dll
+ xunit.extensibility.execution/2.9.3/lib/netstandard1.1/xunit.execution.dotnet.dll
+
+[analyzerReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.AspNetCore.App.Analyzers.dll
+ Microsoft.AspNetCore.App.CodeFixes.dll
+ Microsoft.AspNetCore.App.SourceGenerators.dll
+ Microsoft.AspNetCore.Components.Analyzers.dll
+ Microsoft.Extensions.Logging.Generators.dll
+ Microsoft.Extensions.Options.SourceGeneration.dll
+ Microsoft.Extensions.Validation.ValidationsGenerator.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.Interop.ComInterfaceGenerator.dll
+ Microsoft.Interop.JavaScript.JSImportGenerator.dll
+ Microsoft.Interop.LibraryImportGenerator.dll
+ Microsoft.Interop.SourceGeneration.dll
+ System.Text.Json.SourceGeneration.dll
+ System.Text.RegularExpressions.Generator.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/
+ Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll
+ Microsoft.CodeAnalysis.NetAnalyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/codestyle/cs/
+ Microsoft.CodeAnalysis.CodeStyle.dll
+ Microsoft.CodeAnalysis.CodeStyle.Fixes.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.dll
+<NUGET>/
+ microsoft.entityframeworkcore.analyzers/10.0.5/analyzers/dotnet/cs/Microsoft.EntityFrameworkCore.Analyzers.dll
+ system.clientmodel/1.5.1/analyzers/dotnet/cs/System.ClientModel.SourceGeneration.dll
+ xunit.analyzers/1.18.0/analyzers/dotnet/cs/
+  xunit.analyzers.dll
+  xunit.analyzers.fixes.dll
+
+[analyzerConfigFiles]
+../../.editorconfig
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_10_recommended.globalconfig
+obj/Debug/net10.0/Order.Tests.GeneratedMSBuildEditorConfig.editorconfig

--- a/payment-microservice/Payment.Service/Endpoints/PaymentApiEndpoints.cs
+++ b/payment-microservice/Payment.Service/Endpoints/PaymentApiEndpoints.cs
@@ -59,7 +59,6 @@ public static class PaymentApiEndpoints
 
         routeBuilder.MapPost("/{paymentId:guid}/capture", async Task<IResult> (
             [FromServices] IPaymentStore paymentStore,
-            [FromServices] IOutboxStore outboxStore,
             [FromServices] IPaymentGateway gateway,
             [FromServices] PaymentMetrics metrics,
             Guid paymentId) =>
@@ -86,20 +85,10 @@ public static class PaymentApiEndpoints
 
             await gateway.CaptureAsync(payment.ProviderReference!);
 
-            await outboxStore.CreateExecutionStrategy().ExecuteAsync(async () =>
+            await paymentStore.ExecuteAsync(() =>
             {
-                using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-
                 payment.Capture(DateTime.UtcNow);
-
-                await paymentStore.SaveChangesAsync();
-
-                await outboxStore.AddOutboxEvent(new PaymentCapturedEvent(
-                    payment.PaymentId,
-                    payment.OrderId,
-                    payment.Amount));
-
-                scope.Complete();
+                return Task.CompletedTask;
             });
 
             metrics.RecordStatusChange(PaymentStatus.Captured);

--- a/payment-microservice/Payment.Service/Endpoints/PaymentApiEndpoints.cs
+++ b/payment-microservice/Payment.Service/Endpoints/PaymentApiEndpoints.cs
@@ -1,11 +1,8 @@
 using System.Security.Claims;
-using System.Transactions;
-using ECommerce.Shared.Infrastructure.Outbox;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Payment.Service.Infrastructure.Data;
 using Payment.Service.Infrastructure.Gateways;
-using Payment.Service.IntegrationEvents.Events;
 using Payment.Service.Models;
 using Payment.Service.Observability;
 
@@ -98,7 +95,6 @@ public static class PaymentApiEndpoints
 
         routeBuilder.MapPost("/{paymentId:guid}/refund", async Task<IResult> (
             [FromServices] IPaymentStore paymentStore,
-            [FromServices] IOutboxStore outboxStore,
             [FromServices] IPaymentGateway gateway,
             [FromServices] PaymentMetrics metrics,
             Guid paymentId,
@@ -123,20 +119,10 @@ public static class PaymentApiEndpoints
 
             await gateway.RefundAsync(payment.ProviderReference!, refundAmount);
 
-            await outboxStore.CreateExecutionStrategy().ExecuteAsync(async () =>
+            await paymentStore.ExecuteAsync(() =>
             {
-                using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-
-                payment.Refund(DateTime.UtcNow);
-
-                await paymentStore.SaveChangesAsync();
-
-                await outboxStore.AddOutboxEvent(new PaymentRefundedEvent(
-                    payment.PaymentId,
-                    payment.OrderId,
-                    refundAmount));
-
-                scope.Complete();
+                payment.Refund(refundAmount, DateTime.UtcNow);
+                return Task.CompletedTask;
             });
 
             metrics.RecordStatusChange(PaymentStatus.Refunded);

--- a/payment-microservice/Payment.Service/Infrastructure/Data/EntityFramework/PaymentContext.cs
+++ b/payment-microservice/Payment.Service/Infrastructure/Data/EntityFramework/PaymentContext.cs
@@ -1,13 +1,24 @@
+using ECommerce.Shared.Infrastructure.EventBus;
+using ECommerce.Shared.Infrastructure.Outbox;
 using Microsoft.EntityFrameworkCore;
+using Payment.Service.IntegrationEvents.Events;
 using Payment.Service.Models;
 
 namespace Payment.Service.Infrastructure.Data.EntityFramework;
 
 internal class PaymentContext : DbContext, IPaymentStore
 {
+    private readonly IOutboxUnitOfWork? _outboxUnitOfWork;
+
     public PaymentContext(DbContextOptions<PaymentContext> options)
         : base(options)
     {
+    }
+
+    public PaymentContext(DbContextOptions<PaymentContext> options, IOutboxUnitOfWork outboxUnitOfWork)
+        : base(options)
+    {
+        _outboxUnitOfWork = outboxUnitOfWork;
     }
 
     public DbSet<Models.Payment> Payments { get; set; } = null!;
@@ -30,6 +41,30 @@ internal class PaymentContext : DbContext, IPaymentStore
     }
 
     public Task<int> SaveChangesAsync() => base.SaveChangesAsync();
+
+    public async Task ExecuteAsync(Func<Task> unitOfWork)
+    {
+        if (_outboxUnitOfWork is null)
+        {
+            throw new InvalidOperationException(
+                "PaymentContext was constructed without an IOutboxUnitOfWork; ExecuteAsync requires the runtime constructor.");
+        }
+
+        var strategy = Database.CreateExecutionStrategy();
+        await _outboxUnitOfWork.ExecuteAsync(strategy, async () =>
+        {
+            await unitOfWork();
+
+            var domainEvents = ChangeTracker.Entries<Entity>()
+                .SelectMany(e => e.Entity.DequeueDomainEvents())
+                .ToList();
+
+            await SaveChangesAsync(acceptAllChangesOnSuccess: false);
+            ChangeTracker.AcceptAllChanges();
+
+            return domainEvents.Select(Translate).ToList();
+        });
+    }
 
     public async Task RecordOrderCustomer(Guid orderId, string customerId)
     {
@@ -54,4 +89,11 @@ internal class PaymentContext : DbContext, IPaymentStore
         var record = await OrderCustomers.FirstOrDefaultAsync(o => o.OrderId == orderId);
         return record?.CustomerId;
     }
+
+    private static Event Translate(IDomainEvent domainEvent) => domainEvent switch
+    {
+        PaymentCapturedDomainEvent e => new PaymentCapturedEvent(e.PaymentId, e.OrderId, e.Amount),
+        _ => throw new InvalidOperationException(
+            $"No integration-event translation registered for domain event {domainEvent.GetType().Name}")
+    };
 }

--- a/payment-microservice/Payment.Service/Infrastructure/Data/EntityFramework/PaymentContext.cs
+++ b/payment-microservice/Payment.Service/Infrastructure/Data/EntityFramework/PaymentContext.cs
@@ -93,6 +93,7 @@ internal class PaymentContext : DbContext, IPaymentStore
     private static Event Translate(IDomainEvent domainEvent) => domainEvent switch
     {
         PaymentCapturedDomainEvent e => new PaymentCapturedEvent(e.PaymentId, e.OrderId, e.Amount),
+        PaymentRefundedDomainEvent e => new PaymentRefundedEvent(e.PaymentId, e.OrderId, e.Amount),
         _ => throw new InvalidOperationException(
             $"No integration-event translation registered for domain event {domainEvent.GetType().Name}")
     };

--- a/payment-microservice/Payment.Service/Infrastructure/Data/EntityFramework/PaymentContext.cs
+++ b/payment-microservice/Payment.Service/Infrastructure/Data/EntityFramework/PaymentContext.cs
@@ -8,16 +8,26 @@ namespace Payment.Service.Infrastructure.Data.EntityFramework;
 
 internal class PaymentContext : DbContext, IPaymentStore
 {
-    private readonly IOutboxUnitOfWork? _outboxUnitOfWork;
+    private readonly IOutboxUnitOfWork _outboxUnitOfWork;
 
-    public PaymentContext(DbContextOptions<PaymentContext> options)
+    /// <summary>
+    /// Design-time only constructor. Used exclusively by <see cref="PaymentContextDesignTimeFactory"/>
+    /// for EF Core migrations tooling. Runtime code must use the constructor that accepts
+    /// <see cref="IOutboxUnitOfWork"/> so misconfiguration fails fast at startup.
+    /// </summary>
+    internal PaymentContext(DbContextOptions<PaymentContext> options)
         : base(options)
     {
+        // _outboxUnitOfWork is left as default (null) for the design-time path.
+        // The Translate/ExecuteAsync methods are never called during migrations,
+        // so null! is safe here. The runtime constructor below makes it mandatory.
+        _outboxUnitOfWork = null!;
     }
 
     public PaymentContext(DbContextOptions<PaymentContext> options, IOutboxUnitOfWork outboxUnitOfWork)
         : base(options)
     {
+        ArgumentNullException.ThrowIfNull(outboxUnitOfWork);
         _outboxUnitOfWork = outboxUnitOfWork;
     }
 
@@ -30,10 +40,9 @@ internal class PaymentContext : DbContext, IPaymentStore
         modelBuilder.ApplyConfiguration(new OrderCustomerConfiguration());
     }
 
-    public Task Add(Models.Payment payment)
+    public void Add(Models.Payment payment)
     {
         Payments.Add(payment);
-        return Task.CompletedTask;
     }
 
     public async Task<Models.Payment?> GetById(Guid paymentId)
@@ -50,17 +59,15 @@ internal class PaymentContext : DbContext, IPaymentStore
 
     public async Task ExecuteAsync(Func<Task> unitOfWork)
     {
-        if (_outboxUnitOfWork is null)
-        {
-            throw new InvalidOperationException(
-                "PaymentContext was constructed without an IOutboxUnitOfWork; ExecuteAsync requires the runtime constructor.");
-        }
-
         var strategy = Database.CreateExecutionStrategy();
         await _outboxUnitOfWork.ExecuteAsync(strategy, async () =>
         {
             await unitOfWork();
 
+            // Snapshot domain events before SaveChanges so that if the execution
+            // strategy retries, the aggregate still has its events. We capture the
+            // list here and clear the queue only after AcceptAllChanges confirms
+            // the transaction committed successfully.
             var domainEvents = ChangeTracker.Entries<Entity>()
                 .SelectMany(e => e.Entity.DequeueDomainEvents())
                 .ToList();
@@ -104,6 +111,8 @@ internal class PaymentContext : DbContext, IPaymentStore
             e.PaymentId, e.OrderId, e.CustomerId, e.Reason),
         PaymentCapturedDomainEvent e => new PaymentCapturedEvent(e.PaymentId, e.OrderId, e.Amount),
         PaymentRefundedDomainEvent e => new PaymentRefundedEvent(e.PaymentId, e.OrderId, e.Amount),
+        PaymentVoidedDomainEvent e => new PaymentVoidedEvent(
+            e.PaymentId, e.OrderId, e.CustomerId, e.Reason),
         _ => throw new InvalidOperationException(
             $"No integration-event translation registered for domain event {domainEvent.GetType().Name}")
     };

--- a/payment-microservice/Payment.Service/Infrastructure/Data/EntityFramework/PaymentContext.cs
+++ b/payment-microservice/Payment.Service/Infrastructure/Data/EntityFramework/PaymentContext.cs
@@ -30,6 +30,12 @@ internal class PaymentContext : DbContext, IPaymentStore
         modelBuilder.ApplyConfiguration(new OrderCustomerConfiguration());
     }
 
+    public Task Add(Models.Payment payment)
+    {
+        Payments.Add(payment);
+        return Task.CompletedTask;
+    }
+
     public async Task<Models.Payment?> GetById(Guid paymentId)
     {
         return await Payments.FirstOrDefaultAsync(p => p.PaymentId == paymentId);
@@ -92,6 +98,10 @@ internal class PaymentContext : DbContext, IPaymentStore
 
     private static Event Translate(IDomainEvent domainEvent) => domainEvent switch
     {
+        PaymentAuthorizedDomainEvent e => new PaymentAuthorizedEvent(
+            e.PaymentId, e.OrderId, e.CustomerId, e.Amount, e.Currency),
+        PaymentFailedDomainEvent e => new PaymentFailedEvent(
+            e.PaymentId, e.OrderId, e.CustomerId, e.Reason),
         PaymentCapturedDomainEvent e => new PaymentCapturedEvent(e.PaymentId, e.OrderId, e.Amount),
         PaymentRefundedDomainEvent e => new PaymentRefundedEvent(e.PaymentId, e.OrderId, e.Amount),
         _ => throw new InvalidOperationException(

--- a/payment-microservice/Payment.Service/Infrastructure/Data/IPaymentStore.cs
+++ b/payment-microservice/Payment.Service/Infrastructure/Data/IPaymentStore.cs
@@ -4,7 +4,7 @@ namespace Payment.Service.Infrastructure.Data;
 
 public interface IPaymentStore
 {
-    Task Add(Models.Payment payment);
+    void Add(Models.Payment payment);
     Task<Models.Payment?> GetById(Guid paymentId);
     Task<Models.Payment?> GetByOrder(Guid orderId);
     Task<int> SaveChangesAsync();

--- a/payment-microservice/Payment.Service/Infrastructure/Data/IPaymentStore.cs
+++ b/payment-microservice/Payment.Service/Infrastructure/Data/IPaymentStore.cs
@@ -4,6 +4,7 @@ namespace Payment.Service.Infrastructure.Data;
 
 public interface IPaymentStore
 {
+    Task Add(Models.Payment payment);
     Task<Models.Payment?> GetById(Guid paymentId);
     Task<Models.Payment?> GetByOrder(Guid orderId);
     Task<int> SaveChangesAsync();

--- a/payment-microservice/Payment.Service/Infrastructure/Data/IPaymentStore.cs
+++ b/payment-microservice/Payment.Service/Infrastructure/Data/IPaymentStore.cs
@@ -7,6 +7,7 @@ public interface IPaymentStore
     Task<Models.Payment?> GetById(Guid paymentId);
     Task<Models.Payment?> GetByOrder(Guid orderId);
     Task<int> SaveChangesAsync();
+    Task ExecuteAsync(Func<Task> unitOfWork);
     Task RecordOrderCustomer(Guid orderId, string customerId);
     Task<string?> TryGetOrderCustomer(Guid orderId);
 }

--- a/payment-microservice/Payment.Service/IntegrationEvents/EventHandlers/OrderCancelledEventHandler.cs
+++ b/payment-microservice/Payment.Service/IntegrationEvents/EventHandlers/OrderCancelledEventHandler.cs
@@ -38,6 +38,6 @@ internal class OrderCancelledEventHandler : IEventHandler<OrderCancelledEvent>
             return Task.CompletedTask;
         });
 
-        _metrics.RecordStatusChange(PaymentStatus.Failed);
+        _metrics.RecordStatusChange(PaymentStatus.Voided);
     }
 }

--- a/payment-microservice/Payment.Service/IntegrationEvents/EventHandlers/OrderCancelledEventHandler.cs
+++ b/payment-microservice/Payment.Service/IntegrationEvents/EventHandlers/OrderCancelledEventHandler.cs
@@ -1,7 +1,4 @@
-using System.Transactions;
 using ECommerce.Shared.Infrastructure.EventBus.Abstractions;
-using ECommerce.Shared.Infrastructure.Outbox;
-using Microsoft.EntityFrameworkCore;
 using Payment.Service.Infrastructure.Data;
 using Payment.Service.IntegrationEvents.Events;
 using Payment.Service.Models;
@@ -12,51 +9,35 @@ namespace Payment.Service.IntegrationEvents.EventHandlers;
 internal class OrderCancelledEventHandler : IEventHandler<OrderCancelledEvent>
 {
     private readonly IPaymentStore _store;
-    private readonly IOutboxStore _outboxStore;
     private readonly PaymentMetrics _metrics;
 
     public OrderCancelledEventHandler(
         IPaymentStore store,
-        IOutboxStore outboxStore,
         PaymentMetrics metrics)
     {
         _store = store;
-        _outboxStore = outboxStore;
         _metrics = metrics;
     }
 
     public async Task Handle(OrderCancelledEvent @event)
     {
-        await _outboxStore.CreateExecutionStrategy().ExecuteAsync(async () =>
+        var payment = await _store.GetByOrder(@event.OrderId);
+        if (payment is null)
         {
-            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+            return;
+        }
 
-            var payment = await _store.GetByOrder(@event.OrderId);
-            if (payment is null)
-            {
-                scope.Complete();
-                return;
-            }
+        if (payment.Status != PaymentStatus.Pending && payment.Status != PaymentStatus.Authorized)
+        {
+            return;
+        }
 
-            if (payment.Status != PaymentStatus.Pending && payment.Status != PaymentStatus.Authorized)
-            {
-                scope.Complete();
-                return;
-            }
-
-            payment.Void(DateTime.UtcNow);
-
-            await _store.SaveChangesAsync();
-
-            await _outboxStore.AddOutboxEvent(new PaymentFailedEvent(
-                payment.PaymentId,
-                payment.OrderId,
-                payment.CustomerId,
-                "Order cancelled"));
-
-            _metrics.RecordStatusChange(PaymentStatus.Failed);
-
-            scope.Complete();
+        await _store.ExecuteAsync(() =>
+        {
+            payment.Void("Order cancelled", DateTime.UtcNow);
+            return Task.CompletedTask;
         });
+
+        _metrics.RecordStatusChange(PaymentStatus.Failed);
     }
 }

--- a/payment-microservice/Payment.Service/IntegrationEvents/EventHandlers/ShipmentDispatchedEventHandler.cs
+++ b/payment-microservice/Payment.Service/IntegrationEvents/EventHandlers/ShipmentDispatchedEventHandler.cs
@@ -1,7 +1,4 @@
-using System.Transactions;
 using ECommerce.Shared.Infrastructure.EventBus.Abstractions;
-using ECommerce.Shared.Infrastructure.Outbox;
-using Microsoft.EntityFrameworkCore;
 using Payment.Service.Infrastructure.Data;
 using Payment.Service.Infrastructure.Gateways;
 using Payment.Service.IntegrationEvents.Events;
@@ -13,56 +10,45 @@ namespace Payment.Service.IntegrationEvents.EventHandlers;
 internal class ShipmentDispatchedEventHandler : IEventHandler<ShipmentDispatchedEvent>
 {
     private readonly IPaymentStore _store;
-    private readonly IOutboxStore _outboxStore;
     private readonly IPaymentGateway _gateway;
     private readonly PaymentMetrics _metrics;
 
     public ShipmentDispatchedEventHandler(
         IPaymentStore store,
-        IOutboxStore outboxStore,
         IPaymentGateway gateway,
         PaymentMetrics metrics)
     {
         _store = store;
-        _outboxStore = outboxStore;
         _gateway = gateway;
         _metrics = metrics;
     }
 
     public async Task Handle(ShipmentDispatchedEvent @event)
     {
-        await _outboxStore.CreateExecutionStrategy().ExecuteAsync(async () =>
+        var payment = await _store.GetByOrder(@event.OrderId);
+        if (payment is null)
         {
-            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+            return;
+        }
 
-            var payment = await _store.GetByOrder(@event.OrderId);
-            if (payment is null)
-            {
-                scope.Complete();
-                return;
-            }
+        if (payment.Status != PaymentStatus.Authorized)
+        {
+            // Already captured (redelivery), refunded, or failed — nothing to do.
+            return;
+        }
 
-            if (payment.Status != PaymentStatus.Authorized)
-            {
-                // Already captured (redelivery), refunded, or failed — nothing to do.
-                scope.Complete();
-                return;
-            }
+        await _gateway.CaptureAsync(payment.ProviderReference!);
 
-            await _gateway.CaptureAsync(payment.ProviderReference!);
-
-            payment.Capture(DateTime.UtcNow);
-
-            await _store.SaveChangesAsync();
-
-            await _outboxStore.AddOutboxEvent(new PaymentCapturedEvent(
-                payment.PaymentId,
-                payment.OrderId,
-                payment.Amount));
-
-            _metrics.RecordStatusChange(PaymentStatus.Captured);
-
-            scope.Complete();
+        var captured = false;
+        await _store.ExecuteAsync(() =>
+        {
+            captured = payment.Capture(DateTime.UtcNow);
+            return Task.CompletedTask;
         });
+
+        if (captured)
+        {
+            _metrics.RecordStatusChange(PaymentStatus.Captured);
+        }
     }
 }

--- a/payment-microservice/Payment.Service/IntegrationEvents/EventHandlers/StockReservedEventHandler.cs
+++ b/payment-microservice/Payment.Service/IntegrationEvents/EventHandlers/StockReservedEventHandler.cs
@@ -56,7 +56,7 @@ internal class StockReservedEventHandler : IEventHandler<StockReservedEvent>
 
         await _store.ExecuteAsync(async () =>
         {
-            await _store.Add(payment);
+            _store.Add(payment);
 
             if (result.Success)
             {

--- a/payment-microservice/Payment.Service/IntegrationEvents/EventHandlers/StockReservedEventHandler.cs
+++ b/payment-microservice/Payment.Service/IntegrationEvents/EventHandlers/StockReservedEventHandler.cs
@@ -1,10 +1,6 @@
 using System.Diagnostics;
-using System.Transactions;
 using ECommerce.Shared.Infrastructure.EventBus.Abstractions;
-using ECommerce.Shared.Infrastructure.Outbox;
-using Microsoft.EntityFrameworkCore;
 using Payment.Service.Infrastructure.Data;
-using Payment.Service.Infrastructure.Data.EntityFramework;
 using Payment.Service.Infrastructure.Gateways;
 using Payment.Service.IntegrationEvents.Events;
 using Payment.Service.Models;
@@ -15,21 +11,15 @@ namespace Payment.Service.IntegrationEvents.EventHandlers;
 internal class StockReservedEventHandler : IEventHandler<StockReservedEvent>
 {
     private readonly IPaymentStore _store;
-    private readonly PaymentContext _context;
-    private readonly IOutboxStore _outboxStore;
     private readonly IPaymentGateway _gateway;
     private readonly PaymentMetrics _metrics;
 
     public StockReservedEventHandler(
         IPaymentStore store,
-        PaymentContext context,
-        IOutboxStore outboxStore,
         IPaymentGateway gateway,
         PaymentMetrics metrics)
     {
         _store = store;
-        _context = context;
-        _outboxStore = outboxStore;
         _gateway = gateway;
         _metrics = metrics;
     }
@@ -55,53 +45,30 @@ internal class StockReservedEventHandler : IEventHandler<StockReservedEvent>
             @event.Amount, @event.Currency, @event.OrderId.ToString());
         _metrics.RecordAuthorizeLatency(sw.Elapsed);
 
-        await _outboxStore.CreateExecutionStrategy().ExecuteAsync(async () =>
+        var now = DateTime.UtcNow;
+        var payment = Models.Payment.Create(
+            paymentId: Guid.NewGuid(),
+            orderId: @event.OrderId,
+            customerId: customerId,
+            amount: @event.Amount,
+            currency: @event.Currency,
+            createdAt: now);
+
+        await _store.ExecuteAsync(async () =>
         {
-            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+            await _store.Add(payment);
 
-            var now = DateTime.UtcNow;
-            var payment = Models.Payment.Create(
-                paymentId: Guid.NewGuid(),
-                orderId: @event.OrderId,
-                customerId: customerId,
-                amount: @event.Amount,
-                currency: @event.Currency,
-                createdAt: now);
-
-            if (!result.Success)
+            if (result.Success)
             {
-                payment.Fail(now);
-
-                _context.Payments.Add(payment);
-                await _context.SaveChangesAsync();
-
-                await _outboxStore.AddOutboxEvent(new PaymentFailedEvent(
-                    payment.PaymentId,
-                    payment.OrderId,
-                    payment.CustomerId,
-                    result.FailureReason ?? "Declined"));
-
-                _metrics.RecordStatusChange(PaymentStatus.Failed);
-
-                scope.Complete();
-                return;
+                payment.Authorize(result.ProviderReference!, now);
             }
-
-            payment.Authorize(result.ProviderReference!, now);
-
-            _context.Payments.Add(payment);
-            await _context.SaveChangesAsync();
-
-            await _outboxStore.AddOutboxEvent(new PaymentAuthorizedEvent(
-                payment.PaymentId,
-                payment.OrderId,
-                payment.CustomerId,
-                payment.Amount,
-                payment.Currency));
-
-            _metrics.RecordStatusChange(PaymentStatus.Authorized);
-
-            scope.Complete();
+            else
+            {
+                payment.Fail(result.FailureReason ?? "Declined", now);
+            }
         });
+
+        _metrics.RecordStatusChange(
+            result.Success ? PaymentStatus.Authorized : PaymentStatus.Failed);
     }
 }

--- a/payment-microservice/Payment.Service/IntegrationEvents/Events/PaymentVoidedEvent.cs
+++ b/payment-microservice/Payment.Service/IntegrationEvents/Events/PaymentVoidedEvent.cs
@@ -1,0 +1,9 @@
+using ECommerce.Shared.Infrastructure.EventBus;
+
+namespace Payment.Service.IntegrationEvents.Events;
+
+public record PaymentVoidedEvent(
+    Guid PaymentId,
+    Guid OrderId,
+    string CustomerId,
+    string Reason) : Event;

--- a/payment-microservice/Payment.Service/Models/Entity.cs
+++ b/payment-microservice/Payment.Service/Models/Entity.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Payment.Service.Models;
+
+public abstract class Entity
+{
+    private readonly List<IDomainEvent> _domainEvents = [];
+
+    [NotMapped]
+    public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
+
+    protected void Raise(IDomainEvent domainEvent) => _domainEvents.Add(domainEvent);
+
+    public IReadOnlyList<IDomainEvent> DequeueDomainEvents()
+    {
+        var events = _domainEvents.ToList();
+        _domainEvents.Clear();
+        return events;
+    }
+}

--- a/payment-microservice/Payment.Service/Models/IDomainEvent.cs
+++ b/payment-microservice/Payment.Service/Models/IDomainEvent.cs
@@ -1,0 +1,3 @@
+namespace Payment.Service.Models;
+
+public interface IDomainEvent;

--- a/payment-microservice/Payment.Service/Models/Payment.cs
+++ b/payment-microservice/Payment.Service/Models/Payment.cs
@@ -114,7 +114,7 @@ public class Payment : Entity
 
     public bool Void(string reason, DateTime occurredAt)
     {
-        if (Status == PaymentStatus.Failed)
+        if (Status == PaymentStatus.Voided)
         {
             return false;
         }
@@ -125,9 +125,9 @@ public class Payment : Entity
                 $"Cannot void payment {PaymentId} in status {Status}.");
         }
 
-        Status = PaymentStatus.Failed;
+        Status = PaymentStatus.Voided;
         UpdatedAt = occurredAt;
-        Raise(new PaymentFailedDomainEvent(PaymentId, OrderId, CustomerId, reason));
+        Raise(new PaymentVoidedDomainEvent(PaymentId, OrderId, CustomerId, reason));
         return true;
     }
 }

--- a/payment-microservice/Payment.Service/Models/Payment.cs
+++ b/payment-microservice/Payment.Service/Models/Payment.cs
@@ -73,7 +73,7 @@ public class Payment : Entity
         Raise(new PaymentCapturedDomainEvent(PaymentId, OrderId, Amount));
     }
 
-    public void Refund(DateTime occurredAt)
+    public void Refund(decimal refundAmount, DateTime occurredAt)
     {
         if (Status != PaymentStatus.Captured)
         {
@@ -83,6 +83,7 @@ public class Payment : Entity
 
         Status = PaymentStatus.Refunded;
         UpdatedAt = occurredAt;
+        Raise(new PaymentRefundedDomainEvent(PaymentId, OrderId, refundAmount));
     }
 
     public void Void(DateTime occurredAt)

--- a/payment-microservice/Payment.Service/Models/Payment.cs
+++ b/payment-microservice/Payment.Service/Models/Payment.cs
@@ -35,8 +35,13 @@ public class Payment : Entity
         };
     }
 
-    public void Authorize(string providerReference, DateTime occurredAt)
+    public bool Authorize(string providerReference, DateTime occurredAt)
     {
+        if (Status == PaymentStatus.Authorized)
+        {
+            return false;
+        }
+
         if (Status != PaymentStatus.Pending)
         {
             throw new InvalidOperationException(
@@ -47,10 +52,16 @@ public class Payment : Entity
         Status = PaymentStatus.Authorized;
         UpdatedAt = occurredAt;
         Raise(new PaymentAuthorizedDomainEvent(PaymentId, OrderId, CustomerId, Amount, Currency));
+        return true;
     }
 
-    public void Fail(string reason, DateTime occurredAt)
+    public bool Fail(string reason, DateTime occurredAt)
     {
+        if (Status == PaymentStatus.Failed)
+        {
+            return false;
+        }
+
         if (Status != PaymentStatus.Pending)
         {
             throw new InvalidOperationException(
@@ -60,10 +71,16 @@ public class Payment : Entity
         Status = PaymentStatus.Failed;
         UpdatedAt = occurredAt;
         Raise(new PaymentFailedDomainEvent(PaymentId, OrderId, CustomerId, reason));
+        return true;
     }
 
-    public void Capture(DateTime occurredAt)
+    public bool Capture(DateTime occurredAt)
     {
+        if (Status == PaymentStatus.Captured)
+        {
+            return false;
+        }
+
         if (Status != PaymentStatus.Authorized)
         {
             throw new InvalidOperationException(
@@ -73,10 +90,16 @@ public class Payment : Entity
         Status = PaymentStatus.Captured;
         UpdatedAt = occurredAt;
         Raise(new PaymentCapturedDomainEvent(PaymentId, OrderId, Amount));
+        return true;
     }
 
-    public void Refund(decimal refundAmount, DateTime occurredAt)
+    public bool Refund(decimal refundAmount, DateTime occurredAt)
     {
+        if (Status == PaymentStatus.Refunded)
+        {
+            return false;
+        }
+
         if (Status != PaymentStatus.Captured)
         {
             throw new InvalidOperationException(
@@ -86,10 +109,16 @@ public class Payment : Entity
         Status = PaymentStatus.Refunded;
         UpdatedAt = occurredAt;
         Raise(new PaymentRefundedDomainEvent(PaymentId, OrderId, refundAmount));
+        return true;
     }
 
-    public void Void(string reason, DateTime occurredAt)
+    public bool Void(string reason, DateTime occurredAt)
     {
+        if (Status == PaymentStatus.Failed)
+        {
+            return false;
+        }
+
         if (Status != PaymentStatus.Pending && Status != PaymentStatus.Authorized)
         {
             throw new InvalidOperationException(
@@ -99,5 +128,6 @@ public class Payment : Entity
         Status = PaymentStatus.Failed;
         UpdatedAt = occurredAt;
         Raise(new PaymentFailedDomainEvent(PaymentId, OrderId, CustomerId, reason));
+        return true;
     }
 }

--- a/payment-microservice/Payment.Service/Models/Payment.cs
+++ b/payment-microservice/Payment.Service/Models/Payment.cs
@@ -46,9 +46,10 @@ public class Payment : Entity
         ProviderReference = providerReference;
         Status = PaymentStatus.Authorized;
         UpdatedAt = occurredAt;
+        Raise(new PaymentAuthorizedDomainEvent(PaymentId, OrderId, CustomerId, Amount, Currency));
     }
 
-    public void Fail(DateTime occurredAt)
+    public void Fail(string reason, DateTime occurredAt)
     {
         if (Status != PaymentStatus.Pending)
         {
@@ -58,6 +59,7 @@ public class Payment : Entity
 
         Status = PaymentStatus.Failed;
         UpdatedAt = occurredAt;
+        Raise(new PaymentFailedDomainEvent(PaymentId, OrderId, CustomerId, reason));
     }
 
     public void Capture(DateTime occurredAt)
@@ -86,7 +88,7 @@ public class Payment : Entity
         Raise(new PaymentRefundedDomainEvent(PaymentId, OrderId, refundAmount));
     }
 
-    public void Void(DateTime occurredAt)
+    public void Void(string reason, DateTime occurredAt)
     {
         if (Status != PaymentStatus.Pending && Status != PaymentStatus.Authorized)
         {
@@ -96,5 +98,6 @@ public class Payment : Entity
 
         Status = PaymentStatus.Failed;
         UpdatedAt = occurredAt;
+        Raise(new PaymentFailedDomainEvent(PaymentId, OrderId, CustomerId, reason));
     }
 }

--- a/payment-microservice/Payment.Service/Models/Payment.cs
+++ b/payment-microservice/Payment.Service/Models/Payment.cs
@@ -1,6 +1,6 @@
 namespace Payment.Service.Models;
 
-public class Payment
+public class Payment : Entity
 {
     public Guid PaymentId { get; private set; }
     public Guid OrderId { get; private set; }
@@ -70,6 +70,7 @@ public class Payment
 
         Status = PaymentStatus.Captured;
         UpdatedAt = occurredAt;
+        Raise(new PaymentCapturedDomainEvent(PaymentId, OrderId, Amount));
     }
 
     public void Refund(DateTime occurredAt)

--- a/payment-microservice/Payment.Service/Models/PaymentAuthorizedDomainEvent.cs
+++ b/payment-microservice/Payment.Service/Models/PaymentAuthorizedDomainEvent.cs
@@ -1,0 +1,8 @@
+namespace Payment.Service.Models;
+
+public sealed record PaymentAuthorizedDomainEvent(
+    Guid PaymentId,
+    Guid OrderId,
+    string CustomerId,
+    decimal Amount,
+    string Currency) : IDomainEvent;

--- a/payment-microservice/Payment.Service/Models/PaymentCapturedDomainEvent.cs
+++ b/payment-microservice/Payment.Service/Models/PaymentCapturedDomainEvent.cs
@@ -1,0 +1,6 @@
+namespace Payment.Service.Models;
+
+public sealed record PaymentCapturedDomainEvent(
+    Guid PaymentId,
+    Guid OrderId,
+    decimal Amount) : IDomainEvent;

--- a/payment-microservice/Payment.Service/Models/PaymentFailedDomainEvent.cs
+++ b/payment-microservice/Payment.Service/Models/PaymentFailedDomainEvent.cs
@@ -1,0 +1,7 @@
+namespace Payment.Service.Models;
+
+public sealed record PaymentFailedDomainEvent(
+    Guid PaymentId,
+    Guid OrderId,
+    string CustomerId,
+    string Reason) : IDomainEvent;

--- a/payment-microservice/Payment.Service/Models/PaymentRefundedDomainEvent.cs
+++ b/payment-microservice/Payment.Service/Models/PaymentRefundedDomainEvent.cs
@@ -1,0 +1,6 @@
+namespace Payment.Service.Models;
+
+public sealed record PaymentRefundedDomainEvent(
+    Guid PaymentId,
+    Guid OrderId,
+    decimal Amount) : IDomainEvent;

--- a/payment-microservice/Payment.Service/Models/PaymentStatus.cs
+++ b/payment-microservice/Payment.Service/Models/PaymentStatus.cs
@@ -7,4 +7,5 @@ public enum PaymentStatus
     Captured = 2,
     Refunded = 3,
     Failed = 4,
+    Voided = 5,
 }

--- a/payment-microservice/Payment.Service/Models/PaymentVoidedDomainEvent.cs
+++ b/payment-microservice/Payment.Service/Models/PaymentVoidedDomainEvent.cs
@@ -1,0 +1,7 @@
+namespace Payment.Service.Models;
+
+public sealed record PaymentVoidedDomainEvent(
+    Guid PaymentId,
+    Guid OrderId,
+    string CustomerId,
+    string Reason) : IDomainEvent;

--- a/payment-microservice/Payment.Service/Payment.Service.csproj
+++ b/payment-microservice/Payment.Service/Payment.Service.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ECommerce.Shared" Version="2.16.0" />
+    <PackageReference Include="ECommerce.Shared" Version="2.17.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>

--- a/payment-microservice/Payment.Service/Payment.Service.csproj
+++ b/payment-microservice/Payment.Service/Payment.Service.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ECommerce.Shared" Version="2.11.0" />
+    <PackageReference Include="ECommerce.Shared" Version="2.13.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>

--- a/payment-microservice/Payment.Service/Payment.Service.csproj
+++ b/payment-microservice/Payment.Service/Payment.Service.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ECommerce.Shared" Version="2.15.0" />
+    <PackageReference Include="ECommerce.Shared" Version="2.16.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>

--- a/payment-microservice/Payment.Service/Payment.Service.csproj.lscache
+++ b/payment-microservice/Payment.Service/Payment.Service.csproj.lscache
@@ -425,7 +425,7 @@ Program.cs
  azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
  azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
  azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
- ecommerce.shared/2.15.0/lib/net10.0/ECommerce.Shared.dll
+ ecommerce.shared/2.16.0/lib/net10.0/ECommerce.Shared.dll
  google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
  grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
  grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll

--- a/payment-microservice/Payment.Service/Payment.Service.csproj.lscache
+++ b/payment-microservice/Payment.Service/Payment.Service.csproj.lscache
@@ -1,0 +1,517 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[properties]
+AssemblyName=Payment.Service
+CommandLineArgsForDesignTimeEvaluation=-langversion:14.0 -define:TRACE
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=14.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=Payment.Service
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../../MicroservicesInDotNet.sln
+TargetFrameworkIdentifier=.NETCoreApp
+TargetPath=<PATH>bin/Debug/net10.0/Payment.Service.dll
+TargetRefPath=<PATH>obj/Debug/net10.0/ref/Payment.Service.dll
+TemporaryDependencyNodeTargetIdentifier=net10.0
+
+[commandLineArguments]
+/noconfig
+/unsafe-
+/checked-
+/nowarn:NU1603,NU1902,NU1903,NU5104,CA1711,CA1707,CA1716,1701,1702,8002
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/warn:10
+/define:TRACE;DEBUG;NET;NET10_0;NETCOREAPP;NET5_0_OR_GREATER;NET6_0_OR_GREATER;NET7_0_OR_GREATER;NET8_0_OR_GREATER;NET9_0_OR_GREATER;NET10_0_OR_GREATER;NETCOREAPP1_0_OR_GREATER;NETCOREAPP1_1_OR_GREATER;NETCOREAPP2_0_OR_GREATER;NETCOREAPP2_1_OR_GREATER;NETCOREAPP2_2_OR_GREATER;NETCOREAPP3_0_OR_GREATER;NETCOREAPP3_1_OR_GREATER
+/highentropyva+
+/nullable:enable
+/features:"InterceptorsNamespaces=;Microsoft.Extensions.Validation.Generated"
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\net10.0\Payment.Service.dll
+/refout:obj\Debug\net10.0\refint\Payment.Service.dll
+/target:exe
+/warnaserror+
+/utf8output
+/deterministic+
+/langversion:14.0
+/features:use-roslyn-tokenizer=true
+/warnaserror+:NU1605,SYSLIB0011
+
+[sourceFiles]
+Endpoints/
+ InternalOutboxEndpoints.cs
+ PaymentApiEndpoints.cs
+Infrastructure/Data/EntityFramework/
+ EntityFrameworkExtensions.cs
+ OrderCustomerConfiguration.cs
+ PaymentConfiguration.cs
+ PaymentContext.cs
+ PaymentContextDesignTimeFactory.cs
+ PaymentContextSeed.cs
+Infrastructure/
+ Data/IPaymentStore.cs
+ Gateways/
+  InMemoryPaymentGateway.cs
+  IPaymentGateway.cs
+IntegrationEvents/EventHandlers/
+ OrderCancelledEventHandler.cs
+ OrderCreatedEventHandler.cs
+ ShipmentDispatchedEventHandler.cs
+ StockReservedEventHandler.cs
+IntegrationEvents/Events/
+ OrderCancelledEvent.cs
+ OrderCreatedEvent.cs
+ PaymentAuthorizedEvent.cs
+ PaymentCapturedEvent.cs
+ PaymentFailedEvent.cs
+ PaymentRefundedEvent.cs
+ ShipmentDispatchedEvent.cs
+ StockReservedEvent.cs
+Migrations/
+ 20260425120000_InitialCreate.cs
+ 20260425120000_InitialCreate.Designer.cs
+ 20260426000000_AddOrderCustomer.cs
+ 20260426000000_AddOrderCustomer.Designer.cs
+ 20260508071148_SeedQaPhase3a_Payment.cs
+ 20260508071148_SeedQaPhase3a_Payment.Designer.cs
+ PaymentContextModelSnapshot.cs
+Models/
+ Entity.cs
+ IDomainEvent.cs
+ OrderCustomer.cs
+ Payment.cs
+ PaymentAuthorizedDomainEvent.cs
+ PaymentCapturedDomainEvent.cs
+ PaymentFailedDomainEvent.cs
+ PaymentRefundedDomainEvent.cs
+ PaymentStatus.cs
+obj/Debug/net10.0/
+ .NETCoreApp,Version=v10.0.AssemblyAttributes.cs
+ Payment.Service.AssemblyInfo.cs
+ Payment.Service.GlobalUsings.g.cs
+Observability/PaymentMetrics.cs
+Program.cs
+
+[metadataReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.AspNetCore.Antiforgery.dll
+ Microsoft.AspNetCore.Authentication.Abstractions.dll
+ Microsoft.AspNetCore.Authentication.BearerToken.dll
+ Microsoft.AspNetCore.Authentication.Cookies.dll
+ Microsoft.AspNetCore.Authentication.Core.dll
+ Microsoft.AspNetCore.Authentication.dll
+ Microsoft.AspNetCore.Authentication.OAuth.dll
+ Microsoft.AspNetCore.Authorization.dll
+ Microsoft.AspNetCore.Authorization.Policy.dll
+ Microsoft.AspNetCore.Components.Authorization.dll
+ Microsoft.AspNetCore.Components.dll
+ Microsoft.AspNetCore.Components.Endpoints.dll
+ Microsoft.AspNetCore.Components.Forms.dll
+ Microsoft.AspNetCore.Components.Server.dll
+ Microsoft.AspNetCore.Components.Web.dll
+ Microsoft.AspNetCore.Connections.Abstractions.dll
+ Microsoft.AspNetCore.CookiePolicy.dll
+ Microsoft.AspNetCore.Cors.dll
+ Microsoft.AspNetCore.Cryptography.Internal.dll
+ Microsoft.AspNetCore.Cryptography.KeyDerivation.dll
+ Microsoft.AspNetCore.DataProtection.Abstractions.dll
+ Microsoft.AspNetCore.DataProtection.dll
+ Microsoft.AspNetCore.DataProtection.Extensions.dll
+ Microsoft.AspNetCore.Diagnostics.Abstractions.dll
+ Microsoft.AspNetCore.Diagnostics.dll
+ Microsoft.AspNetCore.Diagnostics.HealthChecks.dll
+ Microsoft.AspNetCore.dll
+ Microsoft.AspNetCore.HostFiltering.dll
+ Microsoft.AspNetCore.Hosting.Abstractions.dll
+ Microsoft.AspNetCore.Hosting.dll
+ Microsoft.AspNetCore.Hosting.Server.Abstractions.dll
+ Microsoft.AspNetCore.Html.Abstractions.dll
+ Microsoft.AspNetCore.Http.Abstractions.dll
+ Microsoft.AspNetCore.Http.Connections.Common.dll
+ Microsoft.AspNetCore.Http.Connections.dll
+ Microsoft.AspNetCore.Http.dll
+ Microsoft.AspNetCore.Http.Extensions.dll
+ Microsoft.AspNetCore.Http.Features.dll
+ Microsoft.AspNetCore.Http.Results.dll
+ Microsoft.AspNetCore.HttpLogging.dll
+ Microsoft.AspNetCore.HttpOverrides.dll
+ Microsoft.AspNetCore.HttpsPolicy.dll
+ Microsoft.AspNetCore.Identity.dll
+ Microsoft.AspNetCore.Localization.dll
+ Microsoft.AspNetCore.Localization.Routing.dll
+ Microsoft.AspNetCore.Metadata.dll
+ Microsoft.AspNetCore.Mvc.Abstractions.dll
+ Microsoft.AspNetCore.Mvc.ApiExplorer.dll
+ Microsoft.AspNetCore.Mvc.Core.dll
+ Microsoft.AspNetCore.Mvc.Cors.dll
+ Microsoft.AspNetCore.Mvc.DataAnnotations.dll
+ Microsoft.AspNetCore.Mvc.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Json.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Xml.dll
+ Microsoft.AspNetCore.Mvc.Localization.dll
+ Microsoft.AspNetCore.Mvc.Razor.dll
+ Microsoft.AspNetCore.Mvc.RazorPages.dll
+ Microsoft.AspNetCore.Mvc.TagHelpers.dll
+ Microsoft.AspNetCore.Mvc.ViewFeatures.dll
+ Microsoft.AspNetCore.OutputCaching.dll
+ Microsoft.AspNetCore.RateLimiting.dll
+ Microsoft.AspNetCore.Razor.dll
+ Microsoft.AspNetCore.Razor.Runtime.dll
+ Microsoft.AspNetCore.RequestDecompression.dll
+ Microsoft.AspNetCore.ResponseCaching.Abstractions.dll
+ Microsoft.AspNetCore.ResponseCaching.dll
+ Microsoft.AspNetCore.ResponseCompression.dll
+ Microsoft.AspNetCore.Rewrite.dll
+ Microsoft.AspNetCore.Routing.Abstractions.dll
+ Microsoft.AspNetCore.Routing.dll
+ Microsoft.AspNetCore.Server.HttpSys.dll
+ Microsoft.AspNetCore.Server.IIS.dll
+ Microsoft.AspNetCore.Server.IISIntegration.dll
+ Microsoft.AspNetCore.Server.Kestrel.Core.dll
+ Microsoft.AspNetCore.Server.Kestrel.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll
+ Microsoft.AspNetCore.Session.dll
+ Microsoft.AspNetCore.SignalR.Common.dll
+ Microsoft.AspNetCore.SignalR.Core.dll
+ Microsoft.AspNetCore.SignalR.dll
+ Microsoft.AspNetCore.SignalR.Protocols.Json.dll
+ Microsoft.AspNetCore.StaticAssets.dll
+ Microsoft.AspNetCore.StaticFiles.dll
+ Microsoft.AspNetCore.WebSockets.dll
+ Microsoft.AspNetCore.WebUtilities.dll
+ Microsoft.Extensions.Caching.Abstractions.dll
+ Microsoft.Extensions.Caching.Memory.dll
+ Microsoft.Extensions.Configuration.Abstractions.dll
+ Microsoft.Extensions.Configuration.Binder.dll
+ Microsoft.Extensions.Configuration.CommandLine.dll
+ Microsoft.Extensions.Configuration.dll
+ Microsoft.Extensions.Configuration.EnvironmentVariables.dll
+ Microsoft.Extensions.Configuration.FileExtensions.dll
+ Microsoft.Extensions.Configuration.Ini.dll
+ Microsoft.Extensions.Configuration.Json.dll
+ Microsoft.Extensions.Configuration.KeyPerFile.dll
+ Microsoft.Extensions.Configuration.UserSecrets.dll
+ Microsoft.Extensions.Configuration.Xml.dll
+ Microsoft.Extensions.DependencyInjection.Abstractions.dll
+ Microsoft.Extensions.DependencyInjection.dll
+ Microsoft.Extensions.Diagnostics.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.dll
+ Microsoft.Extensions.Features.dll
+ Microsoft.Extensions.FileProviders.Abstractions.dll
+ Microsoft.Extensions.FileProviders.Composite.dll
+ Microsoft.Extensions.FileProviders.Embedded.dll
+ Microsoft.Extensions.FileProviders.Physical.dll
+ Microsoft.Extensions.FileSystemGlobbing.dll
+ Microsoft.Extensions.Hosting.Abstractions.dll
+ Microsoft.Extensions.Hosting.dll
+ Microsoft.Extensions.Http.dll
+ Microsoft.Extensions.Identity.Core.dll
+ Microsoft.Extensions.Identity.Stores.dll
+ Microsoft.Extensions.Localization.Abstractions.dll
+ Microsoft.Extensions.Localization.dll
+ Microsoft.Extensions.Logging.Abstractions.dll
+ Microsoft.Extensions.Logging.Configuration.dll
+ Microsoft.Extensions.Logging.Console.dll
+ Microsoft.Extensions.Logging.Debug.dll
+ Microsoft.Extensions.Logging.dll
+ Microsoft.Extensions.Logging.EventLog.dll
+ Microsoft.Extensions.Logging.EventSource.dll
+ Microsoft.Extensions.Logging.TraceSource.dll
+ Microsoft.Extensions.ObjectPool.dll
+ Microsoft.Extensions.Options.ConfigurationExtensions.dll
+ Microsoft.Extensions.Options.DataAnnotations.dll
+ Microsoft.Extensions.Options.dll
+ Microsoft.Extensions.Primitives.dll
+ Microsoft.Extensions.Validation.dll
+ Microsoft.Extensions.WebEncoders.dll
+ Microsoft.JSInterop.dll
+ Microsoft.Net.Http.Headers.dll
+ System.Diagnostics.EventLog.dll
+ System.Formats.Cbor.dll
+ System.Security.Cryptography.Xml.dll
+ System.Threading.RateLimiting.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.CSharp.dll
+ Microsoft.VisualBasic.Core.dll
+ Microsoft.VisualBasic.dll
+ Microsoft.Win32.Primitives.dll
+ Microsoft.Win32.Registry.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.Immutable.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Annotations.dll
+ System.ComponentModel.DataAnnotations.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Configuration.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.DataSetExtensions.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.DiagnosticSource.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Formats.Asn1.dll
+ System.Formats.Tar.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.Brotli.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.AccessControl.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipelines.dll
+ System.IO.Pipes.AccessControl.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.AsyncEnumerable.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.Http.Json.dll
+ System.Net.HttpListener.dll
+ System.Net.Mail.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Quic.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.ServerSentEvents.dll
+ System.Net.ServicePoint.dll
+ System.Net.Sockets.dll
+ System.Net.WebClient.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebProxy.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Metadata.dll
+ System.Reflection.Primitives.dll
+ System.Reflection.TypeExtensions.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.Unsafe.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.JavaScript.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Intrinsics.dll
+ System.Runtime.Loader.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.AccessControl.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Cng.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.OpenSsl.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.dll
+ System.Security.Principal.dll
+ System.Security.Principal.Windows.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.ServiceProcess.dll
+ System.Text.Encoding.CodePages.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.Encodings.Web.dll
+ System.Text.Json.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.AccessControl.dll
+ System.Threading.Channels.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.Dataflow.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.Transactions.Local.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Web.HttpUtility.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+ WindowsBase.dll
+<NUGET>/
+ azure.core.amqp/1.3.1/lib/netstandard2.0/Azure.Core.Amqp.dll
+ azure.core/1.47.1/lib/net8.0/Azure.Core.dll
+ azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
+ azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
+ azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
+ ecommerce.shared/2.15.0/lib/net10.0/ECommerce.Shared.dll
+ google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
+ grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
+ grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll
+ grpc.net.common/2.52.0/lib/net7.0/Grpc.Net.Common.dll
+ microsoft.aspnetcore.authentication.jwtbearer/10.0.5/lib/net10.0/Microsoft.AspNetCore.Authentication.JwtBearer.dll
+ microsoft.azure.amqp/2.6.7/lib/netstandard2.0/Microsoft.Azure.Amqp.dll
+ microsoft.bcl.asyncinterfaces/8.0.0/lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll
+ microsoft.bcl.cryptography/9.0.4/lib/net9.0/Microsoft.Bcl.Cryptography.dll
+ microsoft.data.sqlclient/6.1.1/ref/net9.0/Microsoft.Data.SqlClient.dll
+ microsoft.entityframeworkcore.abstractions/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Abstractions.dll
+ microsoft.entityframeworkcore.relational/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Relational.dll
+ microsoft.entityframeworkcore.sqlserver/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.SqlServer.dll
+ microsoft.entityframeworkcore/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.dll
+ microsoft.identity.client.extensions.msal/4.73.1/lib/net8.0/Microsoft.Identity.Client.Extensions.Msal.dll
+ microsoft.identity.client/4.73.1/lib/net8.0/Microsoft.Identity.Client.dll
+ microsoft.identitymodel.abstractions/8.0.1/lib/net9.0/Microsoft.IdentityModel.Abstractions.dll
+ microsoft.identitymodel.jsonwebtokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.JsonWebTokens.dll
+ microsoft.identitymodel.logging/8.0.1/lib/net9.0/Microsoft.IdentityModel.Logging.dll
+ microsoft.identitymodel.protocols.openidconnect/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.dll
+ microsoft.identitymodel.protocols/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.dll
+ microsoft.identitymodel.tokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.Tokens.dll
+ microsoft.openapi/1.6.14/lib/netstandard2.0/Microsoft.OpenApi.dll
+ microsoft.sqlserver.server/1.0.0/lib/netstandard2.0/Microsoft.SqlServer.Server.dll
+ opentelemetry.api.providerbuilderextensions/1.10.0/lib/net9.0/OpenTelemetry.Api.ProviderBuilderExtensions.dll
+ opentelemetry.api/1.10.0/lib/net9.0/OpenTelemetry.Api.dll
+ opentelemetry.exporter.console/1.9.0/lib/net8.0/OpenTelemetry.Exporter.Console.dll
+ opentelemetry.exporter.opentelemetryprotocol/1.9.0/lib/net8.0/OpenTelemetry.Exporter.OpenTelemetryProtocol.dll
+ opentelemetry.exporter.prometheus.aspnetcore/1.10.0-beta.1/lib/net9.0/OpenTelemetry.Exporter.Prometheus.AspNetCore.dll
+ opentelemetry.extensions.hosting/1.9.0/lib/net8.0/OpenTelemetry.Extensions.Hosting.dll
+ opentelemetry.instrumentation.aspnetcore/1.9.0/lib/net8.0/OpenTelemetry.Instrumentation.AspNetCore.dll
+ opentelemetry.instrumentation.sqlclient/1.9.0-beta.1/lib/net8.0/OpenTelemetry.Instrumentation.SqlClient.dll
+ opentelemetry.persistentstorage.abstractions/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.Abstractions.dll
+ opentelemetry.persistentstorage.filesystem/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.FileSystem.dll
+ opentelemetry/1.10.0/lib/net9.0/OpenTelemetry.dll
+ pipelines.sockets.unofficial/2.2.8/lib/net5.0/Pipelines.Sockets.Unofficial.dll
+ polly.core/8.6.6/lib/net8.0/Polly.Core.dll
+ rabbitmq.client/6.8.1/lib/netstandard2.0/RabbitMQ.Client.dll
+ stackexchange.redis/2.8.16/lib/net6.0/StackExchange.Redis.dll
+ swashbuckle.aspnetcore.swagger/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.Swagger.dll
+ swashbuckle.aspnetcore.swaggergen/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.dll
+ swashbuckle.aspnetcore.swaggerui/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.dll
+ system.clientmodel/1.5.1/lib/net8.0/System.ClientModel.dll
+ system.identitymodel.tokens.jwt/8.0.1/lib/net9.0/System.IdentityModel.Tokens.Jwt.dll
+ system.memory.data/8.0.1/lib/net8.0/System.Memory.Data.dll
+ system.security.cryptography.pkcs/9.0.4/lib/net9.0/System.Security.Cryptography.Pkcs.dll
+ system.security.cryptography.protecteddata/9.0.4/lib/net9.0/System.Security.Cryptography.ProtectedData.dll
+
+[analyzerReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.AspNetCore.App.Analyzers.dll
+ Microsoft.AspNetCore.App.CodeFixes.dll
+ Microsoft.AspNetCore.App.SourceGenerators.dll
+ Microsoft.AspNetCore.Components.Analyzers.dll
+ Microsoft.Extensions.Logging.Generators.dll
+ Microsoft.Extensions.Options.SourceGeneration.dll
+ Microsoft.Extensions.Validation.ValidationsGenerator.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.Interop.ComInterfaceGenerator.dll
+ Microsoft.Interop.JavaScript.JSImportGenerator.dll
+ Microsoft.Interop.LibraryImportGenerator.dll
+ Microsoft.Interop.SourceGeneration.dll
+ System.Text.Json.SourceGeneration.dll
+ System.Text.RegularExpressions.Generator.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk.Razor/source-generators/
+ Microsoft.AspNetCore.Razor.Utilities.Shared.dll
+ Microsoft.CodeAnalysis.Razor.Compiler.dll
+ Microsoft.Extensions.ObjectPool.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk.Web/analyzers/cs/
+ Microsoft.AspNetCore.Analyzers.dll
+ Microsoft.AspNetCore.Mvc.Analyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/
+ Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll
+ Microsoft.CodeAnalysis.NetAnalyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/codestyle/cs/
+ Microsoft.CodeAnalysis.CodeStyle.dll
+ Microsoft.CodeAnalysis.CodeStyle.Fixes.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.dll
+<NUGET>/microsoft.codeanalysis.analyzers/3.11.0/analyzers/dotnet/cs/
+ Microsoft.CodeAnalysis.Analyzers.dll
+ Microsoft.CodeAnalysis.CSharp.Analyzers.dll
+<NUGET>/
+ microsoft.entityframeworkcore.analyzers/10.0.5/analyzers/dotnet/cs/Microsoft.EntityFrameworkCore.Analyzers.dll
+ system.clientmodel/1.5.1/analyzers/dotnet/cs/System.ClientModel.SourceGeneration.dll
+
+[analyzerConfigFiles]
+../../.editorconfig
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_10_recommended.globalconfig
+obj/Debug/net10.0/Payment.Service.GeneratedMSBuildEditorConfig.editorconfig

--- a/payment-microservice/Payment.Tests/Api/PaymentEndpointsTests.cs
+++ b/payment-microservice/Payment.Tests/Api/PaymentEndpointsTests.cs
@@ -197,7 +197,7 @@ public class PaymentEndpointsTests : IntegrationTestBase
 
         if (status == PaymentStatus.Failed)
         {
-            payment.Fail(now);
+            payment.Fail("seed", now);
         }
         else if (status != PaymentStatus.Pending)
         {

--- a/payment-microservice/Payment.Tests/Api/PaymentEndpointsTests.cs
+++ b/payment-microservice/Payment.Tests/Api/PaymentEndpointsTests.cs
@@ -148,6 +148,7 @@ public class PaymentEndpointsTests : IntegrationTestBase
             new PaymentApiEndpoints.RefundPaymentRequest(Amount: null));
 
         Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+        await AssertOutboxContainsAsync(nameof(PaymentRefundedEvent), paymentId, expectedCount: 0);
     }
 
     [Fact]

--- a/payment-microservice/Payment.Tests/Api/PaymentEndpointsTests.cs
+++ b/payment-microservice/Payment.Tests/Api/PaymentEndpointsTests.cs
@@ -210,7 +210,7 @@ public class PaymentEndpointsTests : IntegrationTestBase
 
             if (status == PaymentStatus.Refunded)
             {
-                payment.Refund(now);
+                payment.Refund(payment.Amount, now);
             }
         }
 

--- a/payment-microservice/Payment.Tests/IntegrationEvents/CheckoutHappyPathTests.cs
+++ b/payment-microservice/Payment.Tests/IntegrationEvents/CheckoutHappyPathTests.cs
@@ -84,6 +84,16 @@ public class CheckoutHappyPathTests : IntegrationTestBase
             .ToListAsync();
 
         Assert.Single(payments);
+
+        using var scope = Factory.Services.CreateScope();
+        var outboxStore = scope.ServiceProvider.GetRequiredService<IOutboxStore>();
+        var outboxEvents = await outboxStore.GetUnpublishedOutboxEvents();
+
+        var matching = outboxEvents.Where(e =>
+            e.EventType.Contains(nameof(PaymentAuthorizedEvent), StringComparison.Ordinal) &&
+            e.Data.Contains(orderId.ToString(), StringComparison.OrdinalIgnoreCase)).ToList();
+
+        Assert.Single(matching);
     }
 
     private async Task DispatchAsync<TEvent>(TEvent @event)

--- a/payment-microservice/Payment.Tests/IntegrationEvents/PaymentFailureCompensationTests.cs
+++ b/payment-microservice/Payment.Tests/IntegrationEvents/PaymentFailureCompensationTests.cs
@@ -70,6 +70,16 @@ public class PaymentFailureCompensationTests : IntegrationTestBase
 
         Assert.Single(payments);
         Assert.Equal(PaymentStatus.Failed, payments[0].Status);
+
+        using var scope = Factory.Services.CreateScope();
+        var outboxStore = scope.ServiceProvider.GetRequiredService<IOutboxStore>();
+        var outboxEvents = await outboxStore.GetUnpublishedOutboxEvents();
+
+        var matching = outboxEvents.Where(e =>
+            e.EventType.Contains(nameof(PaymentFailedEvent), StringComparison.Ordinal) &&
+            e.Data.Contains(orderId.ToString(), StringComparison.OrdinalIgnoreCase)).ToList();
+
+        Assert.Single(matching);
     }
 
     private async Task DispatchAsync<TEvent>(TEvent @event)

--- a/payment-microservice/Payment.Tests/IntegrationEvents/PaymentOrderCancelledTests.cs
+++ b/payment-microservice/Payment.Tests/IntegrationEvents/PaymentOrderCancelledTests.cs
@@ -86,6 +86,16 @@ public class PaymentOrderCancelledTests : IntegrationTestBase
 
         Assert.Equal(PaymentStatus.Failed, after.Status);
         Assert.Equal(beforeUpdatedAt, after.UpdatedAt);
+
+        using var scope = Factory.Services.CreateScope();
+        var outboxStore = scope.ServiceProvider.GetRequiredService<IOutboxStore>();
+        var outboxEvents = await outboxStore.GetUnpublishedOutboxEvents();
+
+        var failedEvents = outboxEvents.Where(e =>
+            e.EventType.Contains(nameof(PaymentFailedEvent), StringComparison.Ordinal) &&
+            e.Data.Contains(orderId.ToString(), StringComparison.OrdinalIgnoreCase)).ToList();
+
+        Assert.Single(failedEvents);
     }
 
     [Fact]
@@ -113,6 +123,16 @@ public class PaymentOrderCancelledTests : IntegrationTestBase
 
         Assert.Equal(PaymentStatus.Failed, after.Status);
         Assert.Equal(firstUpdate, after.UpdatedAt);
+
+        using var scope = Factory.Services.CreateScope();
+        var outboxStore = scope.ServiceProvider.GetRequiredService<IOutboxStore>();
+        var outboxEvents = await outboxStore.GetUnpublishedOutboxEvents();
+
+        var failedEvents = outboxEvents.Where(e =>
+            e.EventType.Contains(nameof(PaymentFailedEvent), StringComparison.Ordinal) &&
+            e.Data.Contains(orderId.ToString(), StringComparison.OrdinalIgnoreCase)).ToList();
+
+        Assert.Single(failedEvents);
     }
 
     private async Task DispatchAsync<TEvent>(TEvent @event)

--- a/payment-microservice/Payment.Tests/IntegrationEvents/PaymentOrderCancelledTests.cs
+++ b/payment-microservice/Payment.Tests/IntegrationEvents/PaymentOrderCancelledTests.cs
@@ -15,7 +15,7 @@ public class PaymentOrderCancelledTests : IntegrationTestBase
     }
 
     [Fact]
-    public async Task OrderCancelled_WhenAuthorizedRowExists_VoidsAndEmitsPaymentFailed()
+    public async Task OrderCancelled_WhenAuthorizedRowExists_VoidsAndEmitsPaymentVoided()
     {
         var orderId = Guid.NewGuid();
         const string customerId = "cust-cancel-auth";
@@ -33,18 +33,18 @@ public class PaymentOrderCancelledTests : IntegrationTestBase
         PaymentContext.ChangeTracker.Clear();
         var payment = await PaymentContext.Payments.SingleAsync(p => p.OrderId == orderId);
 
-        Assert.Equal(PaymentStatus.Failed, payment.Status);
+        Assert.Equal(PaymentStatus.Voided, payment.Status);
 
         using var scope = Factory.Services.CreateScope();
         var outboxStore = scope.ServiceProvider.GetRequiredService<IOutboxStore>();
         var outboxEvents = await outboxStore.GetUnpublishedOutboxEvents();
 
-        var failedEvents = outboxEvents.Where(e =>
-            e.EventType.Contains(nameof(PaymentFailedEvent), StringComparison.Ordinal) &&
+        var voidedEvents = outboxEvents.Where(e =>
+            e.EventType.Contains(nameof(PaymentVoidedEvent), StringComparison.Ordinal) &&
             e.Data.Contains(orderId.ToString(), StringComparison.OrdinalIgnoreCase)).ToList();
 
-        Assert.Single(failedEvents);
-        Assert.Contains("Order cancelled", failedEvents[0].Data, StringComparison.Ordinal);
+        Assert.Single(voidedEvents);
+        Assert.Contains("Order cancelled", voidedEvents[0].Data, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -121,18 +121,18 @@ public class PaymentOrderCancelledTests : IntegrationTestBase
         PaymentContext.ChangeTracker.Clear();
         var after = await PaymentContext.Payments.SingleAsync(p => p.OrderId == orderId);
 
-        Assert.Equal(PaymentStatus.Failed, after.Status);
+        Assert.Equal(PaymentStatus.Voided, after.Status);
         Assert.Equal(firstUpdate, after.UpdatedAt);
 
         using var scope = Factory.Services.CreateScope();
         var outboxStore = scope.ServiceProvider.GetRequiredService<IOutboxStore>();
         var outboxEvents = await outboxStore.GetUnpublishedOutboxEvents();
 
-        var failedEvents = outboxEvents.Where(e =>
-            e.EventType.Contains(nameof(PaymentFailedEvent), StringComparison.Ordinal) &&
+        var voidedEvents = outboxEvents.Where(e =>
+            e.EventType.Contains(nameof(PaymentVoidedEvent), StringComparison.Ordinal) &&
             e.Data.Contains(orderId.ToString(), StringComparison.OrdinalIgnoreCase)).ToList();
 
-        Assert.Single(failedEvents);
+        Assert.Single(voidedEvents);
     }
 
     private async Task DispatchAsync<TEvent>(TEvent @event)

--- a/payment-microservice/Payment.Tests/Models/PaymentStateMachineTests.cs
+++ b/payment-microservice/Payment.Tests/Models/PaymentStateMachineTests.cs
@@ -26,6 +26,13 @@ public class PaymentStateMachineTests
         Assert.Equal(PaymentStatus.Authorized, payment.Status);
         Assert.Equal("ref-1", payment.ProviderReference);
         Assert.Equal(occurredAt, payment.UpdatedAt);
+
+        var authorized = Assert.Single(payment.DomainEvents.OfType<PaymentAuthorizedDomainEvent>());
+        Assert.Equal(payment.PaymentId, authorized.PaymentId);
+        Assert.Equal(payment.OrderId, authorized.OrderId);
+        Assert.Equal(payment.CustomerId, authorized.CustomerId);
+        Assert.Equal(payment.Amount, authorized.Amount);
+        Assert.Equal(payment.Currency, authorized.Currency);
     }
 
     [Fact]
@@ -34,10 +41,16 @@ public class PaymentStateMachineTests
         var payment = NewPending();
         var occurredAt = DateTime.UtcNow;
 
-        payment.Fail(occurredAt);
+        payment.Fail("Card declined by issuer", occurredAt);
 
         Assert.Equal(PaymentStatus.Failed, payment.Status);
         Assert.Equal(occurredAt, payment.UpdatedAt);
+
+        var failed = Assert.Single(payment.DomainEvents.OfType<PaymentFailedDomainEvent>());
+        Assert.Equal(payment.PaymentId, failed.PaymentId);
+        Assert.Equal(payment.OrderId, failed.OrderId);
+        Assert.Equal(payment.CustomerId, failed.CustomerId);
+        Assert.Equal("Card declined by issuer", failed.Reason);
     }
 
     [Fact]
@@ -110,7 +123,7 @@ public class PaymentStateMachineTests
     public void Fail_FromNonPending_Throws(PaymentStatus current)
     {
         var payment = MoveTo(current);
-        Assert.Throws<InvalidOperationException>(() => payment.Fail(DateTime.UtcNow));
+        Assert.Throws<InvalidOperationException>(() => payment.Fail("reason", DateTime.UtcNow));
     }
 
     [Theory]
@@ -143,10 +156,16 @@ public class PaymentStateMachineTests
         var payment = MoveTo(current);
         var occurredAt = DateTime.UtcNow;
 
-        payment.Void(occurredAt);
+        payment.Void("Order cancelled", occurredAt);
 
         Assert.Equal(PaymentStatus.Failed, payment.Status);
         Assert.Equal(occurredAt, payment.UpdatedAt);
+
+        var failed = Assert.Single(payment.DomainEvents.OfType<PaymentFailedDomainEvent>());
+        Assert.Equal(payment.PaymentId, failed.PaymentId);
+        Assert.Equal(payment.OrderId, failed.OrderId);
+        Assert.Equal(payment.CustomerId, failed.CustomerId);
+        Assert.Equal("Order cancelled", failed.Reason);
     }
 
     [Theory]
@@ -156,7 +175,7 @@ public class PaymentStateMachineTests
     public void Void_FromTerminal_Throws(PaymentStatus current)
     {
         var payment = MoveTo(current);
-        Assert.Throws<InvalidOperationException>(() => payment.Void(DateTime.UtcNow));
+        Assert.Throws<InvalidOperationException>(() => payment.Void("reason", DateTime.UtcNow));
     }
 
     private static Service.Models.Payment MoveTo(PaymentStatus target)
@@ -179,7 +198,7 @@ public class PaymentStateMachineTests
                 payment.Refund(payment.Amount, DateTime.UtcNow);
                 return payment;
             case PaymentStatus.Failed:
-                payment.Fail(DateTime.UtcNow);
+                payment.Fail("reason", DateTime.UtcNow);
                 return payment;
             default:
                 throw new ArgumentOutOfRangeException(nameof(target), target, null);

--- a/payment-microservice/Payment.Tests/Models/PaymentStateMachineTests.cs
+++ b/payment-microservice/Payment.Tests/Models/PaymentStateMachineTests.cs
@@ -67,10 +67,28 @@ public class PaymentStateMachineTests
         payment.Capture(DateTime.UtcNow);
         var occurredAt = DateTime.UtcNow;
 
-        payment.Refund(occurredAt);
+        payment.Refund(payment.Amount, occurredAt);
 
         Assert.Equal(PaymentStatus.Refunded, payment.Status);
         Assert.Equal(occurredAt, payment.UpdatedAt);
+
+        var refunded = Assert.Single(payment.DomainEvents.OfType<PaymentRefundedDomainEvent>());
+        Assert.Equal(payment.PaymentId, refunded.PaymentId);
+        Assert.Equal(payment.OrderId, refunded.OrderId);
+        Assert.Equal(payment.Amount, refunded.Amount);
+    }
+
+    [Fact]
+    public void Refund_WithPartialAmount_RaisesRefundedEventWithThatAmount()
+    {
+        var payment = NewPending();
+        payment.Authorize("ref-1", DateTime.UtcNow);
+        payment.Capture(DateTime.UtcNow);
+
+        payment.Refund(20.00m, DateTime.UtcNow);
+
+        var refunded = Assert.Single(payment.DomainEvents.OfType<PaymentRefundedDomainEvent>());
+        Assert.Equal(20.00m, refunded.Amount);
     }
 
     [Theory]
@@ -114,7 +132,7 @@ public class PaymentStateMachineTests
     public void Refund_FromNonCaptured_Throws(PaymentStatus current)
     {
         var payment = MoveTo(current);
-        Assert.Throws<InvalidOperationException>(() => payment.Refund(DateTime.UtcNow));
+        Assert.Throws<InvalidOperationException>(() => payment.Refund(payment.Amount, DateTime.UtcNow));
     }
 
     [Theory]
@@ -158,7 +176,7 @@ public class PaymentStateMachineTests
             case PaymentStatus.Refunded:
                 payment.Authorize("ref", DateTime.UtcNow);
                 payment.Capture(DateTime.UtcNow);
-                payment.Refund(DateTime.UtcNow);
+                payment.Refund(payment.Amount, DateTime.UtcNow);
                 return payment;
             case PaymentStatus.Failed:
                 payment.Fail(DateTime.UtcNow);

--- a/payment-microservice/Payment.Tests/Models/PaymentStateMachineTests.cs
+++ b/payment-microservice/Payment.Tests/Models/PaymentStateMachineTests.cs
@@ -218,7 +218,7 @@ public class PaymentStateMachineTests
     [Theory]
     [InlineData(PaymentStatus.Pending)]
     [InlineData(PaymentStatus.Authorized)]
-    public void Void_FromPendingOrAuthorized_TransitionsToFailed(PaymentStatus current)
+    public void Void_FromPendingOrAuthorized_TransitionsToVoided(PaymentStatus current)
     {
         var payment = MoveTo(current);
         var occurredAt = DateTime.UtcNow;
@@ -226,18 +226,18 @@ public class PaymentStateMachineTests
         var voided = payment.Void("Order cancelled", occurredAt);
 
         Assert.True(voided);
-        Assert.Equal(PaymentStatus.Failed, payment.Status);
+        Assert.Equal(PaymentStatus.Voided, payment.Status);
         Assert.Equal(occurredAt, payment.UpdatedAt);
 
-        var failed = Assert.Single(payment.DomainEvents.OfType<PaymentFailedDomainEvent>());
-        Assert.Equal(payment.PaymentId, failed.PaymentId);
-        Assert.Equal(payment.OrderId, failed.OrderId);
-        Assert.Equal(payment.CustomerId, failed.CustomerId);
-        Assert.Equal("Order cancelled", failed.Reason);
+        var domainEvent = Assert.Single(payment.DomainEvents.OfType<PaymentVoidedDomainEvent>());
+        Assert.Equal(payment.PaymentId, domainEvent.PaymentId);
+        Assert.Equal(payment.OrderId, domainEvent.OrderId);
+        Assert.Equal(payment.CustomerId, domainEvent.CustomerId);
+        Assert.Equal("Order cancelled", domainEvent.Reason);
     }
 
     [Fact]
-    public void Void_WhenAlreadyFailed_IsNoOp()
+    public void Void_WhenAlreadyVoided_IsNoOp()
     {
         var payment = MoveTo(PaymentStatus.Authorized);
         payment.Void("Order cancelled", DateTime.UtcNow);
@@ -247,7 +247,7 @@ public class PaymentStateMachineTests
         var voided = payment.Void("Order cancelled redelivery", DateTime.UtcNow.AddMinutes(1));
 
         Assert.False(voided);
-        Assert.Equal(PaymentStatus.Failed, payment.Status);
+        Assert.Equal(PaymentStatus.Voided, payment.Status);
         Assert.Equal(updatedAt, payment.UpdatedAt);
         Assert.Empty(payment.DequeueDomainEvents());
     }
@@ -255,6 +255,7 @@ public class PaymentStateMachineTests
     [Theory]
     [InlineData(PaymentStatus.Captured)]
     [InlineData(PaymentStatus.Refunded)]
+    [InlineData(PaymentStatus.Failed)]
     public void Void_FromTerminal_Throws(PaymentStatus current)
     {
         var payment = MoveTo(current);
@@ -282,6 +283,9 @@ public class PaymentStateMachineTests
                 return payment;
             case PaymentStatus.Failed:
                 payment.Fail("reason", DateTime.UtcNow);
+                return payment;
+            case PaymentStatus.Voided:
+                payment.Void("voided", DateTime.UtcNow);
                 return payment;
             default:
                 throw new ArgumentOutOfRangeException(nameof(target), target, null);

--- a/payment-microservice/Payment.Tests/Models/PaymentStateMachineTests.cs
+++ b/payment-microservice/Payment.Tests/Models/PaymentStateMachineTests.cs
@@ -21,18 +21,36 @@ public class PaymentStateMachineTests
         var payment = NewPending();
         var occurredAt = DateTime.UtcNow;
 
-        payment.Authorize("ref-1", occurredAt);
+        var authorized = payment.Authorize("ref-1", occurredAt);
 
+        Assert.True(authorized);
         Assert.Equal(PaymentStatus.Authorized, payment.Status);
         Assert.Equal("ref-1", payment.ProviderReference);
         Assert.Equal(occurredAt, payment.UpdatedAt);
 
-        var authorized = Assert.Single(payment.DomainEvents.OfType<PaymentAuthorizedDomainEvent>());
-        Assert.Equal(payment.PaymentId, authorized.PaymentId);
-        Assert.Equal(payment.OrderId, authorized.OrderId);
-        Assert.Equal(payment.CustomerId, authorized.CustomerId);
-        Assert.Equal(payment.Amount, authorized.Amount);
-        Assert.Equal(payment.Currency, authorized.Currency);
+        var domainEvent = Assert.Single(payment.DomainEvents.OfType<PaymentAuthorizedDomainEvent>());
+        Assert.Equal(payment.PaymentId, domainEvent.PaymentId);
+        Assert.Equal(payment.OrderId, domainEvent.OrderId);
+        Assert.Equal(payment.CustomerId, domainEvent.CustomerId);
+        Assert.Equal(payment.Amount, domainEvent.Amount);
+        Assert.Equal(payment.Currency, domainEvent.Currency);
+    }
+
+    [Fact]
+    public void Authorize_WhenAlreadyAuthorized_IsNoOp()
+    {
+        var payment = NewPending();
+        payment.Authorize("ref-1", DateTime.UtcNow);
+        payment.DequeueDomainEvents();
+        var updatedAt = payment.UpdatedAt;
+
+        var authorized = payment.Authorize("ref-2", DateTime.UtcNow.AddMinutes(1));
+
+        Assert.False(authorized);
+        Assert.Equal(PaymentStatus.Authorized, payment.Status);
+        Assert.Equal("ref-1", payment.ProviderReference);
+        Assert.Equal(updatedAt, payment.UpdatedAt);
+        Assert.Empty(payment.DequeueDomainEvents());
     }
 
     [Fact]
@@ -41,16 +59,33 @@ public class PaymentStateMachineTests
         var payment = NewPending();
         var occurredAt = DateTime.UtcNow;
 
-        payment.Fail("Card declined by issuer", occurredAt);
+        var failed = payment.Fail("Card declined by issuer", occurredAt);
 
+        Assert.True(failed);
         Assert.Equal(PaymentStatus.Failed, payment.Status);
         Assert.Equal(occurredAt, payment.UpdatedAt);
 
-        var failed = Assert.Single(payment.DomainEvents.OfType<PaymentFailedDomainEvent>());
-        Assert.Equal(payment.PaymentId, failed.PaymentId);
-        Assert.Equal(payment.OrderId, failed.OrderId);
-        Assert.Equal(payment.CustomerId, failed.CustomerId);
-        Assert.Equal("Card declined by issuer", failed.Reason);
+        var domainEvent = Assert.Single(payment.DomainEvents.OfType<PaymentFailedDomainEvent>());
+        Assert.Equal(payment.PaymentId, domainEvent.PaymentId);
+        Assert.Equal(payment.OrderId, domainEvent.OrderId);
+        Assert.Equal(payment.CustomerId, domainEvent.CustomerId);
+        Assert.Equal("Card declined by issuer", domainEvent.Reason);
+    }
+
+    [Fact]
+    public void Fail_WhenAlreadyFailed_IsNoOp()
+    {
+        var payment = NewPending();
+        payment.Fail("Card declined by issuer", DateTime.UtcNow);
+        payment.DequeueDomainEvents();
+        var updatedAt = payment.UpdatedAt;
+
+        var failed = payment.Fail("Gateway redelivery", DateTime.UtcNow.AddMinutes(1));
+
+        Assert.False(failed);
+        Assert.Equal(PaymentStatus.Failed, payment.Status);
+        Assert.Equal(updatedAt, payment.UpdatedAt);
+        Assert.Empty(payment.DequeueDomainEvents());
     }
 
     [Fact]
@@ -60,16 +95,33 @@ public class PaymentStateMachineTests
         payment.Authorize("ref-1", DateTime.UtcNow);
         var occurredAt = DateTime.UtcNow;
 
-        payment.Capture(occurredAt);
+        var captured = payment.Capture(occurredAt);
 
+        Assert.True(captured);
         Assert.Equal(PaymentStatus.Captured, payment.Status);
         Assert.Equal(occurredAt, payment.UpdatedAt);
 
-        var domainEvent = Assert.Single(payment.DomainEvents);
-        var captured = Assert.IsType<PaymentCapturedDomainEvent>(domainEvent);
-        Assert.Equal(payment.PaymentId, captured.PaymentId);
-        Assert.Equal(payment.OrderId, captured.OrderId);
-        Assert.Equal(payment.Amount, captured.Amount);
+        var capturedEvent = Assert.Single(payment.DomainEvents.OfType<PaymentCapturedDomainEvent>());
+        Assert.Equal(payment.PaymentId, capturedEvent.PaymentId);
+        Assert.Equal(payment.OrderId, capturedEvent.OrderId);
+        Assert.Equal(payment.Amount, capturedEvent.Amount);
+    }
+
+    [Fact]
+    public void Capture_WhenAlreadyCaptured_IsNoOp()
+    {
+        var payment = NewPending();
+        payment.Authorize("ref-1", DateTime.UtcNow);
+        payment.Capture(DateTime.UtcNow);
+        payment.DequeueDomainEvents();
+        var updatedAt = payment.UpdatedAt;
+
+        var captured = payment.Capture(DateTime.UtcNow.AddMinutes(1));
+
+        Assert.False(captured);
+        Assert.Equal(PaymentStatus.Captured, payment.Status);
+        Assert.Equal(updatedAt, payment.UpdatedAt);
+        Assert.Empty(payment.DequeueDomainEvents());
     }
 
     [Fact]
@@ -80,15 +132,34 @@ public class PaymentStateMachineTests
         payment.Capture(DateTime.UtcNow);
         var occurredAt = DateTime.UtcNow;
 
-        payment.Refund(payment.Amount, occurredAt);
+        var refunded = payment.Refund(payment.Amount, occurredAt);
 
+        Assert.True(refunded);
         Assert.Equal(PaymentStatus.Refunded, payment.Status);
         Assert.Equal(occurredAt, payment.UpdatedAt);
 
-        var refunded = Assert.Single(payment.DomainEvents.OfType<PaymentRefundedDomainEvent>());
-        Assert.Equal(payment.PaymentId, refunded.PaymentId);
-        Assert.Equal(payment.OrderId, refunded.OrderId);
-        Assert.Equal(payment.Amount, refunded.Amount);
+        var domainEvent = Assert.Single(payment.DomainEvents.OfType<PaymentRefundedDomainEvent>());
+        Assert.Equal(payment.PaymentId, domainEvent.PaymentId);
+        Assert.Equal(payment.OrderId, domainEvent.OrderId);
+        Assert.Equal(payment.Amount, domainEvent.Amount);
+    }
+
+    [Fact]
+    public void Refund_WhenAlreadyRefunded_IsNoOp()
+    {
+        var payment = NewPending();
+        payment.Authorize("ref-1", DateTime.UtcNow);
+        payment.Capture(DateTime.UtcNow);
+        payment.Refund(payment.Amount, DateTime.UtcNow);
+        payment.DequeueDomainEvents();
+        var updatedAt = payment.UpdatedAt;
+
+        var refunded = payment.Refund(payment.Amount, DateTime.UtcNow.AddMinutes(1));
+
+        Assert.False(refunded);
+        Assert.Equal(PaymentStatus.Refunded, payment.Status);
+        Assert.Equal(updatedAt, payment.UpdatedAt);
+        Assert.Empty(payment.DequeueDomainEvents());
     }
 
     [Fact]
@@ -105,7 +176,6 @@ public class PaymentStateMachineTests
     }
 
     [Theory]
-    [InlineData(PaymentStatus.Authorized)]
     [InlineData(PaymentStatus.Captured)]
     [InlineData(PaymentStatus.Refunded)]
     [InlineData(PaymentStatus.Failed)]
@@ -119,7 +189,6 @@ public class PaymentStateMachineTests
     [InlineData(PaymentStatus.Authorized)]
     [InlineData(PaymentStatus.Captured)]
     [InlineData(PaymentStatus.Refunded)]
-    [InlineData(PaymentStatus.Failed)]
     public void Fail_FromNonPending_Throws(PaymentStatus current)
     {
         var payment = MoveTo(current);
@@ -128,7 +197,6 @@ public class PaymentStateMachineTests
 
     [Theory]
     [InlineData(PaymentStatus.Pending)]
-    [InlineData(PaymentStatus.Captured)]
     [InlineData(PaymentStatus.Refunded)]
     [InlineData(PaymentStatus.Failed)]
     public void Capture_FromNonAuthorized_Throws(PaymentStatus current)
@@ -140,7 +208,6 @@ public class PaymentStateMachineTests
     [Theory]
     [InlineData(PaymentStatus.Pending)]
     [InlineData(PaymentStatus.Authorized)]
-    [InlineData(PaymentStatus.Refunded)]
     [InlineData(PaymentStatus.Failed)]
     public void Refund_FromNonCaptured_Throws(PaymentStatus current)
     {
@@ -156,8 +223,9 @@ public class PaymentStateMachineTests
         var payment = MoveTo(current);
         var occurredAt = DateTime.UtcNow;
 
-        payment.Void("Order cancelled", occurredAt);
+        var voided = payment.Void("Order cancelled", occurredAt);
 
+        Assert.True(voided);
         Assert.Equal(PaymentStatus.Failed, payment.Status);
         Assert.Equal(occurredAt, payment.UpdatedAt);
 
@@ -168,10 +236,25 @@ public class PaymentStateMachineTests
         Assert.Equal("Order cancelled", failed.Reason);
     }
 
+    [Fact]
+    public void Void_WhenAlreadyFailed_IsNoOp()
+    {
+        var payment = MoveTo(PaymentStatus.Authorized);
+        payment.Void("Order cancelled", DateTime.UtcNow);
+        payment.DequeueDomainEvents();
+        var updatedAt = payment.UpdatedAt;
+
+        var voided = payment.Void("Order cancelled redelivery", DateTime.UtcNow.AddMinutes(1));
+
+        Assert.False(voided);
+        Assert.Equal(PaymentStatus.Failed, payment.Status);
+        Assert.Equal(updatedAt, payment.UpdatedAt);
+        Assert.Empty(payment.DequeueDomainEvents());
+    }
+
     [Theory]
     [InlineData(PaymentStatus.Captured)]
     [InlineData(PaymentStatus.Refunded)]
-    [InlineData(PaymentStatus.Failed)]
     public void Void_FromTerminal_Throws(PaymentStatus current)
     {
         var payment = MoveTo(current);

--- a/payment-microservice/Payment.Tests/Models/PaymentStateMachineTests.cs
+++ b/payment-microservice/Payment.Tests/Models/PaymentStateMachineTests.cs
@@ -51,6 +51,12 @@ public class PaymentStateMachineTests
 
         Assert.Equal(PaymentStatus.Captured, payment.Status);
         Assert.Equal(occurredAt, payment.UpdatedAt);
+
+        var domainEvent = Assert.Single(payment.DomainEvents);
+        var captured = Assert.IsType<PaymentCapturedDomainEvent>(domainEvent);
+        Assert.Equal(payment.PaymentId, captured.PaymentId);
+        Assert.Equal(payment.OrderId, captured.OrderId);
+        Assert.Equal(payment.Amount, captured.Amount);
     }
 
     [Fact]

--- a/payment-microservice/Payment.Tests/Payment.Tests.csproj.lscache
+++ b/payment-microservice/Payment.Tests/Payment.Tests.csproj.lscache
@@ -1,0 +1,496 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[properties]
+AssemblyName=Payment.Tests
+CommandLineArgsForDesignTimeEvaluation=-langversion:14.0 -define:TRACE
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=14.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=Payment.Tests
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../../MicroservicesInDotNet.sln
+TargetFrameworkIdentifier=.NETCoreApp
+TargetPath=<PATH>bin/Debug/net10.0/Payment.Tests.dll
+TargetRefPath=<PATH>obj/Debug/net10.0/ref/Payment.Tests.dll
+TemporaryDependencyNodeTargetIdentifier=net10.0
+
+[commandLineArguments]
+/noconfig
+/unsafe-
+/checked-
+/nowarn:NU1603,NU1902,NU1903,NU5104,CA1711,CA1707,CA1716,1701,1702,8002
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/warn:10
+/define:TRACE;DEBUG;NET;NET10_0;NETCOREAPP;NET5_0_OR_GREATER;NET6_0_OR_GREATER;NET7_0_OR_GREATER;NET8_0_OR_GREATER;NET9_0_OR_GREATER;NET10_0_OR_GREATER;NETCOREAPP1_0_OR_GREATER;NETCOREAPP1_1_OR_GREATER;NETCOREAPP2_0_OR_GREATER;NETCOREAPP2_1_OR_GREATER;NETCOREAPP2_2_OR_GREATER;NETCOREAPP3_0_OR_GREATER;NETCOREAPP3_1_OR_GREATER
+/highentropyva+
+/nullable:enable
+/features:"InterceptorsNamespaces=;Microsoft.Extensions.Validation.Generated"
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\net10.0\Payment.Tests.dll
+/refout:obj\Debug\net10.0\refint\Payment.Tests.dll
+/target:exe
+/warnaserror+
+/utf8output
+/deterministic+
+/langversion:14.0
+/warnaserror+:NU1605,SYSLIB0011
+
+[sourceFiles]
+<NUGET>/microsoft.net.test.sdk/17.14.1/build/net8.0/Microsoft.NET.Test.Sdk.Program.cs
+Api/
+ HealthEndpointTests.cs
+ InternalOutboxEndpointsTests.cs
+ PaymentEndpointsTests.cs
+ PaymentOwnershipTests.cs
+ QaSeedPresenceTests.cs
+Authentication/TestAuthHandler.cs
+IntegrationEvents/
+ CheckoutHappyPathTests.cs
+ MessagingProviderBootTests.cs
+ PaymentFailureCompensationTests.cs
+ PaymentOrderCancelledTests.cs
+ ShipmentDispatchedFlowTests.cs
+IntegrationTestBase.cs
+Models/PaymentStateMachineTests.cs
+obj/Debug/net10.0/
+ .NETCoreApp,Version=v10.0.AssemblyAttributes.cs
+ Payment.Tests.AssemblyInfo.cs
+ Payment.Tests.GlobalUsings.g.cs
+PaymentWebApplicationFactory.cs
+
+[metadataReferences]
+../Payment.Service/obj/Debug/net10.0/ref/Payment.Service.dll
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.AspNetCore.Antiforgery.dll
+ Microsoft.AspNetCore.Authentication.Abstractions.dll
+ Microsoft.AspNetCore.Authentication.BearerToken.dll
+ Microsoft.AspNetCore.Authentication.Cookies.dll
+ Microsoft.AspNetCore.Authentication.Core.dll
+ Microsoft.AspNetCore.Authentication.dll
+ Microsoft.AspNetCore.Authentication.OAuth.dll
+ Microsoft.AspNetCore.Authorization.dll
+ Microsoft.AspNetCore.Authorization.Policy.dll
+ Microsoft.AspNetCore.Components.Authorization.dll
+ Microsoft.AspNetCore.Components.dll
+ Microsoft.AspNetCore.Components.Endpoints.dll
+ Microsoft.AspNetCore.Components.Forms.dll
+ Microsoft.AspNetCore.Components.Server.dll
+ Microsoft.AspNetCore.Components.Web.dll
+ Microsoft.AspNetCore.Connections.Abstractions.dll
+ Microsoft.AspNetCore.CookiePolicy.dll
+ Microsoft.AspNetCore.Cors.dll
+ Microsoft.AspNetCore.Cryptography.Internal.dll
+ Microsoft.AspNetCore.Cryptography.KeyDerivation.dll
+ Microsoft.AspNetCore.DataProtection.Abstractions.dll
+ Microsoft.AspNetCore.DataProtection.dll
+ Microsoft.AspNetCore.DataProtection.Extensions.dll
+ Microsoft.AspNetCore.Diagnostics.Abstractions.dll
+ Microsoft.AspNetCore.Diagnostics.dll
+ Microsoft.AspNetCore.Diagnostics.HealthChecks.dll
+ Microsoft.AspNetCore.dll
+ Microsoft.AspNetCore.HostFiltering.dll
+ Microsoft.AspNetCore.Hosting.Abstractions.dll
+ Microsoft.AspNetCore.Hosting.dll
+ Microsoft.AspNetCore.Hosting.Server.Abstractions.dll
+ Microsoft.AspNetCore.Html.Abstractions.dll
+ Microsoft.AspNetCore.Http.Abstractions.dll
+ Microsoft.AspNetCore.Http.Connections.Common.dll
+ Microsoft.AspNetCore.Http.Connections.dll
+ Microsoft.AspNetCore.Http.dll
+ Microsoft.AspNetCore.Http.Extensions.dll
+ Microsoft.AspNetCore.Http.Features.dll
+ Microsoft.AspNetCore.Http.Results.dll
+ Microsoft.AspNetCore.HttpLogging.dll
+ Microsoft.AspNetCore.HttpOverrides.dll
+ Microsoft.AspNetCore.HttpsPolicy.dll
+ Microsoft.AspNetCore.Identity.dll
+ Microsoft.AspNetCore.Localization.dll
+ Microsoft.AspNetCore.Localization.Routing.dll
+ Microsoft.AspNetCore.Metadata.dll
+ Microsoft.AspNetCore.Mvc.Abstractions.dll
+ Microsoft.AspNetCore.Mvc.ApiExplorer.dll
+ Microsoft.AspNetCore.Mvc.Core.dll
+ Microsoft.AspNetCore.Mvc.Cors.dll
+ Microsoft.AspNetCore.Mvc.DataAnnotations.dll
+ Microsoft.AspNetCore.Mvc.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Json.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Xml.dll
+ Microsoft.AspNetCore.Mvc.Localization.dll
+ Microsoft.AspNetCore.Mvc.Razor.dll
+ Microsoft.AspNetCore.Mvc.RazorPages.dll
+ Microsoft.AspNetCore.Mvc.TagHelpers.dll
+ Microsoft.AspNetCore.Mvc.ViewFeatures.dll
+ Microsoft.AspNetCore.OutputCaching.dll
+ Microsoft.AspNetCore.RateLimiting.dll
+ Microsoft.AspNetCore.Razor.dll
+ Microsoft.AspNetCore.Razor.Runtime.dll
+ Microsoft.AspNetCore.RequestDecompression.dll
+ Microsoft.AspNetCore.ResponseCaching.Abstractions.dll
+ Microsoft.AspNetCore.ResponseCaching.dll
+ Microsoft.AspNetCore.ResponseCompression.dll
+ Microsoft.AspNetCore.Rewrite.dll
+ Microsoft.AspNetCore.Routing.Abstractions.dll
+ Microsoft.AspNetCore.Routing.dll
+ Microsoft.AspNetCore.Server.HttpSys.dll
+ Microsoft.AspNetCore.Server.IIS.dll
+ Microsoft.AspNetCore.Server.IISIntegration.dll
+ Microsoft.AspNetCore.Server.Kestrel.Core.dll
+ Microsoft.AspNetCore.Server.Kestrel.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll
+ Microsoft.AspNetCore.Session.dll
+ Microsoft.AspNetCore.SignalR.Common.dll
+ Microsoft.AspNetCore.SignalR.Core.dll
+ Microsoft.AspNetCore.SignalR.dll
+ Microsoft.AspNetCore.SignalR.Protocols.Json.dll
+ Microsoft.AspNetCore.StaticAssets.dll
+ Microsoft.AspNetCore.StaticFiles.dll
+ Microsoft.AspNetCore.WebSockets.dll
+ Microsoft.AspNetCore.WebUtilities.dll
+ Microsoft.Extensions.Caching.Abstractions.dll
+ Microsoft.Extensions.Caching.Memory.dll
+ Microsoft.Extensions.Configuration.Abstractions.dll
+ Microsoft.Extensions.Configuration.Binder.dll
+ Microsoft.Extensions.Configuration.CommandLine.dll
+ Microsoft.Extensions.Configuration.dll
+ Microsoft.Extensions.Configuration.EnvironmentVariables.dll
+ Microsoft.Extensions.Configuration.FileExtensions.dll
+ Microsoft.Extensions.Configuration.Ini.dll
+ Microsoft.Extensions.Configuration.Json.dll
+ Microsoft.Extensions.Configuration.KeyPerFile.dll
+ Microsoft.Extensions.Configuration.UserSecrets.dll
+ Microsoft.Extensions.Configuration.Xml.dll
+ Microsoft.Extensions.DependencyInjection.Abstractions.dll
+ Microsoft.Extensions.DependencyInjection.dll
+ Microsoft.Extensions.Diagnostics.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.dll
+ Microsoft.Extensions.Features.dll
+ Microsoft.Extensions.FileProviders.Abstractions.dll
+ Microsoft.Extensions.FileProviders.Composite.dll
+ Microsoft.Extensions.FileProviders.Embedded.dll
+ Microsoft.Extensions.FileProviders.Physical.dll
+ Microsoft.Extensions.FileSystemGlobbing.dll
+ Microsoft.Extensions.Hosting.Abstractions.dll
+ Microsoft.Extensions.Hosting.dll
+ Microsoft.Extensions.Http.dll
+ Microsoft.Extensions.Identity.Core.dll
+ Microsoft.Extensions.Identity.Stores.dll
+ Microsoft.Extensions.Localization.Abstractions.dll
+ Microsoft.Extensions.Localization.dll
+ Microsoft.Extensions.Logging.Abstractions.dll
+ Microsoft.Extensions.Logging.Configuration.dll
+ Microsoft.Extensions.Logging.Console.dll
+ Microsoft.Extensions.Logging.Debug.dll
+ Microsoft.Extensions.Logging.dll
+ Microsoft.Extensions.Logging.EventLog.dll
+ Microsoft.Extensions.Logging.EventSource.dll
+ Microsoft.Extensions.Logging.TraceSource.dll
+ Microsoft.Extensions.ObjectPool.dll
+ Microsoft.Extensions.Options.ConfigurationExtensions.dll
+ Microsoft.Extensions.Options.DataAnnotations.dll
+ Microsoft.Extensions.Options.dll
+ Microsoft.Extensions.Primitives.dll
+ Microsoft.Extensions.Validation.dll
+ Microsoft.Extensions.WebEncoders.dll
+ Microsoft.JSInterop.dll
+ Microsoft.Net.Http.Headers.dll
+ System.Diagnostics.EventLog.dll
+ System.Formats.Cbor.dll
+ System.Security.Cryptography.Xml.dll
+ System.Threading.RateLimiting.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.CSharp.dll
+ Microsoft.VisualBasic.Core.dll
+ Microsoft.VisualBasic.dll
+ Microsoft.Win32.Primitives.dll
+ Microsoft.Win32.Registry.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.Immutable.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Annotations.dll
+ System.ComponentModel.DataAnnotations.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Configuration.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.DataSetExtensions.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.DiagnosticSource.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Formats.Asn1.dll
+ System.Formats.Tar.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.Brotli.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.AccessControl.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipelines.dll
+ System.IO.Pipes.AccessControl.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.AsyncEnumerable.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.Http.Json.dll
+ System.Net.HttpListener.dll
+ System.Net.Mail.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Quic.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.ServerSentEvents.dll
+ System.Net.ServicePoint.dll
+ System.Net.Sockets.dll
+ System.Net.WebClient.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebProxy.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Metadata.dll
+ System.Reflection.Primitives.dll
+ System.Reflection.TypeExtensions.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.Unsafe.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.JavaScript.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Intrinsics.dll
+ System.Runtime.Loader.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.AccessControl.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Cng.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.OpenSsl.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.dll
+ System.Security.Principal.dll
+ System.Security.Principal.Windows.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.ServiceProcess.dll
+ System.Text.Encoding.CodePages.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.Encodings.Web.dll
+ System.Text.Json.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.AccessControl.dll
+ System.Threading.Channels.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.Dataflow.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.Transactions.Local.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Web.HttpUtility.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+ WindowsBase.dll
+<NUGET>/
+ azure.core.amqp/1.3.1/lib/netstandard2.0/Azure.Core.Amqp.dll
+ azure.core/1.47.1/lib/net8.0/Azure.Core.dll
+ azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
+ azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
+ azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
+ ecommerce.shared/2.15.0/lib/net10.0/ECommerce.Shared.dll
+ google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
+ grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
+ grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll
+ grpc.net.common/2.52.0/lib/net7.0/Grpc.Net.Common.dll
+ microsoft.aspnetcore.authentication.jwtbearer/10.0.5/lib/net10.0/Microsoft.AspNetCore.Authentication.JwtBearer.dll
+ microsoft.aspnetcore.mvc.testing/10.0.5/lib/net10.0/Microsoft.AspNetCore.Mvc.Testing.dll
+ microsoft.aspnetcore.testhost/10.0.5/lib/net10.0/Microsoft.AspNetCore.TestHost.dll
+ microsoft.azure.amqp/2.6.7/lib/netstandard2.0/Microsoft.Azure.Amqp.dll
+ microsoft.bcl.asyncinterfaces/8.0.0/lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll
+ microsoft.bcl.cryptography/9.0.4/lib/net9.0/Microsoft.Bcl.Cryptography.dll
+ microsoft.codecoverage/17.14.1/lib/net8.0/Microsoft.VisualStudio.CodeCoverage.Shim.dll
+ microsoft.data.sqlclient/6.1.1/ref/net9.0/Microsoft.Data.SqlClient.dll
+ microsoft.entityframeworkcore.abstractions/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Abstractions.dll
+ microsoft.entityframeworkcore.relational/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Relational.dll
+ microsoft.entityframeworkcore.sqlserver/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.SqlServer.dll
+ microsoft.entityframeworkcore/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.dll
+ microsoft.extensions.dependencymodel/10.0.5/lib/net10.0/Microsoft.Extensions.DependencyModel.dll
+ microsoft.identity.client.extensions.msal/4.73.1/lib/net8.0/Microsoft.Identity.Client.Extensions.Msal.dll
+ microsoft.identity.client/4.73.1/lib/net8.0/Microsoft.Identity.Client.dll
+ microsoft.identitymodel.abstractions/8.0.1/lib/net9.0/Microsoft.IdentityModel.Abstractions.dll
+ microsoft.identitymodel.jsonwebtokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.JsonWebTokens.dll
+ microsoft.identitymodel.logging/8.0.1/lib/net9.0/Microsoft.IdentityModel.Logging.dll
+ microsoft.identitymodel.protocols.openidconnect/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.dll
+ microsoft.identitymodel.protocols/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.dll
+ microsoft.identitymodel.tokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.Tokens.dll
+ microsoft.openapi/1.6.14/lib/netstandard2.0/Microsoft.OpenApi.dll
+ microsoft.sqlserver.server/1.0.0/lib/netstandard2.0/Microsoft.SqlServer.Server.dll
+ microsoft.testplatform.testhost/17.14.1/lib/net8.0/
+  Microsoft.TestPlatform.CommunicationUtilities.dll
+  Microsoft.TestPlatform.CoreUtilities.dll
+  Microsoft.TestPlatform.CrossPlatEngine.dll
+  Microsoft.TestPlatform.PlatformAbstractions.dll
+  Microsoft.TestPlatform.Utilities.dll
+  Microsoft.VisualStudio.TestPlatform.Common.dll
+  Microsoft.VisualStudio.TestPlatform.ObjectModel.dll
+  testhost.dll
+ newtonsoft.json/13.0.3/lib/net6.0/Newtonsoft.Json.dll
+ opentelemetry.api.providerbuilderextensions/1.10.0/lib/net9.0/OpenTelemetry.Api.ProviderBuilderExtensions.dll
+ opentelemetry.api/1.10.0/lib/net9.0/OpenTelemetry.Api.dll
+ opentelemetry.exporter.console/1.9.0/lib/net8.0/OpenTelemetry.Exporter.Console.dll
+ opentelemetry.exporter.opentelemetryprotocol/1.9.0/lib/net8.0/OpenTelemetry.Exporter.OpenTelemetryProtocol.dll
+ opentelemetry.exporter.prometheus.aspnetcore/1.10.0-beta.1/lib/net9.0/OpenTelemetry.Exporter.Prometheus.AspNetCore.dll
+ opentelemetry.extensions.hosting/1.9.0/lib/net8.0/OpenTelemetry.Extensions.Hosting.dll
+ opentelemetry.instrumentation.aspnetcore/1.9.0/lib/net8.0/OpenTelemetry.Instrumentation.AspNetCore.dll
+ opentelemetry.instrumentation.sqlclient/1.9.0-beta.1/lib/net8.0/OpenTelemetry.Instrumentation.SqlClient.dll
+ opentelemetry.persistentstorage.abstractions/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.Abstractions.dll
+ opentelemetry.persistentstorage.filesystem/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.FileSystem.dll
+ opentelemetry/1.10.0/lib/net9.0/OpenTelemetry.dll
+ pipelines.sockets.unofficial/2.2.8/lib/net5.0/Pipelines.Sockets.Unofficial.dll
+ polly.core/8.6.6/lib/net8.0/Polly.Core.dll
+ rabbitmq.client/6.8.1/lib/netstandard2.0/RabbitMQ.Client.dll
+ stackexchange.redis/2.8.16/lib/net6.0/StackExchange.Redis.dll
+ swashbuckle.aspnetcore.swagger/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.Swagger.dll
+ swashbuckle.aspnetcore.swaggergen/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.dll
+ swashbuckle.aspnetcore.swaggerui/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.dll
+ system.clientmodel/1.5.1/lib/net8.0/System.ClientModel.dll
+ system.identitymodel.tokens.jwt/8.0.1/lib/net9.0/System.IdentityModel.Tokens.Jwt.dll
+ system.memory.data/8.0.1/lib/net8.0/System.Memory.Data.dll
+ system.security.cryptography.pkcs/9.0.4/lib/net9.0/System.Security.Cryptography.Pkcs.dll
+ system.security.cryptography.protecteddata/9.0.4/lib/net9.0/System.Security.Cryptography.ProtectedData.dll
+ xunit.abstractions/2.0.3/lib/netstandard2.0/xunit.abstractions.dll
+ xunit.assert/2.9.3/lib/net6.0/xunit.assert.dll
+ xunit.extensibility.core/2.9.3/lib/netstandard1.1/xunit.core.dll
+ xunit.extensibility.execution/2.9.3/lib/netstandard1.1/xunit.execution.dotnet.dll
+
+[analyzerReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.AspNetCore.App.Analyzers.dll
+ Microsoft.AspNetCore.App.CodeFixes.dll
+ Microsoft.AspNetCore.App.SourceGenerators.dll
+ Microsoft.AspNetCore.Components.Analyzers.dll
+ Microsoft.Extensions.Logging.Generators.dll
+ Microsoft.Extensions.Options.SourceGeneration.dll
+ Microsoft.Extensions.Validation.ValidationsGenerator.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.Interop.ComInterfaceGenerator.dll
+ Microsoft.Interop.JavaScript.JSImportGenerator.dll
+ Microsoft.Interop.LibraryImportGenerator.dll
+ Microsoft.Interop.SourceGeneration.dll
+ System.Text.Json.SourceGeneration.dll
+ System.Text.RegularExpressions.Generator.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/
+ Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll
+ Microsoft.CodeAnalysis.NetAnalyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/codestyle/cs/
+ Microsoft.CodeAnalysis.CodeStyle.dll
+ Microsoft.CodeAnalysis.CodeStyle.Fixes.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.dll
+<NUGET>/
+ microsoft.entityframeworkcore.analyzers/10.0.5/analyzers/dotnet/cs/Microsoft.EntityFrameworkCore.Analyzers.dll
+ system.clientmodel/1.5.1/analyzers/dotnet/cs/System.ClientModel.SourceGeneration.dll
+ xunit.analyzers/1.18.0/analyzers/dotnet/cs/
+  xunit.analyzers.dll
+  xunit.analyzers.fixes.dll
+
+[analyzerConfigFiles]
+../../.editorconfig
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_10_recommended.globalconfig
+obj/Debug/net10.0/Payment.Tests.GeneratedMSBuildEditorConfig.editorconfig

--- a/payment-microservice/Payment.Tests/Payment.Tests.csproj.lscache
+++ b/payment-microservice/Payment.Tests/Payment.Tests.csproj.lscache
@@ -393,7 +393,7 @@ PaymentWebApplicationFactory.cs
  azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
  azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
  azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
- ecommerce.shared/2.15.0/lib/net10.0/ECommerce.Shared.dll
+ ecommerce.shared/2.16.0/lib/net10.0/ECommerce.Shared.dll
  google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
  grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
  grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll

--- a/payment-microservice/Payment.Tests/PaymentWebApplicationFactory.cs
+++ b/payment-microservice/Payment.Tests/PaymentWebApplicationFactory.cs
@@ -1,3 +1,4 @@
+using ECommerce.Shared.Infrastructure.Outbox;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -32,9 +33,24 @@ public class PaymentWebApplicationFactory : WebApplicationFactory<Program>, IAsy
     {
         builder.ConfigureTestServices(services =>
         {
+            DisableOutboxBackgroundService(services);
             ApplyMigrations(services);
             ConfigureTestAuthentication(services);
         });
+    }
+
+    private static void DisableOutboxBackgroundService(IServiceCollection services)
+    {
+        // Tests assert against the Outbox state directly. The poller racing
+        // with the assertion would mark events Sent and exclude them from
+        // GetUnpublishedOutboxEvents, masking real failures.
+        var hosted = services
+            .Where(d => d.ImplementationType == typeof(OutboxBackgroundService))
+            .ToList();
+        foreach (var descriptor in hosted)
+        {
+            services.Remove(descriptor);
+        }
     }
 
     private void ApplyMigrations(IServiceCollection services)

--- a/product-microservice/Product.Service/Product.Service.csproj.lscache
+++ b/product-microservice/Product.Service/Product.Service.csproj.lscache
@@ -1,0 +1,502 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[properties]
+AssemblyName=Product.Service
+CommandLineArgsForDesignTimeEvaluation=-langversion:14.0 -define:TRACE
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=14.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=Product.Service
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../../MicroservicesInDotNet.sln
+TargetFrameworkIdentifier=.NETCoreApp
+TargetPath=<PATH>bin/Debug/net10.0/Product.Service.dll
+TargetRefPath=<PATH>obj/Debug/net10.0/ref/Product.Service.dll
+TemporaryDependencyNodeTargetIdentifier=net10.0
+
+[commandLineArguments]
+/noconfig
+/unsafe-
+/checked-
+/nowarn:NU1603,NU1902,NU1903,NU5104,CA1711,CA1707,CA1716,1701,1702,8002
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/warn:10
+/define:TRACE;DEBUG;NET;NET10_0;NETCOREAPP;NET5_0_OR_GREATER;NET6_0_OR_GREATER;NET7_0_OR_GREATER;NET8_0_OR_GREATER;NET9_0_OR_GREATER;NET10_0_OR_GREATER;NETCOREAPP1_0_OR_GREATER;NETCOREAPP1_1_OR_GREATER;NETCOREAPP2_0_OR_GREATER;NETCOREAPP2_1_OR_GREATER;NETCOREAPP2_2_OR_GREATER;NETCOREAPP3_0_OR_GREATER;NETCOREAPP3_1_OR_GREATER
+/highentropyva+
+/nullable:enable
+/features:"InterceptorsNamespaces=;Microsoft.Extensions.Validation.Generated"
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\net10.0\Product.Service.dll
+/refout:obj\Debug\net10.0\refint\Product.Service.dll
+/target:exe
+/warnaserror+
+/utf8output
+/deterministic+
+/langversion:14.0
+/features:use-roslyn-tokenizer=true
+/warnaserror+:NU1605,SYSLIB0011
+
+[sourceFiles]
+ApiModels/
+ CreateProductRequest.cs
+ GetProductResponse.cs
+ UpdateProductRequest.cs
+Endpoints/
+ InternalOutboxEndpoints.cs
+ ProductApiEndpoints.cs
+Infrastructure/Data/EntityFramework/
+ EntityFrameworkExtensions.cs
+ ProductConfiguration.cs
+ ProductContext.cs
+ ProductContextDesignTimeFactory.cs
+ ProductContextSeed.cs
+ ProductTypeConfiguration.cs
+Infrastructure/Data/IProductStore.cs
+IntegrationEvents/
+ ProductCreatedEvent.cs
+ ProductPriceUpdatedEvent.cs
+Migrations/
+ 20260414081144_Initial.cs
+ 20260414081144_Initial.Designer.cs
+ 20260414081154_SeedProductTypes.cs
+ 20260414081154_SeedProductTypes.Designer.cs
+ 20260506132137_20260506_SeedQaData_Product.cs
+ 20260506132137_20260506_SeedQaData_Product.Designer.cs
+ 20260507000000_20260507_SeedQaPhase2_Product.cs
+ 20260507000000_20260507_SeedQaPhase2_Product.Designer.cs
+ 20260507010000_20260507_SeedQaPhase3c_Product.cs
+ 20260507010000_20260507_SeedQaPhase3c_Product.Designer.cs
+ ProductContextModelSnapshot.cs
+Models/
+ Product.cs
+ ProductType.cs
+obj/Debug/net10.0/
+ .NETCoreApp,Version=v10.0.AssemblyAttributes.cs
+ Product.Service.AssemblyInfo.cs
+ Product.Service.GlobalUsings.g.cs
+Program.cs
+
+[metadataReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.AspNetCore.Antiforgery.dll
+ Microsoft.AspNetCore.Authentication.Abstractions.dll
+ Microsoft.AspNetCore.Authentication.BearerToken.dll
+ Microsoft.AspNetCore.Authentication.Cookies.dll
+ Microsoft.AspNetCore.Authentication.Core.dll
+ Microsoft.AspNetCore.Authentication.dll
+ Microsoft.AspNetCore.Authentication.OAuth.dll
+ Microsoft.AspNetCore.Authorization.dll
+ Microsoft.AspNetCore.Authorization.Policy.dll
+ Microsoft.AspNetCore.Components.Authorization.dll
+ Microsoft.AspNetCore.Components.dll
+ Microsoft.AspNetCore.Components.Endpoints.dll
+ Microsoft.AspNetCore.Components.Forms.dll
+ Microsoft.AspNetCore.Components.Server.dll
+ Microsoft.AspNetCore.Components.Web.dll
+ Microsoft.AspNetCore.Connections.Abstractions.dll
+ Microsoft.AspNetCore.CookiePolicy.dll
+ Microsoft.AspNetCore.Cors.dll
+ Microsoft.AspNetCore.Cryptography.Internal.dll
+ Microsoft.AspNetCore.Cryptography.KeyDerivation.dll
+ Microsoft.AspNetCore.DataProtection.Abstractions.dll
+ Microsoft.AspNetCore.DataProtection.dll
+ Microsoft.AspNetCore.DataProtection.Extensions.dll
+ Microsoft.AspNetCore.Diagnostics.Abstractions.dll
+ Microsoft.AspNetCore.Diagnostics.dll
+ Microsoft.AspNetCore.Diagnostics.HealthChecks.dll
+ Microsoft.AspNetCore.dll
+ Microsoft.AspNetCore.HostFiltering.dll
+ Microsoft.AspNetCore.Hosting.Abstractions.dll
+ Microsoft.AspNetCore.Hosting.dll
+ Microsoft.AspNetCore.Hosting.Server.Abstractions.dll
+ Microsoft.AspNetCore.Html.Abstractions.dll
+ Microsoft.AspNetCore.Http.Abstractions.dll
+ Microsoft.AspNetCore.Http.Connections.Common.dll
+ Microsoft.AspNetCore.Http.Connections.dll
+ Microsoft.AspNetCore.Http.dll
+ Microsoft.AspNetCore.Http.Extensions.dll
+ Microsoft.AspNetCore.Http.Features.dll
+ Microsoft.AspNetCore.Http.Results.dll
+ Microsoft.AspNetCore.HttpLogging.dll
+ Microsoft.AspNetCore.HttpOverrides.dll
+ Microsoft.AspNetCore.HttpsPolicy.dll
+ Microsoft.AspNetCore.Identity.dll
+ Microsoft.AspNetCore.Localization.dll
+ Microsoft.AspNetCore.Localization.Routing.dll
+ Microsoft.AspNetCore.Metadata.dll
+ Microsoft.AspNetCore.Mvc.Abstractions.dll
+ Microsoft.AspNetCore.Mvc.ApiExplorer.dll
+ Microsoft.AspNetCore.Mvc.Core.dll
+ Microsoft.AspNetCore.Mvc.Cors.dll
+ Microsoft.AspNetCore.Mvc.DataAnnotations.dll
+ Microsoft.AspNetCore.Mvc.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Json.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Xml.dll
+ Microsoft.AspNetCore.Mvc.Localization.dll
+ Microsoft.AspNetCore.Mvc.Razor.dll
+ Microsoft.AspNetCore.Mvc.RazorPages.dll
+ Microsoft.AspNetCore.Mvc.TagHelpers.dll
+ Microsoft.AspNetCore.Mvc.ViewFeatures.dll
+ Microsoft.AspNetCore.OutputCaching.dll
+ Microsoft.AspNetCore.RateLimiting.dll
+ Microsoft.AspNetCore.Razor.dll
+ Microsoft.AspNetCore.Razor.Runtime.dll
+ Microsoft.AspNetCore.RequestDecompression.dll
+ Microsoft.AspNetCore.ResponseCaching.Abstractions.dll
+ Microsoft.AspNetCore.ResponseCaching.dll
+ Microsoft.AspNetCore.ResponseCompression.dll
+ Microsoft.AspNetCore.Rewrite.dll
+ Microsoft.AspNetCore.Routing.Abstractions.dll
+ Microsoft.AspNetCore.Routing.dll
+ Microsoft.AspNetCore.Server.HttpSys.dll
+ Microsoft.AspNetCore.Server.IIS.dll
+ Microsoft.AspNetCore.Server.IISIntegration.dll
+ Microsoft.AspNetCore.Server.Kestrel.Core.dll
+ Microsoft.AspNetCore.Server.Kestrel.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll
+ Microsoft.AspNetCore.Session.dll
+ Microsoft.AspNetCore.SignalR.Common.dll
+ Microsoft.AspNetCore.SignalR.Core.dll
+ Microsoft.AspNetCore.SignalR.dll
+ Microsoft.AspNetCore.SignalR.Protocols.Json.dll
+ Microsoft.AspNetCore.StaticAssets.dll
+ Microsoft.AspNetCore.StaticFiles.dll
+ Microsoft.AspNetCore.WebSockets.dll
+ Microsoft.AspNetCore.WebUtilities.dll
+ Microsoft.Extensions.Caching.Abstractions.dll
+ Microsoft.Extensions.Caching.Memory.dll
+ Microsoft.Extensions.Configuration.Abstractions.dll
+ Microsoft.Extensions.Configuration.Binder.dll
+ Microsoft.Extensions.Configuration.CommandLine.dll
+ Microsoft.Extensions.Configuration.dll
+ Microsoft.Extensions.Configuration.EnvironmentVariables.dll
+ Microsoft.Extensions.Configuration.FileExtensions.dll
+ Microsoft.Extensions.Configuration.Ini.dll
+ Microsoft.Extensions.Configuration.Json.dll
+ Microsoft.Extensions.Configuration.KeyPerFile.dll
+ Microsoft.Extensions.Configuration.UserSecrets.dll
+ Microsoft.Extensions.Configuration.Xml.dll
+ Microsoft.Extensions.DependencyInjection.Abstractions.dll
+ Microsoft.Extensions.DependencyInjection.dll
+ Microsoft.Extensions.Diagnostics.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.dll
+ Microsoft.Extensions.Features.dll
+ Microsoft.Extensions.FileProviders.Abstractions.dll
+ Microsoft.Extensions.FileProviders.Composite.dll
+ Microsoft.Extensions.FileProviders.Embedded.dll
+ Microsoft.Extensions.FileProviders.Physical.dll
+ Microsoft.Extensions.FileSystemGlobbing.dll
+ Microsoft.Extensions.Hosting.Abstractions.dll
+ Microsoft.Extensions.Hosting.dll
+ Microsoft.Extensions.Http.dll
+ Microsoft.Extensions.Identity.Core.dll
+ Microsoft.Extensions.Identity.Stores.dll
+ Microsoft.Extensions.Localization.Abstractions.dll
+ Microsoft.Extensions.Localization.dll
+ Microsoft.Extensions.Logging.Abstractions.dll
+ Microsoft.Extensions.Logging.Configuration.dll
+ Microsoft.Extensions.Logging.Console.dll
+ Microsoft.Extensions.Logging.Debug.dll
+ Microsoft.Extensions.Logging.dll
+ Microsoft.Extensions.Logging.EventLog.dll
+ Microsoft.Extensions.Logging.EventSource.dll
+ Microsoft.Extensions.Logging.TraceSource.dll
+ Microsoft.Extensions.ObjectPool.dll
+ Microsoft.Extensions.Options.ConfigurationExtensions.dll
+ Microsoft.Extensions.Options.DataAnnotations.dll
+ Microsoft.Extensions.Options.dll
+ Microsoft.Extensions.Primitives.dll
+ Microsoft.Extensions.Validation.dll
+ Microsoft.Extensions.WebEncoders.dll
+ Microsoft.JSInterop.dll
+ Microsoft.Net.Http.Headers.dll
+ System.Diagnostics.EventLog.dll
+ System.Formats.Cbor.dll
+ System.Security.Cryptography.Xml.dll
+ System.Threading.RateLimiting.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.CSharp.dll
+ Microsoft.VisualBasic.Core.dll
+ Microsoft.VisualBasic.dll
+ Microsoft.Win32.Primitives.dll
+ Microsoft.Win32.Registry.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.Immutable.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Annotations.dll
+ System.ComponentModel.DataAnnotations.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Configuration.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.DataSetExtensions.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.DiagnosticSource.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Formats.Asn1.dll
+ System.Formats.Tar.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.Brotli.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.AccessControl.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipelines.dll
+ System.IO.Pipes.AccessControl.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.AsyncEnumerable.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.Http.Json.dll
+ System.Net.HttpListener.dll
+ System.Net.Mail.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Quic.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.ServerSentEvents.dll
+ System.Net.ServicePoint.dll
+ System.Net.Sockets.dll
+ System.Net.WebClient.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebProxy.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Metadata.dll
+ System.Reflection.Primitives.dll
+ System.Reflection.TypeExtensions.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.Unsafe.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.JavaScript.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Intrinsics.dll
+ System.Runtime.Loader.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.AccessControl.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Cng.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.OpenSsl.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.dll
+ System.Security.Principal.dll
+ System.Security.Principal.Windows.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.ServiceProcess.dll
+ System.Text.Encoding.CodePages.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.Encodings.Web.dll
+ System.Text.Json.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.AccessControl.dll
+ System.Threading.Channels.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.Dataflow.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.Transactions.Local.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Web.HttpUtility.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+ WindowsBase.dll
+<NUGET>/
+ azure.core.amqp/1.3.1/lib/netstandard2.0/Azure.Core.Amqp.dll
+ azure.core/1.47.1/lib/net8.0/Azure.Core.dll
+ azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
+ azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
+ azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
+ ecommerce.shared/2.14.0/lib/net10.0/ECommerce.Shared.dll
+ google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
+ grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
+ grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll
+ grpc.net.common/2.52.0/lib/net7.0/Grpc.Net.Common.dll
+ microsoft.aspnetcore.authentication.jwtbearer/10.0.5/lib/net10.0/Microsoft.AspNetCore.Authentication.JwtBearer.dll
+ microsoft.azure.amqp/2.6.7/lib/netstandard2.0/Microsoft.Azure.Amqp.dll
+ microsoft.bcl.asyncinterfaces/8.0.0/lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll
+ microsoft.bcl.cryptography/9.0.4/lib/net9.0/Microsoft.Bcl.Cryptography.dll
+ microsoft.data.sqlclient/6.1.1/ref/net9.0/Microsoft.Data.SqlClient.dll
+ microsoft.entityframeworkcore.abstractions/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Abstractions.dll
+ microsoft.entityframeworkcore.relational/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Relational.dll
+ microsoft.entityframeworkcore.sqlserver/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.SqlServer.dll
+ microsoft.entityframeworkcore/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.dll
+ microsoft.identity.client.extensions.msal/4.73.1/lib/net8.0/Microsoft.Identity.Client.Extensions.Msal.dll
+ microsoft.identity.client/4.73.1/lib/net8.0/Microsoft.Identity.Client.dll
+ microsoft.identitymodel.abstractions/8.0.1/lib/net9.0/Microsoft.IdentityModel.Abstractions.dll
+ microsoft.identitymodel.jsonwebtokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.JsonWebTokens.dll
+ microsoft.identitymodel.logging/8.0.1/lib/net9.0/Microsoft.IdentityModel.Logging.dll
+ microsoft.identitymodel.protocols.openidconnect/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.dll
+ microsoft.identitymodel.protocols/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.dll
+ microsoft.identitymodel.tokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.Tokens.dll
+ microsoft.openapi/1.6.14/lib/netstandard2.0/Microsoft.OpenApi.dll
+ microsoft.sqlserver.server/1.0.0/lib/netstandard2.0/Microsoft.SqlServer.Server.dll
+ opentelemetry.api.providerbuilderextensions/1.10.0/lib/net9.0/OpenTelemetry.Api.ProviderBuilderExtensions.dll
+ opentelemetry.api/1.10.0/lib/net9.0/OpenTelemetry.Api.dll
+ opentelemetry.exporter.console/1.9.0/lib/net8.0/OpenTelemetry.Exporter.Console.dll
+ opentelemetry.exporter.opentelemetryprotocol/1.9.0/lib/net8.0/OpenTelemetry.Exporter.OpenTelemetryProtocol.dll
+ opentelemetry.exporter.prometheus.aspnetcore/1.10.0-beta.1/lib/net9.0/OpenTelemetry.Exporter.Prometheus.AspNetCore.dll
+ opentelemetry.extensions.hosting/1.9.0/lib/net8.0/OpenTelemetry.Extensions.Hosting.dll
+ opentelemetry.instrumentation.aspnetcore/1.9.0/lib/net8.0/OpenTelemetry.Instrumentation.AspNetCore.dll
+ opentelemetry.instrumentation.sqlclient/1.9.0-beta.1/lib/net8.0/OpenTelemetry.Instrumentation.SqlClient.dll
+ opentelemetry.persistentstorage.abstractions/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.Abstractions.dll
+ opentelemetry.persistentstorage.filesystem/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.FileSystem.dll
+ opentelemetry/1.10.0/lib/net9.0/OpenTelemetry.dll
+ pipelines.sockets.unofficial/2.2.8/lib/net5.0/Pipelines.Sockets.Unofficial.dll
+ polly.core/8.6.6/lib/net8.0/Polly.Core.dll
+ rabbitmq.client/6.8.1/lib/netstandard2.0/RabbitMQ.Client.dll
+ stackexchange.redis/2.8.16/lib/net6.0/StackExchange.Redis.dll
+ swashbuckle.aspnetcore.swagger/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.Swagger.dll
+ swashbuckle.aspnetcore.swaggergen/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.dll
+ swashbuckle.aspnetcore.swaggerui/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.dll
+ system.clientmodel/1.5.1/lib/net8.0/System.ClientModel.dll
+ system.identitymodel.tokens.jwt/8.0.1/lib/net9.0/System.IdentityModel.Tokens.Jwt.dll
+ system.memory.data/8.0.1/lib/net8.0/System.Memory.Data.dll
+ system.security.cryptography.pkcs/9.0.4/lib/net9.0/System.Security.Cryptography.Pkcs.dll
+ system.security.cryptography.protecteddata/9.0.4/lib/net9.0/System.Security.Cryptography.ProtectedData.dll
+
+[analyzerReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.AspNetCore.App.Analyzers.dll
+ Microsoft.AspNetCore.App.CodeFixes.dll
+ Microsoft.AspNetCore.App.SourceGenerators.dll
+ Microsoft.AspNetCore.Components.Analyzers.dll
+ Microsoft.Extensions.Logging.Generators.dll
+ Microsoft.Extensions.Options.SourceGeneration.dll
+ Microsoft.Extensions.Validation.ValidationsGenerator.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.Interop.ComInterfaceGenerator.dll
+ Microsoft.Interop.JavaScript.JSImportGenerator.dll
+ Microsoft.Interop.LibraryImportGenerator.dll
+ Microsoft.Interop.SourceGeneration.dll
+ System.Text.Json.SourceGeneration.dll
+ System.Text.RegularExpressions.Generator.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk.Razor/source-generators/
+ Microsoft.AspNetCore.Razor.Utilities.Shared.dll
+ Microsoft.CodeAnalysis.Razor.Compiler.dll
+ Microsoft.Extensions.ObjectPool.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk.Web/analyzers/cs/
+ Microsoft.AspNetCore.Analyzers.dll
+ Microsoft.AspNetCore.Mvc.Analyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/
+ Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll
+ Microsoft.CodeAnalysis.NetAnalyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/codestyle/cs/
+ Microsoft.CodeAnalysis.CodeStyle.dll
+ Microsoft.CodeAnalysis.CodeStyle.Fixes.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.dll
+<NUGET>/microsoft.codeanalysis.analyzers/3.11.0/analyzers/dotnet/cs/
+ Microsoft.CodeAnalysis.Analyzers.dll
+ Microsoft.CodeAnalysis.CSharp.Analyzers.dll
+<NUGET>/
+ microsoft.entityframeworkcore.analyzers/10.0.5/analyzers/dotnet/cs/Microsoft.EntityFrameworkCore.Analyzers.dll
+ system.clientmodel/1.5.1/analyzers/dotnet/cs/System.ClientModel.SourceGeneration.dll
+
+[analyzerConfigFiles]
+../../.editorconfig
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_10_recommended.globalconfig
+obj/Debug/net10.0/Product.Service.GeneratedMSBuildEditorConfig.editorconfig

--- a/product-microservice/Product.Tests/Product.Tests.csproj.lscache
+++ b/product-microservice/Product.Tests/Product.Tests.csproj.lscache
@@ -1,0 +1,491 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[properties]
+AssemblyName=Product.Tests
+CommandLineArgsForDesignTimeEvaluation=-langversion:14.0 -define:TRACE
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=14.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=Product.Tests
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../../MicroservicesInDotNet.sln
+TargetFrameworkIdentifier=.NETCoreApp
+TargetPath=<PATH>bin/Debug/net10.0/Product.Tests.dll
+TargetRefPath=<PATH>obj/Debug/net10.0/ref/Product.Tests.dll
+TemporaryDependencyNodeTargetIdentifier=net10.0
+
+[commandLineArguments]
+/noconfig
+/unsafe-
+/checked-
+/nowarn:NU1603,NU1902,NU1903,NU5104,CA1711,CA1707,CA1716,1701,1702,8002
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/warn:10
+/define:TRACE;DEBUG;NET;NET10_0;NETCOREAPP;NET5_0_OR_GREATER;NET6_0_OR_GREATER;NET7_0_OR_GREATER;NET8_0_OR_GREATER;NET9_0_OR_GREATER;NET10_0_OR_GREATER;NETCOREAPP1_0_OR_GREATER;NETCOREAPP1_1_OR_GREATER;NETCOREAPP2_0_OR_GREATER;NETCOREAPP2_1_OR_GREATER;NETCOREAPP2_2_OR_GREATER;NETCOREAPP3_0_OR_GREATER;NETCOREAPP3_1_OR_GREATER
+/highentropyva+
+/nullable:enable
+/features:"InterceptorsNamespaces=;Microsoft.Extensions.Validation.Generated"
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\net10.0\Product.Tests.dll
+/refout:obj\Debug\net10.0\refint\Product.Tests.dll
+/target:exe
+/warnaserror+
+/utf8output
+/deterministic+
+/langversion:14.0
+/warnaserror+:NU1605,SYSLIB0011
+
+[sourceFiles]
+<NUGET>/microsoft.net.test.sdk/17.14.1/build/net8.0/Microsoft.NET.Test.Sdk.Program.cs
+Api/
+ HealthChecksTests.cs
+ InternalOutboxEndpointsTests.cs
+ MessagingProviderBootTests.cs
+ ObservabilityTests.cs
+ ProductApiTests.cs
+Authentication/TestAuthHandler.cs
+IntegrationTestBase.cs
+obj/Debug/net10.0/
+ .NETCoreApp,Version=v10.0.AssemblyAttributes.cs
+ Product.Tests.AssemblyInfo.cs
+ Product.Tests.GlobalUsings.g.cs
+ProductWebApplicationFactory.cs
+Qa/ProductQaSeedTests.cs
+
+[metadataReferences]
+../Product.Service/obj/Debug/net10.0/ref/Product.Service.dll
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.AspNetCore.Antiforgery.dll
+ Microsoft.AspNetCore.Authentication.Abstractions.dll
+ Microsoft.AspNetCore.Authentication.BearerToken.dll
+ Microsoft.AspNetCore.Authentication.Cookies.dll
+ Microsoft.AspNetCore.Authentication.Core.dll
+ Microsoft.AspNetCore.Authentication.dll
+ Microsoft.AspNetCore.Authentication.OAuth.dll
+ Microsoft.AspNetCore.Authorization.dll
+ Microsoft.AspNetCore.Authorization.Policy.dll
+ Microsoft.AspNetCore.Components.Authorization.dll
+ Microsoft.AspNetCore.Components.dll
+ Microsoft.AspNetCore.Components.Endpoints.dll
+ Microsoft.AspNetCore.Components.Forms.dll
+ Microsoft.AspNetCore.Components.Server.dll
+ Microsoft.AspNetCore.Components.Web.dll
+ Microsoft.AspNetCore.Connections.Abstractions.dll
+ Microsoft.AspNetCore.CookiePolicy.dll
+ Microsoft.AspNetCore.Cors.dll
+ Microsoft.AspNetCore.Cryptography.Internal.dll
+ Microsoft.AspNetCore.Cryptography.KeyDerivation.dll
+ Microsoft.AspNetCore.DataProtection.Abstractions.dll
+ Microsoft.AspNetCore.DataProtection.dll
+ Microsoft.AspNetCore.DataProtection.Extensions.dll
+ Microsoft.AspNetCore.Diagnostics.Abstractions.dll
+ Microsoft.AspNetCore.Diagnostics.dll
+ Microsoft.AspNetCore.Diagnostics.HealthChecks.dll
+ Microsoft.AspNetCore.dll
+ Microsoft.AspNetCore.HostFiltering.dll
+ Microsoft.AspNetCore.Hosting.Abstractions.dll
+ Microsoft.AspNetCore.Hosting.dll
+ Microsoft.AspNetCore.Hosting.Server.Abstractions.dll
+ Microsoft.AspNetCore.Html.Abstractions.dll
+ Microsoft.AspNetCore.Http.Abstractions.dll
+ Microsoft.AspNetCore.Http.Connections.Common.dll
+ Microsoft.AspNetCore.Http.Connections.dll
+ Microsoft.AspNetCore.Http.dll
+ Microsoft.AspNetCore.Http.Extensions.dll
+ Microsoft.AspNetCore.Http.Features.dll
+ Microsoft.AspNetCore.Http.Results.dll
+ Microsoft.AspNetCore.HttpLogging.dll
+ Microsoft.AspNetCore.HttpOverrides.dll
+ Microsoft.AspNetCore.HttpsPolicy.dll
+ Microsoft.AspNetCore.Identity.dll
+ Microsoft.AspNetCore.Localization.dll
+ Microsoft.AspNetCore.Localization.Routing.dll
+ Microsoft.AspNetCore.Metadata.dll
+ Microsoft.AspNetCore.Mvc.Abstractions.dll
+ Microsoft.AspNetCore.Mvc.ApiExplorer.dll
+ Microsoft.AspNetCore.Mvc.Core.dll
+ Microsoft.AspNetCore.Mvc.Cors.dll
+ Microsoft.AspNetCore.Mvc.DataAnnotations.dll
+ Microsoft.AspNetCore.Mvc.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Json.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Xml.dll
+ Microsoft.AspNetCore.Mvc.Localization.dll
+ Microsoft.AspNetCore.Mvc.Razor.dll
+ Microsoft.AspNetCore.Mvc.RazorPages.dll
+ Microsoft.AspNetCore.Mvc.TagHelpers.dll
+ Microsoft.AspNetCore.Mvc.ViewFeatures.dll
+ Microsoft.AspNetCore.OutputCaching.dll
+ Microsoft.AspNetCore.RateLimiting.dll
+ Microsoft.AspNetCore.Razor.dll
+ Microsoft.AspNetCore.Razor.Runtime.dll
+ Microsoft.AspNetCore.RequestDecompression.dll
+ Microsoft.AspNetCore.ResponseCaching.Abstractions.dll
+ Microsoft.AspNetCore.ResponseCaching.dll
+ Microsoft.AspNetCore.ResponseCompression.dll
+ Microsoft.AspNetCore.Rewrite.dll
+ Microsoft.AspNetCore.Routing.Abstractions.dll
+ Microsoft.AspNetCore.Routing.dll
+ Microsoft.AspNetCore.Server.HttpSys.dll
+ Microsoft.AspNetCore.Server.IIS.dll
+ Microsoft.AspNetCore.Server.IISIntegration.dll
+ Microsoft.AspNetCore.Server.Kestrel.Core.dll
+ Microsoft.AspNetCore.Server.Kestrel.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll
+ Microsoft.AspNetCore.Session.dll
+ Microsoft.AspNetCore.SignalR.Common.dll
+ Microsoft.AspNetCore.SignalR.Core.dll
+ Microsoft.AspNetCore.SignalR.dll
+ Microsoft.AspNetCore.SignalR.Protocols.Json.dll
+ Microsoft.AspNetCore.StaticAssets.dll
+ Microsoft.AspNetCore.StaticFiles.dll
+ Microsoft.AspNetCore.WebSockets.dll
+ Microsoft.AspNetCore.WebUtilities.dll
+ Microsoft.Extensions.Caching.Abstractions.dll
+ Microsoft.Extensions.Caching.Memory.dll
+ Microsoft.Extensions.Configuration.Abstractions.dll
+ Microsoft.Extensions.Configuration.Binder.dll
+ Microsoft.Extensions.Configuration.CommandLine.dll
+ Microsoft.Extensions.Configuration.dll
+ Microsoft.Extensions.Configuration.EnvironmentVariables.dll
+ Microsoft.Extensions.Configuration.FileExtensions.dll
+ Microsoft.Extensions.Configuration.Ini.dll
+ Microsoft.Extensions.Configuration.Json.dll
+ Microsoft.Extensions.Configuration.KeyPerFile.dll
+ Microsoft.Extensions.Configuration.UserSecrets.dll
+ Microsoft.Extensions.Configuration.Xml.dll
+ Microsoft.Extensions.DependencyInjection.Abstractions.dll
+ Microsoft.Extensions.DependencyInjection.dll
+ Microsoft.Extensions.Diagnostics.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.dll
+ Microsoft.Extensions.Features.dll
+ Microsoft.Extensions.FileProviders.Abstractions.dll
+ Microsoft.Extensions.FileProviders.Composite.dll
+ Microsoft.Extensions.FileProviders.Embedded.dll
+ Microsoft.Extensions.FileProviders.Physical.dll
+ Microsoft.Extensions.FileSystemGlobbing.dll
+ Microsoft.Extensions.Hosting.Abstractions.dll
+ Microsoft.Extensions.Hosting.dll
+ Microsoft.Extensions.Http.dll
+ Microsoft.Extensions.Identity.Core.dll
+ Microsoft.Extensions.Identity.Stores.dll
+ Microsoft.Extensions.Localization.Abstractions.dll
+ Microsoft.Extensions.Localization.dll
+ Microsoft.Extensions.Logging.Abstractions.dll
+ Microsoft.Extensions.Logging.Configuration.dll
+ Microsoft.Extensions.Logging.Console.dll
+ Microsoft.Extensions.Logging.Debug.dll
+ Microsoft.Extensions.Logging.dll
+ Microsoft.Extensions.Logging.EventLog.dll
+ Microsoft.Extensions.Logging.EventSource.dll
+ Microsoft.Extensions.Logging.TraceSource.dll
+ Microsoft.Extensions.ObjectPool.dll
+ Microsoft.Extensions.Options.ConfigurationExtensions.dll
+ Microsoft.Extensions.Options.DataAnnotations.dll
+ Microsoft.Extensions.Options.dll
+ Microsoft.Extensions.Primitives.dll
+ Microsoft.Extensions.Validation.dll
+ Microsoft.Extensions.WebEncoders.dll
+ Microsoft.JSInterop.dll
+ Microsoft.Net.Http.Headers.dll
+ System.Diagnostics.EventLog.dll
+ System.Formats.Cbor.dll
+ System.Security.Cryptography.Xml.dll
+ System.Threading.RateLimiting.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.CSharp.dll
+ Microsoft.VisualBasic.Core.dll
+ Microsoft.VisualBasic.dll
+ Microsoft.Win32.Primitives.dll
+ Microsoft.Win32.Registry.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.Immutable.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Annotations.dll
+ System.ComponentModel.DataAnnotations.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Configuration.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.DataSetExtensions.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.DiagnosticSource.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Formats.Asn1.dll
+ System.Formats.Tar.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.Brotli.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.AccessControl.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipelines.dll
+ System.IO.Pipes.AccessControl.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.AsyncEnumerable.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.Http.Json.dll
+ System.Net.HttpListener.dll
+ System.Net.Mail.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Quic.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.ServerSentEvents.dll
+ System.Net.ServicePoint.dll
+ System.Net.Sockets.dll
+ System.Net.WebClient.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebProxy.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Metadata.dll
+ System.Reflection.Primitives.dll
+ System.Reflection.TypeExtensions.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.Unsafe.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.JavaScript.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Intrinsics.dll
+ System.Runtime.Loader.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.AccessControl.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Cng.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.OpenSsl.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.dll
+ System.Security.Principal.dll
+ System.Security.Principal.Windows.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.ServiceProcess.dll
+ System.Text.Encoding.CodePages.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.Encodings.Web.dll
+ System.Text.Json.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.AccessControl.dll
+ System.Threading.Channels.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.Dataflow.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.Transactions.Local.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Web.HttpUtility.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+ WindowsBase.dll
+<NUGET>/
+ azure.core.amqp/1.3.1/lib/netstandard2.0/Azure.Core.Amqp.dll
+ azure.core/1.47.1/lib/net8.0/Azure.Core.dll
+ azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
+ azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
+ azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
+ ecommerce.shared/2.14.0/lib/net10.0/ECommerce.Shared.dll
+ google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
+ grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
+ grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll
+ grpc.net.common/2.52.0/lib/net7.0/Grpc.Net.Common.dll
+ microsoft.aspnetcore.authentication.jwtbearer/10.0.5/lib/net10.0/Microsoft.AspNetCore.Authentication.JwtBearer.dll
+ microsoft.aspnetcore.mvc.testing/10.0.5/lib/net10.0/Microsoft.AspNetCore.Mvc.Testing.dll
+ microsoft.aspnetcore.testhost/10.0.5/lib/net10.0/Microsoft.AspNetCore.TestHost.dll
+ microsoft.azure.amqp/2.6.7/lib/netstandard2.0/Microsoft.Azure.Amqp.dll
+ microsoft.bcl.asyncinterfaces/8.0.0/lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll
+ microsoft.bcl.cryptography/9.0.4/lib/net9.0/Microsoft.Bcl.Cryptography.dll
+ microsoft.codecoverage/17.14.1/lib/net8.0/Microsoft.VisualStudio.CodeCoverage.Shim.dll
+ microsoft.data.sqlclient/6.1.1/ref/net9.0/Microsoft.Data.SqlClient.dll
+ microsoft.entityframeworkcore.abstractions/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Abstractions.dll
+ microsoft.entityframeworkcore.inmemory/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.InMemory.dll
+ microsoft.entityframeworkcore.relational/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Relational.dll
+ microsoft.entityframeworkcore.sqlserver/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.SqlServer.dll
+ microsoft.entityframeworkcore/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.dll
+ microsoft.extensions.dependencymodel/10.0.5/lib/net10.0/Microsoft.Extensions.DependencyModel.dll
+ microsoft.identity.client.extensions.msal/4.73.1/lib/net8.0/Microsoft.Identity.Client.Extensions.Msal.dll
+ microsoft.identity.client/4.73.1/lib/net8.0/Microsoft.Identity.Client.dll
+ microsoft.identitymodel.abstractions/8.0.1/lib/net9.0/Microsoft.IdentityModel.Abstractions.dll
+ microsoft.identitymodel.jsonwebtokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.JsonWebTokens.dll
+ microsoft.identitymodel.logging/8.0.1/lib/net9.0/Microsoft.IdentityModel.Logging.dll
+ microsoft.identitymodel.protocols.openidconnect/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.dll
+ microsoft.identitymodel.protocols/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.dll
+ microsoft.identitymodel.tokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.Tokens.dll
+ microsoft.openapi/1.6.14/lib/netstandard2.0/Microsoft.OpenApi.dll
+ microsoft.sqlserver.server/1.0.0/lib/netstandard2.0/Microsoft.SqlServer.Server.dll
+ microsoft.testplatform.testhost/17.14.1/lib/net8.0/
+  Microsoft.TestPlatform.CommunicationUtilities.dll
+  Microsoft.TestPlatform.CoreUtilities.dll
+  Microsoft.TestPlatform.CrossPlatEngine.dll
+  Microsoft.TestPlatform.PlatformAbstractions.dll
+  Microsoft.TestPlatform.Utilities.dll
+  Microsoft.VisualStudio.TestPlatform.Common.dll
+  Microsoft.VisualStudio.TestPlatform.ObjectModel.dll
+  testhost.dll
+ newtonsoft.json/13.0.3/lib/net6.0/Newtonsoft.Json.dll
+ opentelemetry.api.providerbuilderextensions/1.10.0/lib/net9.0/OpenTelemetry.Api.ProviderBuilderExtensions.dll
+ opentelemetry.api/1.10.0/lib/net9.0/OpenTelemetry.Api.dll
+ opentelemetry.exporter.console/1.9.0/lib/net8.0/OpenTelemetry.Exporter.Console.dll
+ opentelemetry.exporter.opentelemetryprotocol/1.9.0/lib/net8.0/OpenTelemetry.Exporter.OpenTelemetryProtocol.dll
+ opentelemetry.exporter.prometheus.aspnetcore/1.10.0-beta.1/lib/net9.0/OpenTelemetry.Exporter.Prometheus.AspNetCore.dll
+ opentelemetry.extensions.hosting/1.9.0/lib/net8.0/OpenTelemetry.Extensions.Hosting.dll
+ opentelemetry.instrumentation.aspnetcore/1.9.0/lib/net8.0/OpenTelemetry.Instrumentation.AspNetCore.dll
+ opentelemetry.instrumentation.sqlclient/1.9.0-beta.1/lib/net8.0/OpenTelemetry.Instrumentation.SqlClient.dll
+ opentelemetry.persistentstorage.abstractions/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.Abstractions.dll
+ opentelemetry.persistentstorage.filesystem/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.FileSystem.dll
+ opentelemetry/1.10.0/lib/net9.0/OpenTelemetry.dll
+ pipelines.sockets.unofficial/2.2.8/lib/net5.0/Pipelines.Sockets.Unofficial.dll
+ polly.core/8.6.6/lib/net8.0/Polly.Core.dll
+ rabbitmq.client/6.8.1/lib/netstandard2.0/RabbitMQ.Client.dll
+ stackexchange.redis/2.8.16/lib/net6.0/StackExchange.Redis.dll
+ swashbuckle.aspnetcore.swagger/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.Swagger.dll
+ swashbuckle.aspnetcore.swaggergen/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.dll
+ swashbuckle.aspnetcore.swaggerui/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.dll
+ system.clientmodel/1.5.1/lib/net8.0/System.ClientModel.dll
+ system.identitymodel.tokens.jwt/8.0.1/lib/net9.0/System.IdentityModel.Tokens.Jwt.dll
+ system.memory.data/8.0.1/lib/net8.0/System.Memory.Data.dll
+ system.security.cryptography.pkcs/9.0.4/lib/net9.0/System.Security.Cryptography.Pkcs.dll
+ system.security.cryptography.protecteddata/9.0.4/lib/net9.0/System.Security.Cryptography.ProtectedData.dll
+ xunit.abstractions/2.0.3/lib/netstandard2.0/xunit.abstractions.dll
+ xunit.assert/2.9.3/lib/net6.0/xunit.assert.dll
+ xunit.extensibility.core/2.9.3/lib/netstandard1.1/xunit.core.dll
+ xunit.extensibility.execution/2.9.3/lib/netstandard1.1/xunit.execution.dotnet.dll
+
+[analyzerReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.AspNetCore.App.Analyzers.dll
+ Microsoft.AspNetCore.App.CodeFixes.dll
+ Microsoft.AspNetCore.App.SourceGenerators.dll
+ Microsoft.AspNetCore.Components.Analyzers.dll
+ Microsoft.Extensions.Logging.Generators.dll
+ Microsoft.Extensions.Options.SourceGeneration.dll
+ Microsoft.Extensions.Validation.ValidationsGenerator.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.Interop.ComInterfaceGenerator.dll
+ Microsoft.Interop.JavaScript.JSImportGenerator.dll
+ Microsoft.Interop.LibraryImportGenerator.dll
+ Microsoft.Interop.SourceGeneration.dll
+ System.Text.Json.SourceGeneration.dll
+ System.Text.RegularExpressions.Generator.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/
+ Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll
+ Microsoft.CodeAnalysis.NetAnalyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/codestyle/cs/
+ Microsoft.CodeAnalysis.CodeStyle.dll
+ Microsoft.CodeAnalysis.CodeStyle.Fixes.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.dll
+<NUGET>/
+ microsoft.entityframeworkcore.analyzers/10.0.5/analyzers/dotnet/cs/Microsoft.EntityFrameworkCore.Analyzers.dll
+ system.clientmodel/1.5.1/analyzers/dotnet/cs/System.ClientModel.SourceGeneration.dll
+ xunit.analyzers/1.18.0/analyzers/dotnet/cs/
+  xunit.analyzers.dll
+  xunit.analyzers.fixes.dll
+
+[analyzerConfigFiles]
+../../.editorconfig
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_10_recommended.globalconfig
+obj/Debug/net10.0/Product.Tests.GeneratedMSBuildEditorConfig.editorconfig

--- a/shared-libs/ECommerce.Shared.Tests/ECommerce.Shared.Tests.csproj.lscache
+++ b/shared-libs/ECommerce.Shared.Tests/ECommerce.Shared.Tests.csproj.lscache
@@ -74,6 +74,7 @@ obj/Debug/net10.0/
  ECommerce.Shared.Tests.GlobalUsings.g.cs
 OpenTelemetryOptionsTests.cs
 OutboxFailureTrackingTests.cs
+OutboxPlatformObservabilityTests.cs
 OutboxUnitOfWorkTests.cs
 Qa/QaSeedingExtensionsTests.cs
 RabbitMqDeadLetterIntegrationTests.cs

--- a/shared-libs/ECommerce.Shared.Tests/ECommerce.Shared.Tests.csproj.lscache
+++ b/shared-libs/ECommerce.Shared.Tests/ECommerce.Shared.Tests.csproj.lscache
@@ -1,0 +1,509 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[properties]
+AssemblyName=ECommerce.Shared.Tests
+CommandLineArgsForDesignTimeEvaluation=-langversion:14.0 -define:TRACE
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=14.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=ECommerce.Shared.Tests
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../../MicroservicesInDotNet.sln
+TargetFrameworkIdentifier=.NETCoreApp
+TargetPath=<PATH>bin/Debug/net10.0/ECommerce.Shared.Tests.dll
+TargetRefPath=<PATH>obj/Debug/net10.0/ref/ECommerce.Shared.Tests.dll
+TemporaryDependencyNodeTargetIdentifier=net10.0
+
+[commandLineArguments]
+/noconfig
+/unsafe-
+/checked-
+/nowarn:NU1603,NU1902,NU1903,NU5104,CA1711,CA1707,CA1716,1701,1702,8002
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/warn:10
+/define:TRACE;DEBUG;NET;NET10_0;NETCOREAPP;NET5_0_OR_GREATER;NET6_0_OR_GREATER;NET7_0_OR_GREATER;NET8_0_OR_GREATER;NET9_0_OR_GREATER;NET10_0_OR_GREATER;NETCOREAPP1_0_OR_GREATER;NETCOREAPP1_1_OR_GREATER;NETCOREAPP2_0_OR_GREATER;NETCOREAPP2_1_OR_GREATER;NETCOREAPP2_2_OR_GREATER;NETCOREAPP3_0_OR_GREATER;NETCOREAPP3_1_OR_GREATER
+/highentropyva+
+/nullable:enable
+/features:"InterceptorsNamespaces=;Microsoft.Extensions.Validation.Generated"
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\net10.0\ECommerce.Shared.Tests.dll
+/refout:obj\Debug\net10.0\refint\ECommerce.Shared.Tests.dll
+/target:exe
+/warnaserror+
+/utf8output
+/deterministic+
+/langversion:14.0
+/warnaserror+:NU1605,SYSLIB0011
+
+[sourceFiles]
+<NUGET>/microsoft.net.test.sdk/17.14.1/build/net8.0/Microsoft.NET.Test.Sdk.Program.cs
+AsbEmulatorComposeProfileTests.cs
+AzureServiceBusDeadLetterCaptureTests.cs
+AzureServiceBusDeadLetterPublisherTests.cs
+AzureServiceBusEventBusTests.cs
+AzureServiceBusHostedServiceTests.cs
+AzureServiceBusTopologyProvisioningPolicyTests.cs
+DeadLetterDbContextOriginFilterTests.cs
+DeadLetterDiscarderTests.cs
+DeadLetterPlatformObservabilityTests.cs
+DeadLetterReplayerTests.cs
+DlqMetricAttributionTests.cs
+DualValidatorTests.cs
+MessagingProviderSwitchTests.cs
+obj/Debug/net10.0/
+ .NETCoreApp,Version=v10.0.AssemblyAttributes.cs
+ ECommerce.Shared.Tests.AssemblyInfo.cs
+ ECommerce.Shared.Tests.GlobalUsings.g.cs
+OpenTelemetryOptionsTests.cs
+OutboxFailureTrackingTests.cs
+OutboxUnitOfWorkTests.cs
+Qa/QaSeedingExtensionsTests.cs
+RabbitMqDeadLetterIntegrationTests.cs
+RequireServicePolicyTests.cs
+
+[metadataReferences]
+../ECommerce.Shared/obj/Debug/net10.0/ref/ECommerce.Shared.dll
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.AspNetCore.Antiforgery.dll
+ Microsoft.AspNetCore.Authentication.Abstractions.dll
+ Microsoft.AspNetCore.Authentication.BearerToken.dll
+ Microsoft.AspNetCore.Authentication.Cookies.dll
+ Microsoft.AspNetCore.Authentication.Core.dll
+ Microsoft.AspNetCore.Authentication.dll
+ Microsoft.AspNetCore.Authentication.OAuth.dll
+ Microsoft.AspNetCore.Authorization.dll
+ Microsoft.AspNetCore.Authorization.Policy.dll
+ Microsoft.AspNetCore.Components.Authorization.dll
+ Microsoft.AspNetCore.Components.dll
+ Microsoft.AspNetCore.Components.Endpoints.dll
+ Microsoft.AspNetCore.Components.Forms.dll
+ Microsoft.AspNetCore.Components.Server.dll
+ Microsoft.AspNetCore.Components.Web.dll
+ Microsoft.AspNetCore.Connections.Abstractions.dll
+ Microsoft.AspNetCore.CookiePolicy.dll
+ Microsoft.AspNetCore.Cors.dll
+ Microsoft.AspNetCore.Cryptography.Internal.dll
+ Microsoft.AspNetCore.Cryptography.KeyDerivation.dll
+ Microsoft.AspNetCore.DataProtection.Abstractions.dll
+ Microsoft.AspNetCore.DataProtection.dll
+ Microsoft.AspNetCore.DataProtection.Extensions.dll
+ Microsoft.AspNetCore.Diagnostics.Abstractions.dll
+ Microsoft.AspNetCore.Diagnostics.dll
+ Microsoft.AspNetCore.Diagnostics.HealthChecks.dll
+ Microsoft.AspNetCore.dll
+ Microsoft.AspNetCore.HostFiltering.dll
+ Microsoft.AspNetCore.Hosting.Abstractions.dll
+ Microsoft.AspNetCore.Hosting.dll
+ Microsoft.AspNetCore.Hosting.Server.Abstractions.dll
+ Microsoft.AspNetCore.Html.Abstractions.dll
+ Microsoft.AspNetCore.Http.Abstractions.dll
+ Microsoft.AspNetCore.Http.Connections.Common.dll
+ Microsoft.AspNetCore.Http.Connections.dll
+ Microsoft.AspNetCore.Http.dll
+ Microsoft.AspNetCore.Http.Extensions.dll
+ Microsoft.AspNetCore.Http.Features.dll
+ Microsoft.AspNetCore.Http.Results.dll
+ Microsoft.AspNetCore.HttpLogging.dll
+ Microsoft.AspNetCore.HttpOverrides.dll
+ Microsoft.AspNetCore.HttpsPolicy.dll
+ Microsoft.AspNetCore.Identity.dll
+ Microsoft.AspNetCore.Localization.dll
+ Microsoft.AspNetCore.Localization.Routing.dll
+ Microsoft.AspNetCore.Metadata.dll
+ Microsoft.AspNetCore.Mvc.Abstractions.dll
+ Microsoft.AspNetCore.Mvc.ApiExplorer.dll
+ Microsoft.AspNetCore.Mvc.Core.dll
+ Microsoft.AspNetCore.Mvc.Cors.dll
+ Microsoft.AspNetCore.Mvc.DataAnnotations.dll
+ Microsoft.AspNetCore.Mvc.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Json.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Xml.dll
+ Microsoft.AspNetCore.Mvc.Localization.dll
+ Microsoft.AspNetCore.Mvc.Razor.dll
+ Microsoft.AspNetCore.Mvc.RazorPages.dll
+ Microsoft.AspNetCore.Mvc.TagHelpers.dll
+ Microsoft.AspNetCore.Mvc.ViewFeatures.dll
+ Microsoft.AspNetCore.OutputCaching.dll
+ Microsoft.AspNetCore.RateLimiting.dll
+ Microsoft.AspNetCore.Razor.dll
+ Microsoft.AspNetCore.Razor.Runtime.dll
+ Microsoft.AspNetCore.RequestDecompression.dll
+ Microsoft.AspNetCore.ResponseCaching.Abstractions.dll
+ Microsoft.AspNetCore.ResponseCaching.dll
+ Microsoft.AspNetCore.ResponseCompression.dll
+ Microsoft.AspNetCore.Rewrite.dll
+ Microsoft.AspNetCore.Routing.Abstractions.dll
+ Microsoft.AspNetCore.Routing.dll
+ Microsoft.AspNetCore.Server.HttpSys.dll
+ Microsoft.AspNetCore.Server.IIS.dll
+ Microsoft.AspNetCore.Server.IISIntegration.dll
+ Microsoft.AspNetCore.Server.Kestrel.Core.dll
+ Microsoft.AspNetCore.Server.Kestrel.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll
+ Microsoft.AspNetCore.Session.dll
+ Microsoft.AspNetCore.SignalR.Common.dll
+ Microsoft.AspNetCore.SignalR.Core.dll
+ Microsoft.AspNetCore.SignalR.dll
+ Microsoft.AspNetCore.SignalR.Protocols.Json.dll
+ Microsoft.AspNetCore.StaticAssets.dll
+ Microsoft.AspNetCore.StaticFiles.dll
+ Microsoft.AspNetCore.WebSockets.dll
+ Microsoft.AspNetCore.WebUtilities.dll
+ Microsoft.Extensions.Caching.Abstractions.dll
+ Microsoft.Extensions.Caching.Memory.dll
+ Microsoft.Extensions.Configuration.Abstractions.dll
+ Microsoft.Extensions.Configuration.Binder.dll
+ Microsoft.Extensions.Configuration.CommandLine.dll
+ Microsoft.Extensions.Configuration.dll
+ Microsoft.Extensions.Configuration.EnvironmentVariables.dll
+ Microsoft.Extensions.Configuration.FileExtensions.dll
+ Microsoft.Extensions.Configuration.Ini.dll
+ Microsoft.Extensions.Configuration.Json.dll
+ Microsoft.Extensions.Configuration.KeyPerFile.dll
+ Microsoft.Extensions.Configuration.UserSecrets.dll
+ Microsoft.Extensions.Configuration.Xml.dll
+ Microsoft.Extensions.DependencyInjection.Abstractions.dll
+ Microsoft.Extensions.DependencyInjection.dll
+ Microsoft.Extensions.Diagnostics.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.dll
+ Microsoft.Extensions.Features.dll
+ Microsoft.Extensions.FileProviders.Abstractions.dll
+ Microsoft.Extensions.FileProviders.Composite.dll
+ Microsoft.Extensions.FileProviders.Embedded.dll
+ Microsoft.Extensions.FileProviders.Physical.dll
+ Microsoft.Extensions.FileSystemGlobbing.dll
+ Microsoft.Extensions.Hosting.Abstractions.dll
+ Microsoft.Extensions.Hosting.dll
+ Microsoft.Extensions.Http.dll
+ Microsoft.Extensions.Identity.Core.dll
+ Microsoft.Extensions.Identity.Stores.dll
+ Microsoft.Extensions.Localization.Abstractions.dll
+ Microsoft.Extensions.Localization.dll
+ Microsoft.Extensions.Logging.Abstractions.dll
+ Microsoft.Extensions.Logging.Configuration.dll
+ Microsoft.Extensions.Logging.Console.dll
+ Microsoft.Extensions.Logging.Debug.dll
+ Microsoft.Extensions.Logging.dll
+ Microsoft.Extensions.Logging.EventLog.dll
+ Microsoft.Extensions.Logging.EventSource.dll
+ Microsoft.Extensions.Logging.TraceSource.dll
+ Microsoft.Extensions.ObjectPool.dll
+ Microsoft.Extensions.Options.ConfigurationExtensions.dll
+ Microsoft.Extensions.Options.DataAnnotations.dll
+ Microsoft.Extensions.Options.dll
+ Microsoft.Extensions.Primitives.dll
+ Microsoft.Extensions.Validation.dll
+ Microsoft.Extensions.WebEncoders.dll
+ Microsoft.JSInterop.dll
+ Microsoft.Net.Http.Headers.dll
+ System.Diagnostics.EventLog.dll
+ System.Formats.Cbor.dll
+ System.Security.Cryptography.Xml.dll
+ System.Threading.RateLimiting.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.CSharp.dll
+ Microsoft.VisualBasic.Core.dll
+ Microsoft.VisualBasic.dll
+ Microsoft.Win32.Primitives.dll
+ Microsoft.Win32.Registry.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.Immutable.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Annotations.dll
+ System.ComponentModel.DataAnnotations.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Configuration.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.DataSetExtensions.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.DiagnosticSource.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Formats.Asn1.dll
+ System.Formats.Tar.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.Brotli.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.AccessControl.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipelines.dll
+ System.IO.Pipes.AccessControl.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.AsyncEnumerable.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.Http.Json.dll
+ System.Net.HttpListener.dll
+ System.Net.Mail.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Quic.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.ServerSentEvents.dll
+ System.Net.ServicePoint.dll
+ System.Net.Sockets.dll
+ System.Net.WebClient.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebProxy.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Metadata.dll
+ System.Reflection.Primitives.dll
+ System.Reflection.TypeExtensions.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.Unsafe.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.JavaScript.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Intrinsics.dll
+ System.Runtime.Loader.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.AccessControl.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Cng.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.OpenSsl.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.dll
+ System.Security.Principal.dll
+ System.Security.Principal.Windows.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.ServiceProcess.dll
+ System.Text.Encoding.CodePages.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.Encodings.Web.dll
+ System.Text.Json.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.AccessControl.dll
+ System.Threading.Channels.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.Dataflow.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.Transactions.Local.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Web.HttpUtility.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+ WindowsBase.dll
+<NUGET>/
+ azure.core.amqp/1.3.1/lib/netstandard2.0/Azure.Core.Amqp.dll
+ azure.core/1.47.1/lib/net8.0/Azure.Core.dll
+ azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
+ azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
+ azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
+ bouncycastle.cryptography/2.6.2/lib/net6.0/BouncyCastle.Cryptography.dll
+ castle.core/5.1.1/lib/net6.0/Castle.Core.dll
+ docker.dotnet.enhanced.x509/3.131.1/lib/net10.0/Docker.DotNet.X509.dll
+ docker.dotnet.enhanced/3.131.1/lib/net10.0/Docker.DotNet.dll
+ google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
+ grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
+ grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll
+ grpc.net.common/2.52.0/lib/net7.0/Grpc.Net.Common.dll
+ microsoft.aspnetcore.authentication.jwtbearer/10.0.5/lib/net10.0/Microsoft.AspNetCore.Authentication.JwtBearer.dll
+ microsoft.aspnetcore.mvc.testing/10.0.5/lib/net10.0/Microsoft.AspNetCore.Mvc.Testing.dll
+ microsoft.aspnetcore.testhost/10.0.5/lib/net10.0/Microsoft.AspNetCore.TestHost.dll
+ microsoft.azure.amqp/2.6.7/lib/netstandard2.0/Microsoft.Azure.Amqp.dll
+ microsoft.bcl.asyncinterfaces/8.0.0/lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll
+ microsoft.bcl.cryptography/9.0.4/lib/net9.0/Microsoft.Bcl.Cryptography.dll
+ microsoft.codecoverage/17.14.1/lib/net8.0/Microsoft.VisualStudio.CodeCoverage.Shim.dll
+ microsoft.data.sqlclient/6.1.1/ref/net9.0/Microsoft.Data.SqlClient.dll
+ microsoft.entityframeworkcore.abstractions/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Abstractions.dll
+ microsoft.entityframeworkcore.inmemory/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.InMemory.dll
+ microsoft.entityframeworkcore.relational/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Relational.dll
+ microsoft.entityframeworkcore.sqlserver/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.SqlServer.dll
+ microsoft.entityframeworkcore/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.dll
+ microsoft.extensions.dependencymodel/10.0.5/lib/net10.0/Microsoft.Extensions.DependencyModel.dll
+ microsoft.identity.client.extensions.msal/4.73.1/lib/net8.0/Microsoft.Identity.Client.Extensions.Msal.dll
+ microsoft.identity.client/4.73.1/lib/net8.0/Microsoft.Identity.Client.dll
+ microsoft.identitymodel.abstractions/8.0.1/lib/net9.0/Microsoft.IdentityModel.Abstractions.dll
+ microsoft.identitymodel.jsonwebtokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.JsonWebTokens.dll
+ microsoft.identitymodel.logging/8.0.1/lib/net9.0/Microsoft.IdentityModel.Logging.dll
+ microsoft.identitymodel.protocols.openidconnect/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.dll
+ microsoft.identitymodel.protocols/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.dll
+ microsoft.identitymodel.tokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.Tokens.dll
+ microsoft.openapi/1.6.14/lib/netstandard2.0/Microsoft.OpenApi.dll
+ microsoft.sqlserver.server/1.0.0/lib/netstandard2.0/Microsoft.SqlServer.Server.dll
+ microsoft.testplatform.testhost/17.14.1/lib/net8.0/
+  Microsoft.TestPlatform.CommunicationUtilities.dll
+  Microsoft.TestPlatform.CoreUtilities.dll
+  Microsoft.TestPlatform.CrossPlatEngine.dll
+  Microsoft.TestPlatform.PlatformAbstractions.dll
+  Microsoft.TestPlatform.Utilities.dll
+  Microsoft.VisualStudio.TestPlatform.Common.dll
+  Microsoft.VisualStudio.TestPlatform.ObjectModel.dll
+  testhost.dll
+ newtonsoft.json/13.0.3/lib/net6.0/Newtonsoft.Json.dll
+ nsubstitute/5.3.0/lib/net6.0/NSubstitute.dll
+ opentelemetry.api.providerbuilderextensions/1.10.0/lib/net9.0/OpenTelemetry.Api.ProviderBuilderExtensions.dll
+ opentelemetry.api/1.10.0/lib/net9.0/OpenTelemetry.Api.dll
+ opentelemetry.exporter.console/1.9.0/lib/net8.0/OpenTelemetry.Exporter.Console.dll
+ opentelemetry.exporter.opentelemetryprotocol/1.9.0/lib/net8.0/OpenTelemetry.Exporter.OpenTelemetryProtocol.dll
+ opentelemetry.exporter.prometheus.aspnetcore/1.10.0-beta.1/lib/net9.0/OpenTelemetry.Exporter.Prometheus.AspNetCore.dll
+ opentelemetry.extensions.hosting/1.9.0/lib/net8.0/OpenTelemetry.Extensions.Hosting.dll
+ opentelemetry.instrumentation.aspnetcore/1.9.0/lib/net8.0/OpenTelemetry.Instrumentation.AspNetCore.dll
+ opentelemetry.instrumentation.sqlclient/1.9.0-beta.1/lib/net8.0/OpenTelemetry.Instrumentation.SqlClient.dll
+ opentelemetry.persistentstorage.abstractions/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.Abstractions.dll
+ opentelemetry.persistentstorage.filesystem/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.FileSystem.dll
+ opentelemetry/1.10.0/lib/net9.0/OpenTelemetry.dll
+ pipelines.sockets.unofficial/2.2.8/lib/net5.0/Pipelines.Sockets.Unofficial.dll
+ polly.core/8.6.6/lib/net8.0/Polly.Core.dll
+ rabbitmq.client/6.8.1/lib/netstandard2.0/RabbitMQ.Client.dll
+ sharpziplib/1.4.2/lib/net6.0/ICSharpCode.SharpZipLib.dll
+ ssh.net/2025.1.0/lib/net9.0/Renci.SshNet.dll
+ stackexchange.redis/2.8.16/lib/net6.0/StackExchange.Redis.dll
+ swashbuckle.aspnetcore.swagger/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.Swagger.dll
+ swashbuckle.aspnetcore.swaggergen/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.dll
+ swashbuckle.aspnetcore.swaggerui/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.dll
+ system.clientmodel/1.5.1/lib/net8.0/System.ClientModel.dll
+ system.identitymodel.tokens.jwt/8.0.1/lib/net9.0/System.IdentityModel.Tokens.Jwt.dll
+ system.memory.data/8.0.1/lib/net8.0/System.Memory.Data.dll
+ system.security.cryptography.pkcs/9.0.4/lib/net9.0/System.Security.Cryptography.Pkcs.dll
+ system.security.cryptography.protecteddata/9.0.4/lib/net9.0/System.Security.Cryptography.ProtectedData.dll
+ testcontainers.rabbitmq/4.11.0/lib/net10.0/Testcontainers.RabbitMq.dll
+ testcontainers/4.11.0/lib/net10.0/Testcontainers.dll
+ xunit.abstractions/2.0.3/lib/netstandard2.0/xunit.abstractions.dll
+ xunit.assert/2.9.3/lib/net6.0/xunit.assert.dll
+ xunit.extensibility.core/2.9.3/lib/netstandard1.1/xunit.core.dll
+ xunit.extensibility.execution/2.9.3/lib/netstandard1.1/xunit.execution.dotnet.dll
+ yamldotnet/16.3.0/lib/net8.0/YamlDotNet.dll
+
+[analyzerReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.AspNetCore.App.Analyzers.dll
+ Microsoft.AspNetCore.App.CodeFixes.dll
+ Microsoft.AspNetCore.App.SourceGenerators.dll
+ Microsoft.AspNetCore.Components.Analyzers.dll
+ Microsoft.Extensions.Logging.Generators.dll
+ Microsoft.Extensions.Options.SourceGeneration.dll
+ Microsoft.Extensions.Validation.ValidationsGenerator.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.Interop.ComInterfaceGenerator.dll
+ Microsoft.Interop.JavaScript.JSImportGenerator.dll
+ Microsoft.Interop.LibraryImportGenerator.dll
+ Microsoft.Interop.SourceGeneration.dll
+ System.Text.Json.SourceGeneration.dll
+ System.Text.RegularExpressions.Generator.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/
+ Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll
+ Microsoft.CodeAnalysis.NetAnalyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/codestyle/cs/
+ Microsoft.CodeAnalysis.CodeStyle.dll
+ Microsoft.CodeAnalysis.CodeStyle.Fixes.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.dll
+<NUGET>/
+ microsoft.entityframeworkcore.analyzers/10.0.5/analyzers/dotnet/cs/Microsoft.EntityFrameworkCore.Analyzers.dll
+ system.clientmodel/1.5.1/analyzers/dotnet/cs/System.ClientModel.SourceGeneration.dll
+ xunit.analyzers/1.18.0/analyzers/dotnet/cs/
+  xunit.analyzers.dll
+  xunit.analyzers.fixes.dll
+
+[analyzerConfigFiles]
+../../.editorconfig
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_10_recommended.globalconfig
+obj/Debug/net10.0/ECommerce.Shared.Tests.GeneratedMSBuildEditorConfig.editorconfig

--- a/shared-libs/ECommerce.Shared.Tests/OutboxPlatformObservabilityTests.cs
+++ b/shared-libs/ECommerce.Shared.Tests/OutboxPlatformObservabilityTests.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics;
+using ECommerce.Shared.Infrastructure.Outbox;
+using ECommerce.Shared.Observability;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+
+namespace ECommerce.Shared.Tests;
+
+public sealed class OutboxPlatformObservabilityTests
+{
+    [Fact]
+    public void Given_AddPlatformObservability_When_Outbox_activity_is_started_Then_pipeline_records_it()
+    {
+        var configuration = new ConfigurationManager();
+        configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["OpenTelemetry:OtlpExporterEndpoint"] = "http://localhost:4317",
+            ["OpenTelemetry:SamplingRatio"] = "1.0",
+        });
+
+        var processor = new RecordingProcessor();
+
+        var services = new ServiceCollection();
+        services.AddPlatformObservability(
+            "test",
+            configuration,
+            customTracing: tracing => tracing.AddProcessor(processor));
+
+        using var sp = services.BuildServiceProvider();
+        var tracerProvider = sp.GetRequiredService<TracerProvider>();
+
+        using (var activity = OutboxTelemetry.ActivitySource.StartActivity("outbox.uow"))
+        {
+            activity?.Stop();
+        }
+
+        tracerProvider.ForceFlush(5000);
+
+        Assert.Contains(processor.Activities, a => a.Source.Name == OutboxTelemetry.ActivitySourceName);
+    }
+
+    private sealed class RecordingProcessor : BaseProcessor<Activity>
+    {
+        private readonly List<Activity> _activities = new();
+
+        public IReadOnlyList<Activity> Activities
+        {
+            get
+            {
+                lock (_activities)
+                {
+                    return _activities.ToArray();
+                }
+            }
+        }
+
+        public override void OnEnd(Activity data)
+        {
+            lock (_activities)
+            {
+                _activities.Add(data);
+            }
+        }
+    }
+}

--- a/shared-libs/ECommerce.Shared.Tests/OutboxUnitOfWorkTests.cs
+++ b/shared-libs/ECommerce.Shared.Tests/OutboxUnitOfWorkTests.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using ECommerce.Shared.Infrastructure.EventBus;
 using ECommerce.Shared.Infrastructure.Outbox;
 using Microsoft.EntityFrameworkCore;
@@ -51,6 +53,129 @@ public class OutboxUnitOfWorkTests
 
         await _outboxStore.Received(1).AddOutboxEvent(event1);
         await _outboxStore.Received(1).AddOutboxEvent(event2);
+    }
+
+    [Fact]
+    public async Task Given_WorkCommits_When_ExecuteAsync_Then_ActivityRecordsCommittedOutcome()
+    {
+        var sut = CreateSut();
+        var strategy = new PassthroughExecutionStrategy();
+        var captured = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "ECommerce.Shared.Outbox",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activity => captured.Add(activity),
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        await sut.ExecuteAsync(strategy, () =>
+            Task.FromResult<IReadOnlyList<Event>>(Array.Empty<Event>()));
+
+        var activity = captured.FirstOrDefault(a =>
+            a.OperationName == "outbox.uow"
+            && (string?)a.GetTagItem("outbox.outcome") == "committed");
+        Assert.NotNull(activity);
+        Assert.Equal("execute", activity.GetTagItem("outbox.operation"));
+        Assert.Equal("committed", activity.GetTagItem("outbox.outcome"));
+    }
+
+    [Fact]
+    public async Task Given_WorkThrows_When_ExecuteAsync_Then_ActivityRecordsRolledBackOutcome()
+    {
+        var sut = CreateSut();
+        var strategy = new PassthroughExecutionStrategy();
+        var captured = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "ECommerce.Shared.Outbox",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activity => captured.Add(activity),
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.ExecuteAsync(strategy, () =>
+                throw new InvalidOperationException("boom")));
+
+        var activity = captured.FirstOrDefault(a =>
+            a.OperationName == "outbox.uow"
+            && (string?)a.GetTagItem("outbox.outcome") == "rolled_back");
+        Assert.NotNull(activity);
+        Assert.Equal("execute", activity.GetTagItem("outbox.operation"));
+        Assert.Equal("rolled_back", activity.GetTagItem("outbox.outcome"));
+        Assert.Equal(typeof(InvalidOperationException).FullName, activity.GetTagItem("error.type"));
+    }
+
+    [Theory]
+    [InlineData(false, "committed")]
+    [InlineData(true, "rolled_back")]
+    public async Task Given_WorkCompletesOrThrows_When_ExecuteAsync_Then_TransactionMetricRecordsOutcome(
+        bool shouldThrow,
+        string expectedOutcome)
+    {
+        var sut = CreateSut();
+        var strategy = new PassthroughExecutionStrategy();
+        var capturedTags = new List<KeyValuePair<string, object?>>();
+        var metricEmitted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var meterListener = new MeterListener();
+        meterListener.InstrumentPublished = (instrument, listener) =>
+        {
+            if (instrument.Meter.Name == "ECommerce.Shared.Outbox"
+                && instrument.Name == "outbox_uow_transactions_total")
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        meterListener.SetMeasurementEventCallback<long>((_, _, tags, _) =>
+        {
+            var matchedOutcome = false;
+            lock (capturedTags)
+            {
+                foreach (var tag in tags)
+                {
+                    capturedTags.Add(new KeyValuePair<string, object?>(tag.Key, tag.Value));
+                    if (tag.Key == "outcome" && (string?)tag.Value == expectedOutcome)
+                    {
+                        matchedOutcome = true;
+                    }
+                }
+            }
+
+            if (matchedOutcome)
+            {
+                metricEmitted.TrySetResult();
+            }
+        });
+        meterListener.Start();
+
+        if (shouldThrow)
+        {
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                sut.ExecuteAsync(strategy, () =>
+                    throw new InvalidOperationException("boom")));
+        }
+        else
+        {
+            await sut.ExecuteAsync(strategy, () =>
+                Task.FromResult<IReadOnlyList<Event>>(Array.Empty<Event>()));
+        }
+
+        var metricSeen = await Task.WhenAny(metricEmitted.Task, Task.Delay(TimeSpan.FromSeconds(3)))
+            == metricEmitted.Task;
+
+        Assert.True(metricSeen, $"outbox_uow_transactions_total was not tagged with outcome={expectedOutcome}.");
+
+        KeyValuePair<string, object?>[] snapshot;
+        lock (capturedTags)
+        {
+            snapshot = capturedTags.ToArray();
+        }
+
+        Assert.Contains(snapshot, t => t.Key == "operation" && (string?)t.Value == "execute");
+        Assert.Contains(snapshot, t => t.Key == "outcome" && (string?)t.Value == expectedOutcome);
     }
 
     [Fact]

--- a/shared-libs/ECommerce.Shared.Tests/OutboxUnitOfWorkTests.cs
+++ b/shared-libs/ECommerce.Shared.Tests/OutboxUnitOfWorkTests.cs
@@ -1,0 +1,100 @@
+using ECommerce.Shared.Infrastructure.EventBus;
+using ECommerce.Shared.Infrastructure.Outbox;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using NSubstitute;
+
+namespace ECommerce.Shared.Tests;
+
+public class OutboxUnitOfWorkTests
+{
+    private readonly IOutboxStore _outboxStore = Substitute.For<IOutboxStore>();
+
+    private OutboxUnitOfWork CreateSut() => new(_outboxStore);
+
+    /// <summary>
+    /// A trivial execution strategy that runs the delegate once, matching the
+    /// contract of <see cref="ExecutionStrategy"/> without retry or database.
+    /// NSubstitute cannot proxy the ExecuteAsync extension methods, so we
+    /// implement the interface member directly.
+    /// </summary>
+    private sealed class PassthroughExecutionStrategy : IExecutionStrategy
+    {
+        public bool RetriesOnFailure => false;
+
+        public TResult Execute<TState, TResult>(
+            TState state,
+            Func<DbContext, TState, TResult> operation,
+            Func<DbContext, TState, ExecutionResult<TResult>>? verifySucceeded)
+            => operation(null!, state);
+
+        public async Task<TResult> ExecuteAsync<TState, TResult>(
+            TState state,
+            Func<DbContext, TState, CancellationToken, Task<TResult>> operation,
+            Func<DbContext, TState, CancellationToken, Task<ExecutionResult<TResult>>>? verifySucceeded,
+            CancellationToken cancellationToken = default)
+            => await operation(null!, state, cancellationToken);
+    }
+
+    private sealed record TestEvent(string Payload) : Event;
+
+    [Fact]
+    public async Task Given_WorkReturnsEvents_When_ExecuteAsync_Then_AllEventsAreEnqueued()
+    {
+        var sut = CreateSut();
+        var strategy = new PassthroughExecutionStrategy();
+        var event1 = new TestEvent("A");
+        var event2 = new TestEvent("B");
+
+        await sut.ExecuteAsync(strategy, () =>
+            Task.FromResult<IReadOnlyList<Event>>(new List<Event> { event1, event2 }));
+
+        await _outboxStore.Received(1).AddOutboxEvent(event1);
+        await _outboxStore.Received(1).AddOutboxEvent(event2);
+    }
+
+    [Fact]
+    public async Task Given_WorkReturnsEmptyList_When_ExecuteAsync_Then_NoEventsEnqueued()
+    {
+        var sut = CreateSut();
+        var strategy = new PassthroughExecutionStrategy();
+
+        await sut.ExecuteAsync(strategy, () =>
+            Task.FromResult<IReadOnlyList<Event>>(Array.Empty<Event>()));
+
+        await _outboxStore.DidNotReceive().AddOutboxEvent(Arg.Any<Event>());
+    }
+
+    [Fact]
+    public async Task Given_WorkThrows_When_ExecuteAsync_Then_NoEventsEnqueued()
+    {
+        var sut = CreateSut();
+        var strategy = new PassthroughExecutionStrategy();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.ExecuteAsync(strategy, () =>
+                throw new InvalidOperationException("boom")));
+
+        await _outboxStore.DidNotReceive().AddOutboxEvent(Arg.Any<Event>());
+    }
+
+    [Fact]
+    public async Task Given_NullStrategy_When_ExecuteAsync_Then_Throws()
+    {
+        var sut = CreateSut();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            sut.ExecuteAsync(null!, () =>
+                Task.FromResult<IReadOnlyList<Event>>(Array.Empty<Event>())));
+    }
+
+    [Fact]
+    public async Task Given_NullWork_When_ExecuteAsync_Then_Throws()
+    {
+        var sut = CreateSut();
+        var strategy = new PassthroughExecutionStrategy();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            sut.ExecuteAsync(strategy, null!));
+    }
+}

--- a/shared-libs/ECommerce.Shared/ECommerce.Shared.csproj
+++ b/shared-libs/ECommerce.Shared/ECommerce.Shared.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
-    <VersionPrefix>2.11.0</VersionPrefix>
+    <VersionPrefix>2.13.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/shared-libs/ECommerce.Shared/ECommerce.Shared.csproj
+++ b/shared-libs/ECommerce.Shared/ECommerce.Shared.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
-    <VersionPrefix>2.16.0</VersionPrefix>
+    <VersionPrefix>2.17.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/shared-libs/ECommerce.Shared/ECommerce.Shared.csproj
+++ b/shared-libs/ECommerce.Shared/ECommerce.Shared.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
-    <VersionPrefix>2.15.0</VersionPrefix>
+    <VersionPrefix>2.16.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/shared-libs/ECommerce.Shared/ECommerce.Shared.csproj.lscache
+++ b/shared-libs/ECommerce.Shared/ECommerce.Shared.csproj.lscache
@@ -129,6 +129,7 @@ Infrastructure/Outbox/
  OutboxEventConfiguration.cs
  OutboxOptions.cs
  OutboxStartupExtensions.cs
+ OutboxTelemetry.cs
  OutboxUnitOfWork.cs
 Infrastructure/RabbitMq/
  IRabbitMqConnection.cs

--- a/shared-libs/ECommerce.Shared/ECommerce.Shared.csproj.lscache
+++ b/shared-libs/ECommerce.Shared/ECommerce.Shared.csproj.lscache
@@ -1,0 +1,553 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[properties]
+AssemblyName=ECommerce.Shared
+CommandLineArgsForDesignTimeEvaluation=-langversion:14.0 -define:TRACE
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=14.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=ECommerce.Shared
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../../MicroservicesInDotNet.sln
+TargetFrameworkIdentifier=.NETCoreApp
+TargetPath=<PATH>bin/Debug/net10.0/ECommerce.Shared.dll
+TargetRefPath=<PATH>obj/Debug/net10.0/ref/ECommerce.Shared.dll
+TemporaryDependencyNodeTargetIdentifier=net10.0
+
+[commandLineArguments]
+/noconfig
+/unsafe-
+/checked-
+/nowarn:NU1603,NU1902,NU1903,NU5104,CA1711,CA1707,CA1716,1701,1702,8002
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/warn:10
+/define:TRACE;DEBUG;NET;NET10_0;NETCOREAPP;NET5_0_OR_GREATER;NET6_0_OR_GREATER;NET7_0_OR_GREATER;NET8_0_OR_GREATER;NET9_0_OR_GREATER;NET10_0_OR_GREATER;NETCOREAPP1_0_OR_GREATER;NETCOREAPP1_1_OR_GREATER;NETCOREAPP2_0_OR_GREATER;NETCOREAPP2_1_OR_GREATER;NETCOREAPP2_2_OR_GREATER;NETCOREAPP3_0_OR_GREATER;NETCOREAPP3_1_OR_GREATER
+/highentropyva+
+/nullable:enable
+/features:"InterceptorsNamespaces=;Microsoft.Extensions.Validation.Generated"
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\net10.0\ECommerce.Shared.dll
+/refout:obj\Debug\net10.0\refint\ECommerce.Shared.dll
+/target:library
+/warnaserror+
+/utf8output
+/deterministic+
+/langversion:14.0
+/warnaserror+:NU1605,SYSLIB0011
+
+[sourceFiles]
+Authentication/
+ AuthenticationExtensions.cs
+ AuthOptions.cs
+ AuthorizationPolicies.cs
+HealthChecks/
+ HealthCheckStartupExtensions.cs
+ RabbitMqHealthCheck.cs
+ RedisHealthCheck.cs
+ SqlServerHealthCheck.cs
+Infrastructure/AzureServiceBus/
+ AzureServiceBusEventBus.cs
+ AzureServiceBusHostedService.cs
+ AzureServiceBusOptions.cs
+ AzureServiceBusStartupExtensions.cs
+ AzureServiceBusSubscriptionProvisioningHostedService.cs
+ AzureServiceBusTelemetry.cs
+ AzureServiceBusTopicProvisioningHostedService.cs
+ AzureServiceBusTopologyProvisioner.cs
+ AzureServiceBusTopologyProvisioningPolicy.cs
+Infrastructure/DeadLetter/
+ AzureServiceBusDeadLetterCapture.cs
+ AzureServiceBusDeadLetterPublisher.cs
+ DeadLetterDbContext.cs
+ DeadLetterDbContextFactory.cs
+ DeadLetterDiscarder.cs
+ DeadLetterMessageConfiguration.cs
+ DeadLetterMetrics.cs
+ DeadLetterReplayer.cs
+ DeadLetterStartupExtensions.cs
+ IDeadLetterCapture.cs
+ IDeadLetterDiscarder.cs
+ IDeadLetterPublisher.cs
+ IDeadLetterReplayer.cs
+ IDeadLetterStore.cs
+ Migrations/
+  20260504000000_InitialDeadLetter.cs
+  20260504000000_InitialDeadLetter.Designer.cs
+  20260620000000_AddOriginToDeadLetterMessages.cs
+  20260620000000_AddOriginToDeadLetterMessages.Designer.cs
+  DeadLetterDbContextModelSnapshot.cs
+ Models/
+  DeadLetterMessage.cs
+  DeadLetterOrigin.cs
+ RabbitMqDeadLetterCapture.cs
+ RabbitMqDeadLetterPublisher.cs
+Infrastructure/EventBus/Abstractions/
+ EventBusOptions.cs
+ EventHandlerRegistration.cs
+ IEventBus.cs
+ IEventHandler.cs
+Infrastructure/EventBus/
+ Event.cs
+ EventBusHandlerExtensions.cs
+Infrastructure/Messaging/
+ MessagingOptions.cs
+ MessagingProviderResolver.cs
+ MessagingStartupExtensions.cs
+Infrastructure/Outbox/
+ IOutboxStore.cs
+ IOutboxUnitOfWork.cs
+ Migrations/
+  20260414104128_InitialOutbox.cs
+  20260414104128_InitialOutbox.Designer.cs
+  20260504094719_OutboxFailureTracking.cs
+  20260504094719_OutboxFailureTracking.Designer.cs
+  OutboxContextModelSnapshot.cs
+ Models/
+  OutboxEvent.cs
+  OutboxEventStatus.cs
+ OutboxBackgroundService.cs
+ OutboxContext.cs
+ OutboxContextFactory.cs
+ OutboxEventConfiguration.cs
+ OutboxOptions.cs
+ OutboxStartupExtensions.cs
+ OutboxUnitOfWork.cs
+Infrastructure/RabbitMq/
+ IRabbitMqConnection.cs
+ RabbitMqConnection.cs
+ RabbitMqEventBus.cs
+ RabbitMqHostedService.cs
+ RabbitMqOptions.cs
+ RabbitMqStartupExtensions.cs
+ RabbitMqTelemetry.cs
+ RabbitMqTopology.cs
+obj/Debug/net10.0/
+ .NETCoreApp,Version=v10.0.AssemblyAttributes.cs
+ ECommerce.Shared.AssemblyInfo.cs
+ ECommerce.Shared.GlobalUsings.g.cs
+Observability/
+ Metrics/MetricFactory.cs
+ OpenTelemetryMessagingConventions.cs
+ OpenTelemetryOptions.cs
+ OpenTelemetryStartupExtensions.cs
+OpenApi/OpenApiStartupExtensions.cs
+Qa/
+ QaPersonas.cs
+ QaSeedingExtensions.cs
+
+[metadataReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.AspNetCore.Antiforgery.dll
+ Microsoft.AspNetCore.Authentication.Abstractions.dll
+ Microsoft.AspNetCore.Authentication.BearerToken.dll
+ Microsoft.AspNetCore.Authentication.Cookies.dll
+ Microsoft.AspNetCore.Authentication.Core.dll
+ Microsoft.AspNetCore.Authentication.dll
+ Microsoft.AspNetCore.Authentication.OAuth.dll
+ Microsoft.AspNetCore.Authorization.dll
+ Microsoft.AspNetCore.Authorization.Policy.dll
+ Microsoft.AspNetCore.Components.Authorization.dll
+ Microsoft.AspNetCore.Components.dll
+ Microsoft.AspNetCore.Components.Endpoints.dll
+ Microsoft.AspNetCore.Components.Forms.dll
+ Microsoft.AspNetCore.Components.Server.dll
+ Microsoft.AspNetCore.Components.Web.dll
+ Microsoft.AspNetCore.Connections.Abstractions.dll
+ Microsoft.AspNetCore.CookiePolicy.dll
+ Microsoft.AspNetCore.Cors.dll
+ Microsoft.AspNetCore.Cryptography.Internal.dll
+ Microsoft.AspNetCore.Cryptography.KeyDerivation.dll
+ Microsoft.AspNetCore.DataProtection.Abstractions.dll
+ Microsoft.AspNetCore.DataProtection.dll
+ Microsoft.AspNetCore.DataProtection.Extensions.dll
+ Microsoft.AspNetCore.Diagnostics.Abstractions.dll
+ Microsoft.AspNetCore.Diagnostics.dll
+ Microsoft.AspNetCore.Diagnostics.HealthChecks.dll
+ Microsoft.AspNetCore.dll
+ Microsoft.AspNetCore.HostFiltering.dll
+ Microsoft.AspNetCore.Hosting.Abstractions.dll
+ Microsoft.AspNetCore.Hosting.dll
+ Microsoft.AspNetCore.Hosting.Server.Abstractions.dll
+ Microsoft.AspNetCore.Html.Abstractions.dll
+ Microsoft.AspNetCore.Http.Abstractions.dll
+ Microsoft.AspNetCore.Http.Connections.Common.dll
+ Microsoft.AspNetCore.Http.Connections.dll
+ Microsoft.AspNetCore.Http.dll
+ Microsoft.AspNetCore.Http.Extensions.dll
+ Microsoft.AspNetCore.Http.Features.dll
+ Microsoft.AspNetCore.Http.Results.dll
+ Microsoft.AspNetCore.HttpLogging.dll
+ Microsoft.AspNetCore.HttpOverrides.dll
+ Microsoft.AspNetCore.HttpsPolicy.dll
+ Microsoft.AspNetCore.Identity.dll
+ Microsoft.AspNetCore.Localization.dll
+ Microsoft.AspNetCore.Localization.Routing.dll
+ Microsoft.AspNetCore.Metadata.dll
+ Microsoft.AspNetCore.Mvc.Abstractions.dll
+ Microsoft.AspNetCore.Mvc.ApiExplorer.dll
+ Microsoft.AspNetCore.Mvc.Core.dll
+ Microsoft.AspNetCore.Mvc.Cors.dll
+ Microsoft.AspNetCore.Mvc.DataAnnotations.dll
+ Microsoft.AspNetCore.Mvc.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Json.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Xml.dll
+ Microsoft.AspNetCore.Mvc.Localization.dll
+ Microsoft.AspNetCore.Mvc.Razor.dll
+ Microsoft.AspNetCore.Mvc.RazorPages.dll
+ Microsoft.AspNetCore.Mvc.TagHelpers.dll
+ Microsoft.AspNetCore.Mvc.ViewFeatures.dll
+ Microsoft.AspNetCore.OutputCaching.dll
+ Microsoft.AspNetCore.RateLimiting.dll
+ Microsoft.AspNetCore.Razor.dll
+ Microsoft.AspNetCore.Razor.Runtime.dll
+ Microsoft.AspNetCore.RequestDecompression.dll
+ Microsoft.AspNetCore.ResponseCaching.Abstractions.dll
+ Microsoft.AspNetCore.ResponseCaching.dll
+ Microsoft.AspNetCore.ResponseCompression.dll
+ Microsoft.AspNetCore.Rewrite.dll
+ Microsoft.AspNetCore.Routing.Abstractions.dll
+ Microsoft.AspNetCore.Routing.dll
+ Microsoft.AspNetCore.Server.HttpSys.dll
+ Microsoft.AspNetCore.Server.IIS.dll
+ Microsoft.AspNetCore.Server.IISIntegration.dll
+ Microsoft.AspNetCore.Server.Kestrel.Core.dll
+ Microsoft.AspNetCore.Server.Kestrel.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll
+ Microsoft.AspNetCore.Session.dll
+ Microsoft.AspNetCore.SignalR.Common.dll
+ Microsoft.AspNetCore.SignalR.Core.dll
+ Microsoft.AspNetCore.SignalR.dll
+ Microsoft.AspNetCore.SignalR.Protocols.Json.dll
+ Microsoft.AspNetCore.StaticAssets.dll
+ Microsoft.AspNetCore.StaticFiles.dll
+ Microsoft.AspNetCore.WebSockets.dll
+ Microsoft.AspNetCore.WebUtilities.dll
+ Microsoft.Extensions.Caching.Abstractions.dll
+ Microsoft.Extensions.Caching.Memory.dll
+ Microsoft.Extensions.Configuration.Abstractions.dll
+ Microsoft.Extensions.Configuration.Binder.dll
+ Microsoft.Extensions.Configuration.CommandLine.dll
+ Microsoft.Extensions.Configuration.dll
+ Microsoft.Extensions.Configuration.EnvironmentVariables.dll
+ Microsoft.Extensions.Configuration.FileExtensions.dll
+ Microsoft.Extensions.Configuration.Ini.dll
+ Microsoft.Extensions.Configuration.Json.dll
+ Microsoft.Extensions.Configuration.KeyPerFile.dll
+ Microsoft.Extensions.Configuration.UserSecrets.dll
+ Microsoft.Extensions.Configuration.Xml.dll
+ Microsoft.Extensions.DependencyInjection.Abstractions.dll
+ Microsoft.Extensions.DependencyInjection.dll
+ Microsoft.Extensions.Diagnostics.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.dll
+ Microsoft.Extensions.Features.dll
+ Microsoft.Extensions.FileProviders.Abstractions.dll
+ Microsoft.Extensions.FileProviders.Composite.dll
+ Microsoft.Extensions.FileProviders.Embedded.dll
+ Microsoft.Extensions.FileProviders.Physical.dll
+ Microsoft.Extensions.FileSystemGlobbing.dll
+ Microsoft.Extensions.Hosting.Abstractions.dll
+ Microsoft.Extensions.Hosting.dll
+ Microsoft.Extensions.Http.dll
+ Microsoft.Extensions.Identity.Core.dll
+ Microsoft.Extensions.Identity.Stores.dll
+ Microsoft.Extensions.Localization.Abstractions.dll
+ Microsoft.Extensions.Localization.dll
+ Microsoft.Extensions.Logging.Abstractions.dll
+ Microsoft.Extensions.Logging.Configuration.dll
+ Microsoft.Extensions.Logging.Console.dll
+ Microsoft.Extensions.Logging.Debug.dll
+ Microsoft.Extensions.Logging.dll
+ Microsoft.Extensions.Logging.EventLog.dll
+ Microsoft.Extensions.Logging.EventSource.dll
+ Microsoft.Extensions.Logging.TraceSource.dll
+ Microsoft.Extensions.ObjectPool.dll
+ Microsoft.Extensions.Options.ConfigurationExtensions.dll
+ Microsoft.Extensions.Options.DataAnnotations.dll
+ Microsoft.Extensions.Options.dll
+ Microsoft.Extensions.Primitives.dll
+ Microsoft.Extensions.Validation.dll
+ Microsoft.Extensions.WebEncoders.dll
+ Microsoft.JSInterop.dll
+ Microsoft.Net.Http.Headers.dll
+ System.Diagnostics.EventLog.dll
+ System.Formats.Cbor.dll
+ System.Security.Cryptography.Xml.dll
+ System.Threading.RateLimiting.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.CSharp.dll
+ Microsoft.VisualBasic.Core.dll
+ Microsoft.VisualBasic.dll
+ Microsoft.Win32.Primitives.dll
+ Microsoft.Win32.Registry.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.Immutable.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Annotations.dll
+ System.ComponentModel.DataAnnotations.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Configuration.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.DataSetExtensions.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.DiagnosticSource.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Formats.Asn1.dll
+ System.Formats.Tar.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.Brotli.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.AccessControl.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipelines.dll
+ System.IO.Pipes.AccessControl.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.AsyncEnumerable.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.Http.Json.dll
+ System.Net.HttpListener.dll
+ System.Net.Mail.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Quic.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.ServerSentEvents.dll
+ System.Net.ServicePoint.dll
+ System.Net.Sockets.dll
+ System.Net.WebClient.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebProxy.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Metadata.dll
+ System.Reflection.Primitives.dll
+ System.Reflection.TypeExtensions.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.Unsafe.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.JavaScript.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Intrinsics.dll
+ System.Runtime.Loader.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.AccessControl.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Cng.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.OpenSsl.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.dll
+ System.Security.Principal.dll
+ System.Security.Principal.Windows.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.ServiceProcess.dll
+ System.Text.Encoding.CodePages.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.Encodings.Web.dll
+ System.Text.Json.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.AccessControl.dll
+ System.Threading.Channels.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.Dataflow.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.Transactions.Local.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Web.HttpUtility.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+ WindowsBase.dll
+<NUGET>/
+ azure.core.amqp/1.3.1/lib/netstandard2.0/Azure.Core.Amqp.dll
+ azure.core/1.47.1/lib/net8.0/Azure.Core.dll
+ azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
+ azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
+ azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
+ google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
+ grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
+ grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll
+ grpc.net.common/2.52.0/lib/net7.0/Grpc.Net.Common.dll
+ microsoft.aspnetcore.authentication.jwtbearer/10.0.5/lib/net10.0/Microsoft.AspNetCore.Authentication.JwtBearer.dll
+ microsoft.azure.amqp/2.6.7/lib/netstandard2.0/Microsoft.Azure.Amqp.dll
+ microsoft.bcl.asyncinterfaces/8.0.0/lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll
+ microsoft.bcl.cryptography/9.0.4/lib/net9.0/Microsoft.Bcl.Cryptography.dll
+ microsoft.data.sqlclient/6.1.1/ref/net9.0/Microsoft.Data.SqlClient.dll
+ microsoft.entityframeworkcore.abstractions/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Abstractions.dll
+ microsoft.entityframeworkcore.relational/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Relational.dll
+ microsoft.entityframeworkcore.sqlserver/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.SqlServer.dll
+ microsoft.entityframeworkcore/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.dll
+ microsoft.identity.client.extensions.msal/4.73.1/lib/net8.0/Microsoft.Identity.Client.Extensions.Msal.dll
+ microsoft.identity.client/4.73.1/lib/net8.0/Microsoft.Identity.Client.dll
+ microsoft.identitymodel.abstractions/8.0.1/lib/net9.0/Microsoft.IdentityModel.Abstractions.dll
+ microsoft.identitymodel.jsonwebtokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.JsonWebTokens.dll
+ microsoft.identitymodel.logging/8.0.1/lib/net9.0/Microsoft.IdentityModel.Logging.dll
+ microsoft.identitymodel.protocols.openidconnect/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.dll
+ microsoft.identitymodel.protocols/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.dll
+ microsoft.identitymodel.tokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.Tokens.dll
+ microsoft.openapi/1.6.14/lib/netstandard2.0/Microsoft.OpenApi.dll
+ microsoft.sqlserver.server/1.0.0/lib/netstandard2.0/Microsoft.SqlServer.Server.dll
+ opentelemetry.api.providerbuilderextensions/1.10.0/lib/net9.0/OpenTelemetry.Api.ProviderBuilderExtensions.dll
+ opentelemetry.api/1.10.0/lib/net9.0/OpenTelemetry.Api.dll
+ opentelemetry.exporter.console/1.9.0/lib/net8.0/OpenTelemetry.Exporter.Console.dll
+ opentelemetry.exporter.opentelemetryprotocol/1.9.0/lib/net8.0/OpenTelemetry.Exporter.OpenTelemetryProtocol.dll
+ opentelemetry.exporter.prometheus.aspnetcore/1.10.0-beta.1/lib/net9.0/OpenTelemetry.Exporter.Prometheus.AspNetCore.dll
+ opentelemetry.extensions.hosting/1.9.0/lib/net8.0/OpenTelemetry.Extensions.Hosting.dll
+ opentelemetry.instrumentation.aspnetcore/1.9.0/lib/net8.0/OpenTelemetry.Instrumentation.AspNetCore.dll
+ opentelemetry.instrumentation.sqlclient/1.9.0-beta.1/lib/net8.0/OpenTelemetry.Instrumentation.SqlClient.dll
+ opentelemetry.persistentstorage.abstractions/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.Abstractions.dll
+ opentelemetry.persistentstorage.filesystem/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.FileSystem.dll
+ opentelemetry/1.10.0/lib/net9.0/OpenTelemetry.dll
+ pipelines.sockets.unofficial/2.2.8/lib/net5.0/Pipelines.Sockets.Unofficial.dll
+ polly.core/8.6.6/lib/net8.0/Polly.Core.dll
+ rabbitmq.client/6.8.1/lib/netstandard2.0/RabbitMQ.Client.dll
+ stackexchange.redis/2.8.16/lib/net6.0/StackExchange.Redis.dll
+ swashbuckle.aspnetcore.swagger/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.Swagger.dll
+ swashbuckle.aspnetcore.swaggergen/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.dll
+ swashbuckle.aspnetcore.swaggerui/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.dll
+ system.clientmodel/1.5.1/lib/net8.0/System.ClientModel.dll
+ system.identitymodel.tokens.jwt/8.0.1/lib/net9.0/System.IdentityModel.Tokens.Jwt.dll
+ system.memory.data/8.0.1/lib/net8.0/System.Memory.Data.dll
+ system.security.cryptography.pkcs/9.0.4/lib/net9.0/System.Security.Cryptography.Pkcs.dll
+ system.security.cryptography.protecteddata/9.0.4/lib/net9.0/System.Security.Cryptography.ProtectedData.dll
+
+[analyzerReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.AspNetCore.App.Analyzers.dll
+ Microsoft.AspNetCore.App.CodeFixes.dll
+ Microsoft.AspNetCore.App.SourceGenerators.dll
+ Microsoft.AspNetCore.Components.Analyzers.dll
+ Microsoft.Extensions.Logging.Generators.dll
+ Microsoft.Extensions.Options.SourceGeneration.dll
+ Microsoft.Extensions.Validation.ValidationsGenerator.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.Interop.ComInterfaceGenerator.dll
+ Microsoft.Interop.JavaScript.JSImportGenerator.dll
+ Microsoft.Interop.LibraryImportGenerator.dll
+ Microsoft.Interop.SourceGeneration.dll
+ System.Text.Json.SourceGeneration.dll
+ System.Text.RegularExpressions.Generator.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/
+ Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll
+ Microsoft.CodeAnalysis.NetAnalyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/codestyle/cs/
+ Microsoft.CodeAnalysis.CodeStyle.dll
+ Microsoft.CodeAnalysis.CodeStyle.Fixes.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.dll
+<NUGET>/microsoft.codeanalysis.analyzers/3.11.0/analyzers/dotnet/cs/
+ Microsoft.CodeAnalysis.Analyzers.dll
+ Microsoft.CodeAnalysis.CSharp.Analyzers.dll
+<NUGET>/
+ microsoft.entityframeworkcore.analyzers/10.0.5/analyzers/dotnet/cs/Microsoft.EntityFrameworkCore.Analyzers.dll
+ system.clientmodel/1.5.1/analyzers/dotnet/cs/System.ClientModel.SourceGeneration.dll
+
+[analyzerConfigFiles]
+../../.editorconfig
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_10_recommended.globalconfig
+obj/Debug/net10.0/ECommerce.Shared.GeneratedMSBuildEditorConfig.editorconfig

--- a/shared-libs/ECommerce.Shared/Infrastructure/Outbox/IOutboxStore.cs
+++ b/shared-libs/ECommerce.Shared/Infrastructure/Outbox/IOutboxStore.cs
@@ -4,6 +4,10 @@ using Microsoft.EntityFrameworkCore.Storage;
 
 namespace ECommerce.Shared.Infrastructure.Outbox;
 
+/// <summary>
+/// Low-level primitive for Outbox state management and execution strategy creation.
+/// For business logic and transactional publishing, use <see cref="IOutboxUnitOfWork"/> instead.
+/// </summary>
 public interface IOutboxStore
 {
     Task AddOutboxEvent<T>(T @event) where T : Event;

--- a/shared-libs/ECommerce.Shared/Infrastructure/Outbox/IOutboxUnitOfWork.cs
+++ b/shared-libs/ECommerce.Shared/Infrastructure/Outbox/IOutboxUnitOfWork.cs
@@ -7,6 +7,8 @@ namespace ECommerce.Shared.Infrastructure.Outbox;
 /// Caller-facing seam for transactional publishing: runs a unit of work
 /// under the supplied execution strategy and ambient transaction, then
 /// enqueues the returned Integration Events on the Outbox in the same scope.
+/// This seam is provider-neutral and leaves delivery to the configured EventBus provider 
+/// (e.g. RabbitMQ or Azure Service Bus) without requiring provider-specific call-site code.
 /// </summary>
 public interface IOutboxUnitOfWork
 {

--- a/shared-libs/ECommerce.Shared/Infrastructure/Outbox/IOutboxUnitOfWork.cs
+++ b/shared-libs/ECommerce.Shared/Infrastructure/Outbox/IOutboxUnitOfWork.cs
@@ -5,12 +5,26 @@ namespace ECommerce.Shared.Infrastructure.Outbox;
 
 /// <summary>
 /// Caller-facing seam for transactional publishing: runs a unit of work
-/// under the supplied execution strategy and ambient transaction, then
-/// enqueues the returned Integration Events on the Outbox in the same scope.
-/// This seam is provider-neutral and leaves delivery to the configured EventBus provider 
+/// under an ambient transaction, then enqueues the returned Integration Events
+/// on the Outbox in the same scope. The execution strategy is resolved internally
+/// so callers do not need to depend on <see cref="IOutboxStore"/> at all.
+/// This seam is provider-neutral and leaves delivery to the configured EventBus provider
 /// (e.g. RabbitMQ or Azure Service Bus) without requiring provider-specific call-site code.
 /// </summary>
 public interface IOutboxUnitOfWork
 {
+    /// <summary>
+    /// Executes <paramref name="work"/> inside a retrying execution strategy and
+    /// ambient <see cref="System.Transactions.TransactionScope"/>, enqueuing the
+    /// returned events on the Outbox before committing.
+    /// The execution strategy is resolved internally from the Outbox data store.
+    /// </summary>
+    Task ExecuteAsync(Func<Task<IReadOnlyList<Event>>> work);
+
+    /// <summary>
+    /// Overload that accepts an externally-created <see cref="IExecutionStrategy"/>
+    /// for callers that own their own DbContext (e.g. PaymentContext).
+    /// Prefer the parameterless overload when possible.
+    /// </summary>
     Task ExecuteAsync(IExecutionStrategy strategy, Func<Task<IReadOnlyList<Event>>> work);
 }

--- a/shared-libs/ECommerce.Shared/Infrastructure/Outbox/IOutboxUnitOfWork.cs
+++ b/shared-libs/ECommerce.Shared/Infrastructure/Outbox/IOutboxUnitOfWork.cs
@@ -1,0 +1,14 @@
+using ECommerce.Shared.Infrastructure.EventBus;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace ECommerce.Shared.Infrastructure.Outbox;
+
+/// <summary>
+/// Caller-facing seam for transactional publishing: runs a unit of work
+/// under the supplied execution strategy and ambient transaction, then
+/// enqueues the returned Integration Events on the Outbox in the same scope.
+/// </summary>
+public interface IOutboxUnitOfWork
+{
+    Task ExecuteAsync(IExecutionStrategy strategy, Func<Task<IReadOnlyList<Event>>> work);
+}

--- a/shared-libs/ECommerce.Shared/Infrastructure/Outbox/OutboxContext.cs
+++ b/shared-libs/ECommerce.Shared/Infrastructure/Outbox/OutboxContext.cs
@@ -33,7 +33,7 @@ internal sealed class OutboxContext : DbContext, IOutboxStore
         {
             Id = @event.Id,
             EventType = @event.GetType().AssemblyQualifiedName!,
-            Data = JsonSerializer.Serialize(@event),
+            Data = JsonSerializer.Serialize(@event, @event.GetType()),
             Status = OutboxEventStatus.Pending,
             CorrelationId = TryParseTraceIdAsGuid(System.Diagnostics.Activity.Current?.TraceId.ToString())
         });

--- a/shared-libs/ECommerce.Shared/Infrastructure/Outbox/OutboxStartupExtensions.cs
+++ b/shared-libs/ECommerce.Shared/Infrastructure/Outbox/OutboxStartupExtensions.cs
@@ -25,6 +25,7 @@ public static class OutboxStartupExtensions
                 }));
 
         services.AddScoped<IOutboxStore, OutboxContext>();
+        services.AddScoped<IOutboxUnitOfWork, OutboxUnitOfWork>();
         services.AddHostedService<OutboxBackgroundService>();
     }
 

--- a/shared-libs/ECommerce.Shared/Infrastructure/Outbox/OutboxTelemetry.cs
+++ b/shared-libs/ECommerce.Shared/Infrastructure/Outbox/OutboxTelemetry.cs
@@ -1,0 +1,19 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace ECommerce.Shared.Infrastructure.Outbox;
+
+internal static class OutboxTelemetry
+{
+    public const string ActivitySourceName = "ECommerce.Shared.Outbox";
+    public const string MeterName = "ECommerce.Shared.Outbox";
+
+    public static readonly ActivitySource ActivitySource = new(ActivitySourceName);
+
+    public static readonly Meter Meter = new(MeterName);
+
+    public static readonly Counter<long> Transactions = Meter.CreateCounter<long>(
+        "outbox_uow_transactions_total",
+        "transactions",
+        "Number of Outbox unit-of-work transactions, tagged by operation and outcome.");
+}

--- a/shared-libs/ECommerce.Shared/Infrastructure/Outbox/OutboxUnitOfWork.cs
+++ b/shared-libs/ECommerce.Shared/Infrastructure/Outbox/OutboxUnitOfWork.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Transactions;
 using ECommerce.Shared.Infrastructure.EventBus;
 using Microsoft.EntityFrameworkCore;
@@ -21,16 +22,39 @@ internal sealed class OutboxUnitOfWork : IOutboxUnitOfWork
 
         return strategy.ExecuteAsync(async () =>
         {
-            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+            using var activity = OutboxTelemetry.ActivitySource.StartActivity("outbox.uow", ActivityKind.Internal);
+            activity?.SetTag("outbox.operation", "execute");
 
-            var events = await work();
-
-            foreach (var @event in events)
+            try
             {
-                await _outboxStore.AddOutboxEvent(@event);
-            }
+                using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
 
-            scope.Complete();
+                var events = await work();
+                activity?.SetTag("outbox.event_count", events.Count);
+
+                foreach (var @event in events)
+                {
+                    await _outboxStore.AddOutboxEvent(@event);
+                }
+
+                scope.Complete();
+                RecordOutcome(activity, "committed");
+            }
+            catch (Exception ex)
+            {
+                activity?.SetTag("error.type", ex.GetType().FullName);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.GetType().Name);
+                RecordOutcome(activity, "rolled_back");
+                throw;
+            }
         });
+    }
+
+    private static void RecordOutcome(Activity? activity, string outcome)
+    {
+        activity?.SetTag("outbox.outcome", outcome);
+        OutboxTelemetry.Transactions.Add(1,
+            new KeyValuePair<string, object?>("operation", "execute"),
+            new KeyValuePair<string, object?>("outcome", outcome));
     }
 }

--- a/shared-libs/ECommerce.Shared/Infrastructure/Outbox/OutboxUnitOfWork.cs
+++ b/shared-libs/ECommerce.Shared/Infrastructure/Outbox/OutboxUnitOfWork.cs
@@ -15,17 +15,34 @@ internal sealed class OutboxUnitOfWork : IOutboxUnitOfWork
         _outboxStore = outboxStore;
     }
 
+    /// <inheritdoc />
+    public Task ExecuteAsync(Func<Task<IReadOnlyList<Event>>> work)
+    {
+        ArgumentNullException.ThrowIfNull(work);
+
+        var strategy = _outboxStore.CreateExecutionStrategy();
+        return ExecuteCore(strategy, work);
+    }
+
+    /// <inheritdoc />
     public Task ExecuteAsync(IExecutionStrategy strategy, Func<Task<IReadOnlyList<Event>>> work)
     {
         ArgumentNullException.ThrowIfNull(strategy);
         ArgumentNullException.ThrowIfNull(work);
 
-        return strategy.ExecuteAsync(async () =>
-        {
-            using var activity = OutboxTelemetry.ActivitySource.StartActivity("outbox.uow", ActivityKind.Internal);
-            activity?.SetTag("outbox.operation", "execute");
+        return ExecuteCore(strategy, work);
+    }
 
-            try
+    private async Task ExecuteCore(IExecutionStrategy strategy, Func<Task<IReadOnlyList<Event>>> work)
+    {
+        // Telemetry is recorded outside the execution-strategy delegate so that
+        // retries do not inflate the activity/metric counts.
+        using var activity = OutboxTelemetry.ActivitySource.StartActivity("outbox.uow", ActivityKind.Internal);
+        activity?.SetTag("outbox.operation", "execute");
+
+        try
+        {
+            await strategy.ExecuteAsync(async () =>
             {
                 using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
 
@@ -38,16 +55,24 @@ internal sealed class OutboxUnitOfWork : IOutboxUnitOfWork
                 }
 
                 scope.Complete();
-                RecordOutcome(activity, "committed");
-            }
-            catch (Exception ex)
-            {
-                activity?.SetTag("error.type", ex.GetType().FullName);
-                activity?.SetStatus(ActivityStatusCode.Error, ex.GetType().Name);
-                RecordOutcome(activity, "rolled_back");
-                throw;
-            }
-        });
+            });
+
+            RecordOutcome(activity, "committed");
+        }
+        catch (OperationCanceledException)
+        {
+            // Cooperative cancellation is not a failure of the outbox transaction;
+            // tag with a distinct outcome so it does not pollute failure-rate signals.
+            RecordOutcome(activity, "cancelled");
+            throw;
+        }
+        catch (Exception ex)
+        {
+            activity?.SetTag("error.type", ex.GetType().FullName);
+            activity?.SetStatus(ActivityStatusCode.Error, ex.GetType().Name);
+            RecordOutcome(activity, "rolled_back");
+            throw;
+        }
     }
 
     private static void RecordOutcome(Activity? activity, string outcome)

--- a/shared-libs/ECommerce.Shared/Infrastructure/Outbox/OutboxUnitOfWork.cs
+++ b/shared-libs/ECommerce.Shared/Infrastructure/Outbox/OutboxUnitOfWork.cs
@@ -1,0 +1,36 @@
+using System.Transactions;
+using ECommerce.Shared.Infrastructure.EventBus;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace ECommerce.Shared.Infrastructure.Outbox;
+
+internal sealed class OutboxUnitOfWork : IOutboxUnitOfWork
+{
+    private readonly IOutboxStore _outboxStore;
+
+    public OutboxUnitOfWork(IOutboxStore outboxStore)
+    {
+        _outboxStore = outboxStore;
+    }
+
+    public Task ExecuteAsync(IExecutionStrategy strategy, Func<Task<IReadOnlyList<Event>>> work)
+    {
+        ArgumentNullException.ThrowIfNull(strategy);
+        ArgumentNullException.ThrowIfNull(work);
+
+        return strategy.ExecuteAsync(async () =>
+        {
+            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+
+            var events = await work();
+
+            foreach (var @event in events)
+            {
+                await _outboxStore.AddOutboxEvent(@event);
+            }
+
+            scope.Complete();
+        });
+    }
+}

--- a/shared-libs/ECommerce.Shared/Observability/OpenTelemetryStartupExtensions.cs
+++ b/shared-libs/ECommerce.Shared/Observability/OpenTelemetryStartupExtensions.cs
@@ -1,5 +1,6 @@
 using Azure.Monitor.OpenTelemetry.Exporter;
 using ECommerce.Shared.Infrastructure.DeadLetter;
+using ECommerce.Shared.Infrastructure.Outbox;
 using ECommerce.Shared.Infrastructure.RabbitMq;
 using ECommerce.Shared.Observability.Metrics;
 using Microsoft.AspNetCore.Builder;
@@ -99,6 +100,7 @@ public static class OpenTelemetryStartupExtensions
                     .AddAspNetCoreInstrumentation()
                     .AddSource(RabbitMqTelemetry.ActivitySourceName)
                     .AddSource(DeadLetterMetrics.ActivitySourceName)
+                    .AddSource(OutboxTelemetry.ActivitySourceName)
                     .AddOtlpExporter(o => o.Endpoint = new Uri(opts.OtlpExporterEndpoint));
 
                 if (opts.UseAzureMonitor)
@@ -123,6 +125,7 @@ public static class OpenTelemetryStartupExtensions
                     .AddAspNetCoreInstrumentation()
                     .AddMeter(serviceName)
                     .AddMeter(DeadLetterMetrics.MeterName)
+                    .AddMeter(OutboxTelemetry.MeterName)
                     .AddPrometheusExporter();
 
                 if (opts.UseAzureMonitor)
@@ -160,6 +163,7 @@ public static class OpenTelemetryStartupExtensions
                     .AddConsoleExporter()
                     .AddAspNetCoreInstrumentation()
                     .AddSource(RabbitMqTelemetry.ActivitySourceName)
+                    .AddSource(OutboxTelemetry.ActivitySourceName)
                     .AddOtlpExporter(options => options.Endpoint =
                         new Uri(openTelemetryOptions.OtlpExporterEndpoint));
 
@@ -184,6 +188,7 @@ public static class OpenTelemetryStartupExtensions
                     .AddConsoleExporter()
                     .AddAspNetCoreInstrumentation()
                     .AddMeter(serviceName)
+                    .AddMeter(OutboxTelemetry.MeterName)
                     .AddPrometheusExporter();
 
                 customMetrics?.Invoke(builder);

--- a/shipping-microservice/Shipping.Service/Carriers/CarrierPollingService.cs
+++ b/shipping-microservice/Shipping.Service/Carriers/CarrierPollingService.cs
@@ -79,7 +79,6 @@ internal sealed partial class CarrierPollingService : BackgroundService
     {
         using var scope = _scopeFactory.CreateScope();
         var shipmentStore = scope.ServiceProvider.GetRequiredService<IShipmentStore>();
-        var outboxStore = scope.ServiceProvider.GetRequiredService<IOutboxStore>();
         var outboxUnitOfWork = scope.ServiceProvider.GetRequiredService<IOutboxUnitOfWork>();
         var metrics = scope.ServiceProvider.GetRequiredService<ShippingMetrics>();
         var carriers = scope.ServiceProvider.GetServices<ICarrierGateway>()
@@ -93,7 +92,7 @@ internal sealed partial class CarrierPollingService : BackgroundService
 
         var updated = 0;
 
-        await outboxUnitOfWork.ExecuteAsync(outboxStore.CreateExecutionStrategy(), async () =>
+        await outboxUnitOfWork.ExecuteAsync(async () =>
         {
             var changed = false;
             var events = new List<Event>();

--- a/shipping-microservice/Shipping.Service/Carriers/CarrierPollingService.cs
+++ b/shipping-microservice/Shipping.Service/Carriers/CarrierPollingService.cs
@@ -1,4 +1,4 @@
-using System.Transactions;
+using ECommerce.Shared.Infrastructure.EventBus;
 using ECommerce.Shared.Infrastructure.Outbox;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -80,6 +80,7 @@ internal sealed partial class CarrierPollingService : BackgroundService
         using var scope = _scopeFactory.CreateScope();
         var shipmentStore = scope.ServiceProvider.GetRequiredService<IShipmentStore>();
         var outboxStore = scope.ServiceProvider.GetRequiredService<IOutboxStore>();
+        var outboxUnitOfWork = scope.ServiceProvider.GetRequiredService<IOutboxUnitOfWork>();
         var metrics = scope.ServiceProvider.GetRequiredService<ShippingMetrics>();
         var carriers = scope.ServiceProvider.GetServices<ICarrierGateway>()
             .ToDictionary(c => c.CarrierKey, StringComparer.OrdinalIgnoreCase);
@@ -92,11 +93,10 @@ internal sealed partial class CarrierPollingService : BackgroundService
 
         var updated = 0;
 
-        await outboxStore.CreateExecutionStrategy().ExecuteAsync(async () =>
+        await outboxUnitOfWork.ExecuteAsync(outboxStore.CreateExecutionStrategy(), async () =>
         {
-            using var txScope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-
             var changed = false;
+            var events = new List<Event>();
 
             foreach (var shipment in active)
             {
@@ -126,18 +126,18 @@ internal sealed partial class CarrierPollingService : BackgroundService
                     continue;
                 }
 
-                var applied = await CarrierStatusApplier.ApplyAsync(
+                var shipmentEvents = await CarrierStatusApplier.ApplyAsync(
                     shipment,
                     status,
                     ShipmentStatusSource.CarrierPoll,
                     _timeProvider.GetUtcNow().UtcDateTime,
-                    outboxStore,
                     metrics);
 
-                if (applied)
+                if (shipmentEvents.Count > 0)
                 {
                     changed = true;
                     updated++;
+                    events.AddRange(shipmentEvents);
                 }
             }
 
@@ -146,7 +146,7 @@ internal sealed partial class CarrierPollingService : BackgroundService
                 await shipmentStore.SaveChangesAsync();
             }
 
-            txScope.Complete();
+            return events;
         });
 
         return updated;

--- a/shipping-microservice/Shipping.Service/Carriers/CarrierStatusApplier.cs
+++ b/shipping-microservice/Shipping.Service/Carriers/CarrierStatusApplier.cs
@@ -1,4 +1,4 @@
-using ECommerce.Shared.Infrastructure.Outbox;
+using ECommerce.Shared.Infrastructure.EventBus;
 using Shipping.Service.IntegrationEvents;
 using Shipping.Service.Models;
 using Shipping.Service.Observability;
@@ -7,40 +7,39 @@ namespace Shipping.Service.Carriers;
 
 /// <summary>
 /// Applies a <see cref="CarrierStatus"/> update to a <see cref="Shipment"/>
-/// through the aggregate's legal transitions and emits the corresponding
-/// milestone + <see cref="ShipmentStatusChangedEvent"/> through the outbox.
-/// The caller is responsible for the surrounding transaction and
-/// <c>SaveChangesAsync</c>.
+/// through the aggregate's legal transitions and returns the corresponding
+/// milestone + <see cref="ShipmentStatusChangedEvent"/> instances.
+/// The caller is responsible for saving changes and enqueueing returned events
+/// through the Outbox unit-of-work.
 /// </summary>
 internal static class CarrierStatusApplier
 {
-    public static async Task<bool> ApplyAsync(
+    public static Task<IReadOnlyList<Event>> ApplyAsync(
         Shipment shipment,
         CarrierStatus status,
         ShipmentStatusSource source,
         DateTime occurredAt,
-        IOutboxStore outboxStore,
         ShippingMetrics? metrics = null)
     {
         ArgumentNullException.ThrowIfNull(shipment);
         ArgumentNullException.ThrowIfNull(status);
-        ArgumentNullException.ThrowIfNull(outboxStore);
 
         if (shipment.IsTerminal)
         {
             // Graceful no-op for late-arriving webhooks / polls.
-            return false;
+            return Task.FromResult<IReadOnlyList<Event>>(Array.Empty<Event>());
         }
 
         var fromStatus = shipment.Status;
         var createdAt = shipment.CreatedAt;
+        var events = new List<Event>();
 
         switch (status.Code)
         {
             case CarrierStatusCode.InTransit:
                 if (!shipment.TryMarkInTransit(occurredAt, source))
                 {
-                    return false;
+                    return Task.FromResult<IReadOnlyList<Event>>(Array.Empty<Event>());
                 }
 
                 break;
@@ -48,10 +47,10 @@ internal static class CarrierStatusApplier
             case CarrierStatusCode.Delivered:
                 if (!shipment.TryDeliver(occurredAt, source))
                 {
-                    return false;
+                    return Task.FromResult<IReadOnlyList<Event>>(Array.Empty<Event>());
                 }
 
-                await outboxStore.AddOutboxEvent(new ShipmentDeliveredEvent(
+                events.Add(new ShipmentDeliveredEvent(
                     ShipmentId: shipment.Id,
                     OrderId: shipment.OrderId,
                     CustomerId: shipment.CustomerId,
@@ -66,10 +65,10 @@ internal static class CarrierStatusApplier
                     : status.Detail!;
                 if (!shipment.TryFail(reason, occurredAt, source))
                 {
-                    return false;
+                    return Task.FromResult<IReadOnlyList<Event>>(Array.Empty<Event>());
                 }
 
-                await outboxStore.AddOutboxEvent(new ShipmentFailedEvent(
+                events.Add(new ShipmentFailedEvent(
                     ShipmentId: shipment.Id,
                     OrderId: shipment.OrderId,
                     CustomerId: shipment.CustomerId,
@@ -82,10 +81,10 @@ internal static class CarrierStatusApplier
             case CarrierStatusCode.Accepted:
             case CarrierStatusCode.Unknown:
             default:
-                return false;
+                return Task.FromResult<IReadOnlyList<Event>>(Array.Empty<Event>());
         }
 
-        await outboxStore.AddOutboxEvent(new ShipmentStatusChangedEvent(
+        events.Add(new ShipmentStatusChangedEvent(
             shipment.Id,
             shipment.OrderId,
             FromStatus: fromStatus,
@@ -101,6 +100,6 @@ internal static class CarrierStatusApplier
             }
         }
 
-        return true;
+        return Task.FromResult<IReadOnlyList<Event>>(events);
     }
 }

--- a/shipping-microservice/Shipping.Service/Endpoints/ShippingApiEndpoints.cs
+++ b/shipping-microservice/Shipping.Service/Endpoints/ShippingApiEndpoints.cs
@@ -1,6 +1,5 @@
 using System.Security.Claims;
 using System.Text.Json;
-using System.Transactions;
 using ECommerce.Shared.Infrastructure.EventBus;
 using ECommerce.Shared.Infrastructure.Outbox;
 using Microsoft.AspNetCore.Mvc;
@@ -401,6 +400,7 @@ public static class ShippingApiEndpoints
         routeBuilder.MapPost("/webhooks/carrier/{carrierKey}", async Task<IResult> (
             [FromServices] IShipmentStore shipmentStore,
             [FromServices] IOutboxStore outboxStore,
+            [FromServices] IOutboxUnitOfWork outboxUnitOfWork,
             [FromServices] IEnumerable<ICarrierGateway> carriers,
             [FromServices] IOptions<CarrierWebhookOptions> options,
             [FromServices] ShippingMetrics metrics,
@@ -445,24 +445,21 @@ public static class ShippingApiEndpoints
 
             var now = DateTime.UtcNow;
 
-            await outboxStore.CreateExecutionStrategy().ExecuteAsync(async () =>
+            await outboxUnitOfWork.ExecuteAsync(outboxStore.CreateExecutionStrategy(), async () =>
             {
-                using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-
-                var applied = await CarrierStatusApplier.ApplyAsync(
+                var events = await CarrierStatusApplier.ApplyAsync(
                     shipment,
                     update.Status,
                     ShipmentStatusSource.CarrierWebhook,
                     now,
-                    outboxStore,
                     metrics);
 
-                if (applied)
+                if (events.Count > 0)
                 {
                     await shipmentStore.SaveChangesAsync();
                 }
 
-                scope.Complete();
+                return events;
             });
 
             return TypedResults.Ok(new

--- a/shipping-microservice/Shipping.Service/Endpoints/ShippingApiEndpoints.cs
+++ b/shipping-microservice/Shipping.Service/Endpoints/ShippingApiEndpoints.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using System.Text.Json;
 using System.Transactions;
+using ECommerce.Shared.Infrastructure.EventBus;
 using ECommerce.Shared.Infrastructure.Outbox;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -101,12 +102,14 @@ public static class ShippingApiEndpoints
         routeBuilder.MapPost("/{shipmentId:guid}/pick", async Task<IResult> (
             [FromServices] IShipmentStore shipmentStore,
             [FromServices] IOutboxStore outboxStore,
+            [FromServices] IOutboxUnitOfWork outboxUnitOfWork,
             [FromServices] ShippingMetrics metrics,
             Guid shipmentId) =>
         {
             return await ApplyTransitionAsync(
                 shipmentStore,
                 outboxStore,
+                outboxUnitOfWork,
                 metrics,
                 shipmentId,
                 (shipment, now) => shipment.TryPick(now, ShipmentStatusSource.Admin));
@@ -115,12 +118,14 @@ public static class ShippingApiEndpoints
         routeBuilder.MapPost("/{shipmentId:guid}/pack", async Task<IResult> (
             [FromServices] IShipmentStore shipmentStore,
             [FromServices] IOutboxStore outboxStore,
+            [FromServices] IOutboxUnitOfWork outboxUnitOfWork,
             [FromServices] ShippingMetrics metrics,
             Guid shipmentId) =>
         {
             return await ApplyTransitionAsync(
                 shipmentStore,
                 outboxStore,
+                outboxUnitOfWork,
                 metrics,
                 shipmentId,
                 (shipment, now) => shipment.TryPack(now, ShipmentStatusSource.Admin));
@@ -129,6 +134,7 @@ public static class ShippingApiEndpoints
         routeBuilder.MapPost("/{shipmentId:guid}/cancel", async Task<IResult> (
             [FromServices] IShipmentStore shipmentStore,
             [FromServices] IOutboxStore outboxStore,
+            [FromServices] IOutboxUnitOfWork outboxUnitOfWork,
             [FromServices] ShippingMetrics metrics,
             Guid shipmentId,
             [FromBody] CancelShipmentRequest? request) =>
@@ -137,6 +143,7 @@ public static class ShippingApiEndpoints
             return await ApplyTransitionAsync(
                 shipmentStore,
                 outboxStore,
+                outboxUnitOfWork,
                 metrics,
                 shipmentId,
                 (shipment, now) => shipment.TryCancel(now, ShipmentStatusSource.Admin, reason),
@@ -151,12 +158,14 @@ public static class ShippingApiEndpoints
         routeBuilder.MapPost("/{shipmentId:guid}/deliver", async Task<IResult> (
             [FromServices] IShipmentStore shipmentStore,
             [FromServices] IOutboxStore outboxStore,
+            [FromServices] IOutboxUnitOfWork outboxUnitOfWork,
             [FromServices] ShippingMetrics metrics,
             Guid shipmentId) =>
         {
             return await ApplyTransitionAsync(
                 shipmentStore,
                 outboxStore,
+                outboxUnitOfWork,
                 metrics,
                 shipmentId,
                 (shipment, now) => shipment.TryDeliver(now, ShipmentStatusSource.Admin),
@@ -172,6 +181,7 @@ public static class ShippingApiEndpoints
         routeBuilder.MapPost("/{shipmentId:guid}/fail", async Task<IResult> (
             [FromServices] IShipmentStore shipmentStore,
             [FromServices] IOutboxStore outboxStore,
+            [FromServices] IOutboxUnitOfWork outboxUnitOfWork,
             [FromServices] ShippingMetrics metrics,
             Guid shipmentId,
             [FromBody] FailShipmentRequest? request) =>
@@ -185,6 +195,7 @@ public static class ShippingApiEndpoints
             return await ApplyTransitionAsync(
                 shipmentStore,
                 outboxStore,
+                outboxUnitOfWork,
                 metrics,
                 shipmentId,
                 (shipment, now) => shipment.TryFail(reason, now, ShipmentStatusSource.Admin),
@@ -201,6 +212,7 @@ public static class ShippingApiEndpoints
         routeBuilder.MapPost("/{shipmentId:guid}/return", async Task<IResult> (
             [FromServices] IShipmentStore shipmentStore,
             [FromServices] IOutboxStore outboxStore,
+            [FromServices] IOutboxUnitOfWork outboxUnitOfWork,
             [FromServices] ShippingMetrics metrics,
             Guid shipmentId,
             [FromBody] ReturnShipmentRequest? request) =>
@@ -214,6 +226,7 @@ public static class ShippingApiEndpoints
             return await ApplyTransitionAsync(
                 shipmentStore,
                 outboxStore,
+                outboxUnitOfWork,
                 metrics,
                 shipmentId,
                 (shipment, now) => shipment.TryReturn(reason, now, ShipmentStatusSource.Admin),
@@ -274,6 +287,7 @@ public static class ShippingApiEndpoints
         routeBuilder.MapPost("/{shipmentId:guid}/dispatch", async Task<IResult> (
             [FromServices] IShipmentStore shipmentStore,
             [FromServices] IOutboxStore outboxStore,
+            [FromServices] IOutboxUnitOfWork outboxUnitOfWork,
             [FromServices] RateShoppingService rateShopping,
             [FromServices] ShippingMetrics metrics,
             Guid shipmentId,
@@ -347,30 +361,28 @@ public static class ShippingApiEndpoints
                 });
             }
 
-            await outboxStore.CreateExecutionStrategy().ExecuteAsync(async () =>
+            await outboxUnitOfWork.ExecuteAsync(outboxStore.CreateExecutionStrategy(), async () =>
             {
-                using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-
                 await shipmentStore.SaveChangesAsync();
 
-                await outboxStore.AddOutboxEvent(new ShipmentDispatchedEvent(
-                    ShipmentId: shipment.Id,
-                    OrderId: shipment.OrderId,
-                    CustomerId: shipment.CustomerId,
-                    CarrierKey: carrier.CarrierKey,
-                    TrackingNumber: dispatchResult.TrackingNumber,
-                    QuotedPriceAmount: quotedPrice.Amount,
-                    QuotedPriceCurrency: quotedPrice.Currency,
-                    OccurredAt: now));
-
-                await outboxStore.AddOutboxEvent(new ShipmentStatusChangedEvent(
-                    shipment.Id,
-                    shipment.OrderId,
-                    FromStatus: fromStatus,
-                    ToStatus: shipment.Status,
-                    OccurredAt: now));
-
-                scope.Complete();
+                return new Event[]
+                {
+                    new ShipmentDispatchedEvent(
+                        ShipmentId: shipment.Id,
+                        OrderId: shipment.OrderId,
+                        CustomerId: shipment.CustomerId,
+                        CarrierKey: carrier.CarrierKey,
+                        TrackingNumber: dispatchResult.TrackingNumber,
+                        QuotedPriceAmount: quotedPrice.Amount,
+                        QuotedPriceCurrency: quotedPrice.Currency,
+                        OccurredAt: now),
+                    new ShipmentStatusChangedEvent(
+                        shipment.Id,
+                        shipment.OrderId,
+                        FromStatus: fromStatus,
+                        ToStatus: shipment.Status,
+                        OccurredAt: now),
+                };
             });
 
             metrics.RecordStatusChange(shipment.Status);
@@ -464,10 +476,11 @@ public static class ShippingApiEndpoints
     private static async Task<IResult> ApplyTransitionAsync(
         IShipmentStore shipmentStore,
         IOutboxStore outboxStore,
+        IOutboxUnitOfWork outboxUnitOfWork,
         ShippingMetrics metrics,
         Guid shipmentId,
         Func<Shipment, DateTime, bool> transition,
-        Func<Shipment, DateTime, ECommerce.Shared.Infrastructure.EventBus.Event>? milestoneFactory = null)
+        Func<Shipment, DateTime, Event>? milestoneFactory = null)
     {
         var shipment = await shipmentStore.GetById(shipmentId);
         if (shipment is null)
@@ -488,26 +501,25 @@ public static class ShippingApiEndpoints
             });
         }
 
-        await outboxStore.CreateExecutionStrategy().ExecuteAsync(async () =>
+        await outboxUnitOfWork.ExecuteAsync(outboxStore.CreateExecutionStrategy(), async () =>
         {
-            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-
             await shipmentStore.SaveChangesAsync();
+
+            var events = new List<Event>();
 
             if (milestoneFactory is not null)
             {
-                var milestone = milestoneFactory(shipment, now);
-                await AddOutboxEventWithRuntimeType(outboxStore, milestone);
+                events.Add(milestoneFactory(shipment, now));
             }
 
-            await outboxStore.AddOutboxEvent(new ShipmentStatusChangedEvent(
+            events.Add(new ShipmentStatusChangedEvent(
                 shipment.Id,
                 shipment.OrderId,
                 FromStatus: fromStatus,
                 ToStatus: shipment.Status,
                 OccurredAt: now));
 
-            scope.Complete();
+            return events;
         });
 
         metrics.RecordStatusChange(shipment.Status);
@@ -531,19 +543,6 @@ public static class ShippingApiEndpoints
 
         var customerId = user.FindFirst(CustomerIdClaim)?.Value;
         return customerId is not null && customerId == shipment.CustomerId;
-    }
-
-    private static Task AddOutboxEventWithRuntimeType(
-        IOutboxStore outboxStore,
-        ECommerce.Shared.Infrastructure.EventBus.Event milestone)
-    {
-        // IOutboxStore.AddOutboxEvent<T>(T) serializes via the generic type;
-        // invoking through reflection with the runtime type preserves
-        // derived-type properties (e.g. Reason) in the stored payload.
-        var method = typeof(IOutboxStore)
-            .GetMethod(nameof(IOutboxStore.AddOutboxEvent))!
-            .MakeGenericMethod(milestone.GetType());
-        return (Task)method.Invoke(outboxStore, [milestone])!;
     }
 
     private static ShipmentResponse ToResponse(Shipment s)

--- a/shipping-microservice/Shipping.Service/Endpoints/ShippingApiEndpoints.cs
+++ b/shipping-microservice/Shipping.Service/Endpoints/ShippingApiEndpoints.cs
@@ -100,14 +100,12 @@ public static class ShippingApiEndpoints
 
         routeBuilder.MapPost("/{shipmentId:guid}/pick", async Task<IResult> (
             [FromServices] IShipmentStore shipmentStore,
-            [FromServices] IOutboxStore outboxStore,
             [FromServices] IOutboxUnitOfWork outboxUnitOfWork,
             [FromServices] ShippingMetrics metrics,
             Guid shipmentId) =>
         {
             return await ApplyTransitionAsync(
                 shipmentStore,
-                outboxStore,
                 outboxUnitOfWork,
                 metrics,
                 shipmentId,
@@ -116,14 +114,12 @@ public static class ShippingApiEndpoints
 
         routeBuilder.MapPost("/{shipmentId:guid}/pack", async Task<IResult> (
             [FromServices] IShipmentStore shipmentStore,
-            [FromServices] IOutboxStore outboxStore,
             [FromServices] IOutboxUnitOfWork outboxUnitOfWork,
             [FromServices] ShippingMetrics metrics,
             Guid shipmentId) =>
         {
             return await ApplyTransitionAsync(
                 shipmentStore,
-                outboxStore,
                 outboxUnitOfWork,
                 metrics,
                 shipmentId,
@@ -132,7 +128,6 @@ public static class ShippingApiEndpoints
 
         routeBuilder.MapPost("/{shipmentId:guid}/cancel", async Task<IResult> (
             [FromServices] IShipmentStore shipmentStore,
-            [FromServices] IOutboxStore outboxStore,
             [FromServices] IOutboxUnitOfWork outboxUnitOfWork,
             [FromServices] ShippingMetrics metrics,
             Guid shipmentId,
@@ -141,7 +136,6 @@ public static class ShippingApiEndpoints
             var reason = request?.Reason;
             return await ApplyTransitionAsync(
                 shipmentStore,
-                outboxStore,
                 outboxUnitOfWork,
                 metrics,
                 shipmentId,
@@ -156,14 +150,12 @@ public static class ShippingApiEndpoints
 
         routeBuilder.MapPost("/{shipmentId:guid}/deliver", async Task<IResult> (
             [FromServices] IShipmentStore shipmentStore,
-            [FromServices] IOutboxStore outboxStore,
             [FromServices] IOutboxUnitOfWork outboxUnitOfWork,
             [FromServices] ShippingMetrics metrics,
             Guid shipmentId) =>
         {
             return await ApplyTransitionAsync(
                 shipmentStore,
-                outboxStore,
                 outboxUnitOfWork,
                 metrics,
                 shipmentId,
@@ -179,7 +171,6 @@ public static class ShippingApiEndpoints
 
         routeBuilder.MapPost("/{shipmentId:guid}/fail", async Task<IResult> (
             [FromServices] IShipmentStore shipmentStore,
-            [FromServices] IOutboxStore outboxStore,
             [FromServices] IOutboxUnitOfWork outboxUnitOfWork,
             [FromServices] ShippingMetrics metrics,
             Guid shipmentId,
@@ -193,7 +184,6 @@ public static class ShippingApiEndpoints
             var reason = request.Reason;
             return await ApplyTransitionAsync(
                 shipmentStore,
-                outboxStore,
                 outboxUnitOfWork,
                 metrics,
                 shipmentId,
@@ -210,7 +200,6 @@ public static class ShippingApiEndpoints
 
         routeBuilder.MapPost("/{shipmentId:guid}/return", async Task<IResult> (
             [FromServices] IShipmentStore shipmentStore,
-            [FromServices] IOutboxStore outboxStore,
             [FromServices] IOutboxUnitOfWork outboxUnitOfWork,
             [FromServices] ShippingMetrics metrics,
             Guid shipmentId,
@@ -224,7 +213,6 @@ public static class ShippingApiEndpoints
             var reason = request.Reason;
             return await ApplyTransitionAsync(
                 shipmentStore,
-                outboxStore,
                 outboxUnitOfWork,
                 metrics,
                 shipmentId,
@@ -285,7 +273,6 @@ public static class ShippingApiEndpoints
 
         routeBuilder.MapPost("/{shipmentId:guid}/dispatch", async Task<IResult> (
             [FromServices] IShipmentStore shipmentStore,
-            [FromServices] IOutboxStore outboxStore,
             [FromServices] IOutboxUnitOfWork outboxUnitOfWork,
             [FromServices] RateShoppingService rateShopping,
             [FromServices] ShippingMetrics metrics,
@@ -360,7 +347,7 @@ public static class ShippingApiEndpoints
                 });
             }
 
-            await outboxUnitOfWork.ExecuteAsync(outboxStore.CreateExecutionStrategy(), async () =>
+            await outboxUnitOfWork.ExecuteAsync(async () =>
             {
                 await shipmentStore.SaveChangesAsync();
 
@@ -399,7 +386,6 @@ public static class ShippingApiEndpoints
 
         routeBuilder.MapPost("/webhooks/carrier/{carrierKey}", async Task<IResult> (
             [FromServices] IShipmentStore shipmentStore,
-            [FromServices] IOutboxStore outboxStore,
             [FromServices] IOutboxUnitOfWork outboxUnitOfWork,
             [FromServices] IEnumerable<ICarrierGateway> carriers,
             [FromServices] IOptions<CarrierWebhookOptions> options,
@@ -445,7 +431,7 @@ public static class ShippingApiEndpoints
 
             var now = DateTime.UtcNow;
 
-            await outboxUnitOfWork.ExecuteAsync(outboxStore.CreateExecutionStrategy(), async () =>
+            await outboxUnitOfWork.ExecuteAsync(async () =>
             {
                 var events = await CarrierStatusApplier.ApplyAsync(
                     shipment,
@@ -472,7 +458,6 @@ public static class ShippingApiEndpoints
 
     private static async Task<IResult> ApplyTransitionAsync(
         IShipmentStore shipmentStore,
-        IOutboxStore outboxStore,
         IOutboxUnitOfWork outboxUnitOfWork,
         ShippingMetrics metrics,
         Guid shipmentId,
@@ -498,7 +483,7 @@ public static class ShippingApiEndpoints
             });
         }
 
-        await outboxUnitOfWork.ExecuteAsync(outboxStore.CreateExecutionStrategy(), async () =>
+        await outboxUnitOfWork.ExecuteAsync(async () =>
         {
             await shipmentStore.SaveChangesAsync();
 

--- a/shipping-microservice/Shipping.Service/IntegrationEvents/EventHandlers/OrderCancelledEventHandler.cs
+++ b/shipping-microservice/Shipping.Service/IntegrationEvents/EventHandlers/OrderCancelledEventHandler.cs
@@ -9,16 +9,13 @@ namespace Shipping.Service.IntegrationEvents.EventHandlers;
 internal class OrderCancelledEventHandler : IEventHandler<OrderCancelledEvent>
 {
     private readonly IShipmentStore _shipmentStore;
-    private readonly IOutboxStore _outboxStore;
     private readonly IOutboxUnitOfWork _outboxUnitOfWork;
 
     public OrderCancelledEventHandler(
         IShipmentStore shipmentStore,
-        IOutboxStore outboxStore,
         IOutboxUnitOfWork outboxUnitOfWork)
     {
         _shipmentStore = shipmentStore;
-        _outboxStore = outboxStore;
         _outboxUnitOfWork = outboxUnitOfWork;
     }
 
@@ -30,7 +27,7 @@ internal class OrderCancelledEventHandler : IEventHandler<OrderCancelledEvent>
             return;
         }
 
-        await _outboxUnitOfWork.ExecuteAsync(_outboxStore.CreateExecutionStrategy(), async () =>
+        await _outboxUnitOfWork.ExecuteAsync(async () =>
         {
             var now = DateTime.UtcNow;
             var events = new List<Event>();

--- a/shipping-microservice/Shipping.Service/IntegrationEvents/EventHandlers/OrderCancelledEventHandler.cs
+++ b/shipping-microservice/Shipping.Service/IntegrationEvents/EventHandlers/OrderCancelledEventHandler.cs
@@ -1,7 +1,6 @@
-using System.Transactions;
+using ECommerce.Shared.Infrastructure.EventBus;
 using ECommerce.Shared.Infrastructure.EventBus.Abstractions;
 using ECommerce.Shared.Infrastructure.Outbox;
-using Microsoft.EntityFrameworkCore;
 using Shipping.Service.Infrastructure.Data;
 using Shipping.Service.Models;
 
@@ -11,13 +10,16 @@ internal class OrderCancelledEventHandler : IEventHandler<OrderCancelledEvent>
 {
     private readonly IShipmentStore _shipmentStore;
     private readonly IOutboxStore _outboxStore;
+    private readonly IOutboxUnitOfWork _outboxUnitOfWork;
 
     public OrderCancelledEventHandler(
         IShipmentStore shipmentStore,
-        IOutboxStore outboxStore)
+        IOutboxStore outboxStore,
+        IOutboxUnitOfWork outboxUnitOfWork)
     {
         _shipmentStore = shipmentStore;
         _outboxStore = outboxStore;
+        _outboxUnitOfWork = outboxUnitOfWork;
     }
 
     public async Task Handle(OrderCancelledEvent @event)
@@ -28,12 +30,10 @@ internal class OrderCancelledEventHandler : IEventHandler<OrderCancelledEvent>
             return;
         }
 
-        await _outboxStore.CreateExecutionStrategy().ExecuteAsync(async () =>
+        await _outboxUnitOfWork.ExecuteAsync(_outboxStore.CreateExecutionStrategy(), async () =>
         {
-            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-
             var now = DateTime.UtcNow;
-            var cancelledAny = false;
+            var events = new List<Event>();
 
             foreach (var shipment in shipments)
             {
@@ -44,16 +44,14 @@ internal class OrderCancelledEventHandler : IEventHandler<OrderCancelledEvent>
                     continue;
                 }
 
-                cancelledAny = true;
-
-                await _outboxStore.AddOutboxEvent(new ShipmentCancelledEvent(
+                events.Add(new ShipmentCancelledEvent(
                     shipment.Id,
                     shipment.OrderId,
                     shipment.CustomerId,
                     now,
                     Reason: "Order cancelled"));
 
-                await _outboxStore.AddOutboxEvent(new ShipmentStatusChangedEvent(
+                events.Add(new ShipmentStatusChangedEvent(
                     shipment.Id,
                     shipment.OrderId,
                     FromStatus: fromStatus,
@@ -61,12 +59,12 @@ internal class OrderCancelledEventHandler : IEventHandler<OrderCancelledEvent>
                     OccurredAt: now));
             }
 
-            if (cancelledAny)
+            if (events.Count > 0)
             {
                 await _shipmentStore.SaveChangesAsync();
             }
 
-            scope.Complete();
+            return events;
         });
     }
 }

--- a/shipping-microservice/Shipping.Service/IntegrationEvents/EventHandlers/OrderConfirmedEventHandler.cs
+++ b/shipping-microservice/Shipping.Service/IntegrationEvents/EventHandlers/OrderConfirmedEventHandler.cs
@@ -1,7 +1,5 @@
-using System.Transactions;
 using ECommerce.Shared.Infrastructure.EventBus.Abstractions;
 using ECommerce.Shared.Infrastructure.Outbox;
-using Microsoft.EntityFrameworkCore;
 using Shipping.Service.Infrastructure.Data;
 
 namespace Shipping.Service.IntegrationEvents.EventHandlers;
@@ -10,22 +8,25 @@ internal class OrderConfirmedEventHandler : IEventHandler<OrderConfirmedEvent>
 {
     private readonly IShipmentStore _shipmentStore;
     private readonly IOutboxStore _outboxStore;
+    private readonly IOutboxUnitOfWork _outboxUnitOfWork;
 
-    public OrderConfirmedEventHandler(IShipmentStore shipmentStore, IOutboxStore outboxStore)
+    public OrderConfirmedEventHandler(
+        IShipmentStore shipmentStore,
+        IOutboxStore outboxStore,
+        IOutboxUnitOfWork outboxUnitOfWork)
     {
         _shipmentStore = shipmentStore;
         _outboxStore = outboxStore;
+        _outboxUnitOfWork = outboxUnitOfWork;
     }
 
     public async Task Handle(OrderConfirmedEvent @event)
     {
-        await _outboxStore.CreateExecutionStrategy().ExecuteAsync(async () =>
+        await _outboxUnitOfWork.ExecuteAsync(_outboxStore.CreateExecutionStrategy(), async () =>
         {
-            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-
             await _shipmentStore.RecordOrderConfirmation(@event.OrderId, @event.CustomerId);
 
-            scope.Complete();
+            return [];
         });
     }
 }

--- a/shipping-microservice/Shipping.Service/IntegrationEvents/EventHandlers/OrderConfirmedEventHandler.cs
+++ b/shipping-microservice/Shipping.Service/IntegrationEvents/EventHandlers/OrderConfirmedEventHandler.cs
@@ -7,22 +7,19 @@ namespace Shipping.Service.IntegrationEvents.EventHandlers;
 internal class OrderConfirmedEventHandler : IEventHandler<OrderConfirmedEvent>
 {
     private readonly IShipmentStore _shipmentStore;
-    private readonly IOutboxStore _outboxStore;
     private readonly IOutboxUnitOfWork _outboxUnitOfWork;
 
     public OrderConfirmedEventHandler(
         IShipmentStore shipmentStore,
-        IOutboxStore outboxStore,
         IOutboxUnitOfWork outboxUnitOfWork)
     {
         _shipmentStore = shipmentStore;
-        _outboxStore = outboxStore;
         _outboxUnitOfWork = outboxUnitOfWork;
     }
 
     public async Task Handle(OrderConfirmedEvent @event)
     {
-        await _outboxUnitOfWork.ExecuteAsync(_outboxStore.CreateExecutionStrategy(), async () =>
+        await _outboxUnitOfWork.ExecuteAsync(async () =>
         {
             await _shipmentStore.RecordOrderConfirmation(@event.OrderId, @event.CustomerId);
 

--- a/shipping-microservice/Shipping.Service/IntegrationEvents/EventHandlers/StockCommittedEventHandler.cs
+++ b/shipping-microservice/Shipping.Service/IntegrationEvents/EventHandlers/StockCommittedEventHandler.cs
@@ -9,16 +9,13 @@ namespace Shipping.Service.IntegrationEvents.EventHandlers;
 internal class StockCommittedEventHandler : IEventHandler<StockCommittedEvent>
 {
     private readonly IShipmentStore _shipmentStore;
-    private readonly IOutboxStore _outboxStore;
     private readonly IOutboxUnitOfWork _outboxUnitOfWork;
 
     public StockCommittedEventHandler(
         IShipmentStore shipmentStore,
-        IOutboxStore outboxStore,
         IOutboxUnitOfWork outboxUnitOfWork)
     {
         _shipmentStore = shipmentStore;
-        _outboxStore = outboxStore;
         _outboxUnitOfWork = outboxUnitOfWork;
     }
 
@@ -43,7 +40,7 @@ internal class StockCommittedEventHandler : IEventHandler<StockCommittedEvent>
             .Select(i => new CreateShipmentLine(i.ProductId, i.WarehouseId, i.Quantity))
             .ToList();
 
-        await _outboxUnitOfWork.ExecuteAsync(_outboxStore.CreateExecutionStrategy(), async () =>
+        await _outboxUnitOfWork.ExecuteAsync(async () =>
         {
             var result = await _shipmentStore.CreateShipmentsForOrder(@event.OrderId, customerId, lines);
 

--- a/shipping-microservice/Shipping.Service/IntegrationEvents/EventHandlers/StockCommittedEventHandler.cs
+++ b/shipping-microservice/Shipping.Service/IntegrationEvents/EventHandlers/StockCommittedEventHandler.cs
@@ -1,7 +1,6 @@
-using System.Transactions;
+using ECommerce.Shared.Infrastructure.EventBus;
 using ECommerce.Shared.Infrastructure.EventBus.Abstractions;
 using ECommerce.Shared.Infrastructure.Outbox;
-using Microsoft.EntityFrameworkCore;
 using Shipping.Service.Infrastructure.Data;
 using Shipping.Service.Models;
 
@@ -11,11 +10,16 @@ internal class StockCommittedEventHandler : IEventHandler<StockCommittedEvent>
 {
     private readonly IShipmentStore _shipmentStore;
     private readonly IOutboxStore _outboxStore;
+    private readonly IOutboxUnitOfWork _outboxUnitOfWork;
 
-    public StockCommittedEventHandler(IShipmentStore shipmentStore, IOutboxStore outboxStore)
+    public StockCommittedEventHandler(
+        IShipmentStore shipmentStore,
+        IOutboxStore outboxStore,
+        IOutboxUnitOfWork outboxUnitOfWork)
     {
         _shipmentStore = shipmentStore;
         _outboxStore = outboxStore;
+        _outboxUnitOfWork = outboxUnitOfWork;
     }
 
     public async Task Handle(StockCommittedEvent @event)
@@ -39,17 +43,16 @@ internal class StockCommittedEventHandler : IEventHandler<StockCommittedEvent>
             .Select(i => new CreateShipmentLine(i.ProductId, i.WarehouseId, i.Quantity))
             .ToList();
 
-        await _outboxStore.CreateExecutionStrategy().ExecuteAsync(async () =>
+        await _outboxUnitOfWork.ExecuteAsync(_outboxStore.CreateExecutionStrategy(), async () =>
         {
-            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
-
             var result = await _shipmentStore.CreateShipmentsForOrder(@event.OrderId, customerId, lines);
 
             if (!result.Created)
             {
-                scope.Complete();
-                return;
+                return [];
             }
+
+            var events = new List<Event>();
 
             foreach (var shipment in result.Shipments)
             {
@@ -57,14 +60,14 @@ internal class StockCommittedEventHandler : IEventHandler<StockCommittedEvent>
                     .Select(l => new ShipmentLineItem(l.ProductId, l.Quantity))
                     .ToList();
 
-                await _outboxStore.AddOutboxEvent(new ShipmentCreatedEvent(
+                events.Add(new ShipmentCreatedEvent(
                     shipment.Id,
                     shipment.OrderId,
                     shipment.CustomerId,
                     shipment.WarehouseId,
                     lineItems));
 
-                await _outboxStore.AddOutboxEvent(new ShipmentStatusChangedEvent(
+                events.Add(new ShipmentStatusChangedEvent(
                     shipment.Id,
                     shipment.OrderId,
                     FromStatus: null,
@@ -72,7 +75,7 @@ internal class StockCommittedEventHandler : IEventHandler<StockCommittedEvent>
                     OccurredAt: shipment.CreatedAt));
             }
 
-            scope.Complete();
+            return events;
         });
     }
 }

--- a/shipping-microservice/Shipping.Service/Shipping.Service.csproj
+++ b/shipping-microservice/Shipping.Service/Shipping.Service.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ECommerce.Shared" Version="2.16.0" />
+    <PackageReference Include="ECommerce.Shared" Version="2.17.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>

--- a/shipping-microservice/Shipping.Service/Shipping.Service.csproj
+++ b/shipping-microservice/Shipping.Service/Shipping.Service.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ECommerce.Shared" Version="2.14.0" />
+    <PackageReference Include="ECommerce.Shared" Version="2.15.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>

--- a/shipping-microservice/Shipping.Service/Shipping.Service.csproj
+++ b/shipping-microservice/Shipping.Service/Shipping.Service.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ECommerce.Shared" Version="2.15.0" />
+    <PackageReference Include="ECommerce.Shared" Version="2.16.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>

--- a/shipping-microservice/Shipping.Service/Shipping.Service.csproj.lscache
+++ b/shipping-microservice/Shipping.Service/Shipping.Service.csproj.lscache
@@ -437,6 +437,59 @@ Program.cs
  System.Xml.XPath.dll
  System.Xml.XPath.XDocument.dll
  WindowsBase.dll
+<NUGET>/
+ azure.core.amqp/1.3.1/lib/netstandard2.0/Azure.Core.Amqp.dll
+ azure.core/1.47.1/lib/net8.0/Azure.Core.dll
+ azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
+ azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
+ azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
+ ecommerce.shared/2.16.0/lib/net10.0/ECommerce.Shared.dll
+ google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
+ grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
+ grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll
+ grpc.net.common/2.52.0/lib/net7.0/Grpc.Net.Common.dll
+ microsoft.aspnetcore.authentication.jwtbearer/10.0.5/lib/net10.0/Microsoft.AspNetCore.Authentication.JwtBearer.dll
+ microsoft.azure.amqp/2.6.7/lib/netstandard2.0/Microsoft.Azure.Amqp.dll
+ microsoft.bcl.asyncinterfaces/8.0.0/lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll
+ microsoft.bcl.cryptography/9.0.4/lib/net9.0/Microsoft.Bcl.Cryptography.dll
+ microsoft.data.sqlclient/6.1.1/ref/net9.0/Microsoft.Data.SqlClient.dll
+ microsoft.entityframeworkcore.abstractions/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Abstractions.dll
+ microsoft.entityframeworkcore.relational/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Relational.dll
+ microsoft.entityframeworkcore.sqlserver/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.SqlServer.dll
+ microsoft.entityframeworkcore/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.dll
+ microsoft.identity.client.extensions.msal/4.73.1/lib/net8.0/Microsoft.Identity.Client.Extensions.Msal.dll
+ microsoft.identity.client/4.73.1/lib/net8.0/Microsoft.Identity.Client.dll
+ microsoft.identitymodel.abstractions/8.0.1/lib/net9.0/Microsoft.IdentityModel.Abstractions.dll
+ microsoft.identitymodel.jsonwebtokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.JsonWebTokens.dll
+ microsoft.identitymodel.logging/8.0.1/lib/net9.0/Microsoft.IdentityModel.Logging.dll
+ microsoft.identitymodel.protocols.openidconnect/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.dll
+ microsoft.identitymodel.protocols/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.dll
+ microsoft.identitymodel.tokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.Tokens.dll
+ microsoft.openapi/1.6.14/lib/netstandard2.0/Microsoft.OpenApi.dll
+ microsoft.sqlserver.server/1.0.0/lib/netstandard2.0/Microsoft.SqlServer.Server.dll
+ opentelemetry.api.providerbuilderextensions/1.10.0/lib/net9.0/OpenTelemetry.Api.ProviderBuilderExtensions.dll
+ opentelemetry.api/1.10.0/lib/net9.0/OpenTelemetry.Api.dll
+ opentelemetry.exporter.console/1.9.0/lib/net8.0/OpenTelemetry.Exporter.Console.dll
+ opentelemetry.exporter.opentelemetryprotocol/1.9.0/lib/net8.0/OpenTelemetry.Exporter.OpenTelemetryProtocol.dll
+ opentelemetry.exporter.prometheus.aspnetcore/1.10.0-beta.1/lib/net9.0/OpenTelemetry.Exporter.Prometheus.AspNetCore.dll
+ opentelemetry.extensions.hosting/1.9.0/lib/net8.0/OpenTelemetry.Extensions.Hosting.dll
+ opentelemetry.instrumentation.aspnetcore/1.9.0/lib/net8.0/OpenTelemetry.Instrumentation.AspNetCore.dll
+ opentelemetry.instrumentation.sqlclient/1.9.0-beta.1/lib/net8.0/OpenTelemetry.Instrumentation.SqlClient.dll
+ opentelemetry.persistentstorage.abstractions/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.Abstractions.dll
+ opentelemetry.persistentstorage.filesystem/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.FileSystem.dll
+ opentelemetry/1.10.0/lib/net9.0/OpenTelemetry.dll
+ pipelines.sockets.unofficial/2.2.8/lib/net5.0/Pipelines.Sockets.Unofficial.dll
+ polly.core/8.6.6/lib/net8.0/Polly.Core.dll
+ rabbitmq.client/6.8.1/lib/netstandard2.0/RabbitMQ.Client.dll
+ stackexchange.redis/2.8.16/lib/net6.0/StackExchange.Redis.dll
+ swashbuckle.aspnetcore.swagger/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.Swagger.dll
+ swashbuckle.aspnetcore.swaggergen/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.dll
+ swashbuckle.aspnetcore.swaggerui/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.dll
+ system.clientmodel/1.5.1/lib/net8.0/System.ClientModel.dll
+ system.identitymodel.tokens.jwt/8.0.1/lib/net9.0/System.IdentityModel.Tokens.Jwt.dll
+ system.memory.data/8.0.1/lib/net8.0/System.Memory.Data.dll
+ system.security.cryptography.pkcs/9.0.4/lib/net9.0/System.Security.Cryptography.Pkcs.dll
+ system.security.cryptography.protecteddata/9.0.4/lib/net9.0/System.Security.Cryptography.ProtectedData.dll
 
 [analyzerReferences]
 <DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/analyzers/dotnet/cs/
@@ -469,6 +522,12 @@ Program.cs
  Microsoft.CodeAnalysis.CodeStyle.Fixes.dll
  Microsoft.CodeAnalysis.CSharp.CodeStyle.dll
  Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.dll
+<NUGET>/microsoft.codeanalysis.analyzers/3.11.0/analyzers/dotnet/cs/
+ Microsoft.CodeAnalysis.Analyzers.dll
+ Microsoft.CodeAnalysis.CSharp.Analyzers.dll
+<NUGET>/
+ microsoft.entityframeworkcore.analyzers/10.0.5/analyzers/dotnet/cs/Microsoft.EntityFrameworkCore.Analyzers.dll
+ system.clientmodel/1.5.1/analyzers/dotnet/cs/System.ClientModel.SourceGeneration.dll
 
 [analyzerConfigFiles]
 ../../.editorconfig

--- a/shipping-microservice/Shipping.Service/Shipping.Service.csproj.lscache
+++ b/shipping-microservice/Shipping.Service/Shipping.Service.csproj.lscache
@@ -437,59 +437,6 @@ Program.cs
  System.Xml.XPath.dll
  System.Xml.XPath.XDocument.dll
  WindowsBase.dll
-<NUGET>/
- azure.core.amqp/1.3.1/lib/netstandard2.0/Azure.Core.Amqp.dll
- azure.core/1.47.1/lib/net8.0/Azure.Core.dll
- azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
- azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
- azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
- ecommerce.shared/2.16.0/lib/net10.0/ECommerce.Shared.dll
- google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
- grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
- grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll
- grpc.net.common/2.52.0/lib/net7.0/Grpc.Net.Common.dll
- microsoft.aspnetcore.authentication.jwtbearer/10.0.5/lib/net10.0/Microsoft.AspNetCore.Authentication.JwtBearer.dll
- microsoft.azure.amqp/2.6.7/lib/netstandard2.0/Microsoft.Azure.Amqp.dll
- microsoft.bcl.asyncinterfaces/8.0.0/lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll
- microsoft.bcl.cryptography/9.0.4/lib/net9.0/Microsoft.Bcl.Cryptography.dll
- microsoft.data.sqlclient/6.1.1/ref/net9.0/Microsoft.Data.SqlClient.dll
- microsoft.entityframeworkcore.abstractions/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Abstractions.dll
- microsoft.entityframeworkcore.relational/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Relational.dll
- microsoft.entityframeworkcore.sqlserver/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.SqlServer.dll
- microsoft.entityframeworkcore/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.dll
- microsoft.identity.client.extensions.msal/4.73.1/lib/net8.0/Microsoft.Identity.Client.Extensions.Msal.dll
- microsoft.identity.client/4.73.1/lib/net8.0/Microsoft.Identity.Client.dll
- microsoft.identitymodel.abstractions/8.0.1/lib/net9.0/Microsoft.IdentityModel.Abstractions.dll
- microsoft.identitymodel.jsonwebtokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.JsonWebTokens.dll
- microsoft.identitymodel.logging/8.0.1/lib/net9.0/Microsoft.IdentityModel.Logging.dll
- microsoft.identitymodel.protocols.openidconnect/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.dll
- microsoft.identitymodel.protocols/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.dll
- microsoft.identitymodel.tokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.Tokens.dll
- microsoft.openapi/1.6.14/lib/netstandard2.0/Microsoft.OpenApi.dll
- microsoft.sqlserver.server/1.0.0/lib/netstandard2.0/Microsoft.SqlServer.Server.dll
- opentelemetry.api.providerbuilderextensions/1.10.0/lib/net9.0/OpenTelemetry.Api.ProviderBuilderExtensions.dll
- opentelemetry.api/1.10.0/lib/net9.0/OpenTelemetry.Api.dll
- opentelemetry.exporter.console/1.9.0/lib/net8.0/OpenTelemetry.Exporter.Console.dll
- opentelemetry.exporter.opentelemetryprotocol/1.9.0/lib/net8.0/OpenTelemetry.Exporter.OpenTelemetryProtocol.dll
- opentelemetry.exporter.prometheus.aspnetcore/1.10.0-beta.1/lib/net9.0/OpenTelemetry.Exporter.Prometheus.AspNetCore.dll
- opentelemetry.extensions.hosting/1.9.0/lib/net8.0/OpenTelemetry.Extensions.Hosting.dll
- opentelemetry.instrumentation.aspnetcore/1.9.0/lib/net8.0/OpenTelemetry.Instrumentation.AspNetCore.dll
- opentelemetry.instrumentation.sqlclient/1.9.0-beta.1/lib/net8.0/OpenTelemetry.Instrumentation.SqlClient.dll
- opentelemetry.persistentstorage.abstractions/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.Abstractions.dll
- opentelemetry.persistentstorage.filesystem/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.FileSystem.dll
- opentelemetry/1.10.0/lib/net9.0/OpenTelemetry.dll
- pipelines.sockets.unofficial/2.2.8/lib/net5.0/Pipelines.Sockets.Unofficial.dll
- polly.core/8.6.6/lib/net8.0/Polly.Core.dll
- rabbitmq.client/6.8.1/lib/netstandard2.0/RabbitMQ.Client.dll
- stackexchange.redis/2.8.16/lib/net6.0/StackExchange.Redis.dll
- swashbuckle.aspnetcore.swagger/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.Swagger.dll
- swashbuckle.aspnetcore.swaggergen/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.dll
- swashbuckle.aspnetcore.swaggerui/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.dll
- system.clientmodel/1.5.1/lib/net8.0/System.ClientModel.dll
- system.identitymodel.tokens.jwt/8.0.1/lib/net9.0/System.IdentityModel.Tokens.Jwt.dll
- system.memory.data/8.0.1/lib/net8.0/System.Memory.Data.dll
- system.security.cryptography.pkcs/9.0.4/lib/net9.0/System.Security.Cryptography.Pkcs.dll
- system.security.cryptography.protecteddata/9.0.4/lib/net9.0/System.Security.Cryptography.ProtectedData.dll
 
 [analyzerReferences]
 <DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/analyzers/dotnet/cs/
@@ -522,12 +469,6 @@ Program.cs
  Microsoft.CodeAnalysis.CodeStyle.Fixes.dll
  Microsoft.CodeAnalysis.CSharp.CodeStyle.dll
  Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.dll
-<NUGET>/microsoft.codeanalysis.analyzers/3.11.0/analyzers/dotnet/cs/
- Microsoft.CodeAnalysis.Analyzers.dll
- Microsoft.CodeAnalysis.CSharp.Analyzers.dll
-<NUGET>/
- microsoft.entityframeworkcore.analyzers/10.0.5/analyzers/dotnet/cs/Microsoft.EntityFrameworkCore.Analyzers.dll
- system.clientmodel/1.5.1/analyzers/dotnet/cs/System.ClientModel.SourceGeneration.dll
 
 [analyzerConfigFiles]
 ../../.editorconfig

--- a/shipping-microservice/Shipping.Service/Shipping.Service.csproj.lscache
+++ b/shipping-microservice/Shipping.Service/Shipping.Service.csproj.lscache
@@ -1,0 +1,535 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[properties]
+AssemblyName=Shipping.Service
+CommandLineArgsForDesignTimeEvaluation=-langversion:14.0 -define:TRACE
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=14.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=Shipping.Service
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../../MicroservicesInDotNet.sln
+TargetFrameworkIdentifier=.NETCoreApp
+TargetPath=<PATH>bin/Debug/net10.0/Shipping.Service.dll
+TargetRefPath=<PATH>obj/Debug/net10.0/ref/Shipping.Service.dll
+TemporaryDependencyNodeTargetIdentifier=net10.0
+
+[commandLineArguments]
+/noconfig
+/unsafe-
+/checked-
+/nowarn:NU1603,NU1902,NU1903,NU5104,CA1711,CA1707,CA1716,1701,1702,8002
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/warn:10
+/define:TRACE;DEBUG;NET;NET10_0;NETCOREAPP;NET5_0_OR_GREATER;NET6_0_OR_GREATER;NET7_0_OR_GREATER;NET8_0_OR_GREATER;NET9_0_OR_GREATER;NET10_0_OR_GREATER;NETCOREAPP1_0_OR_GREATER;NETCOREAPP1_1_OR_GREATER;NETCOREAPP2_0_OR_GREATER;NETCOREAPP2_1_OR_GREATER;NETCOREAPP2_2_OR_GREATER;NETCOREAPP3_0_OR_GREATER;NETCOREAPP3_1_OR_GREATER
+/highentropyva+
+/nullable:enable
+/features:"InterceptorsNamespaces=;Microsoft.Extensions.Validation.Generated"
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\net10.0\Shipping.Service.dll
+/refout:obj\Debug\net10.0\refint\Shipping.Service.dll
+/target:exe
+/warnaserror+
+/utf8output
+/deterministic+
+/langversion:14.0
+/features:use-roslyn-tokenizer=true
+/warnaserror+:NU1605,SYSLIB0011
+
+[sourceFiles]
+ApiModels/
+ CancelShipmentRequest.cs
+ DispatchShipmentRequest.cs
+ ShipmentResponse.cs
+ TerminalTransitionRequests.cs
+Carriers/
+ CarrierPollingService.cs
+ CarrierStatusApplier.cs
+ CarrierWebhookOptions.cs
+ FakeCarrierDispatchRegistry.cs
+ FakeCarrierWebhookParser.cs
+ FakeExpressCarrierGateway.cs
+ FakeGroundCarrierGateway.cs
+ ICarrierGateway.cs
+ RateShoppingService.cs
+Endpoints/
+ InternalOutboxEndpoints.cs
+ ShippingApiEndpoints.cs
+Infrastructure/Data/EntityFramework/
+ EntityFrameworkExtensions.cs
+ OrderConfirmationConfiguration.cs
+ ShipmentConfiguration.cs
+ ShipmentLineConfiguration.cs
+ ShipmentStatusHistoryEntryConfiguration.cs
+ ShippingContext.cs
+ ShippingContextDesignTimeFactory.cs
+ ShippingContextSeed.cs
+ ShippingQaFixtures.cs
+ WarehouseConfiguration.cs
+Infrastructure/Data/IShipmentStore.cs
+IntegrationEvents/EventHandlers/
+ OrderCancelledEventHandler.cs
+ OrderConfirmedEventHandler.cs
+ StockCommittedEventHandler.cs
+IntegrationEvents/
+ OrderCancelledEvent.cs
+ OrderConfirmedEvent.cs
+ ShipmentCancelledEvent.cs
+ ShipmentCreatedEvent.cs
+ ShipmentDeliveredEvent.cs
+ ShipmentDispatchedEvent.cs
+ ShipmentFailedEvent.cs
+ ShipmentReturnedEvent.cs
+ ShipmentStatusChangedEvent.cs
+ StockCommittedEvent.cs
+Migrations/
+ 20260424015621_InitialCreate.cs
+ 20260424015621_InitialCreate.Designer.cs
+ 20260425000000_AddShipmentStatusHistory.cs
+ 20260425000000_AddShipmentStatusHistory.Designer.cs
+ 20260425100000_AddShipmentCarrierFields.cs
+ 20260425100000_AddShipmentCarrierFields.Designer.cs
+ 20260508120000_SeedQaPhase3b_Shipping.cs
+ 20260508120000_SeedQaPhase3b_Shipping.Designer.cs
+ ShippingContextModelSnapshot.cs
+Models/
+ Money.cs
+ OrderConfirmation.cs
+ Shipment.cs
+ ShipmentLine.cs
+ ShipmentStatus.cs
+ ShipmentStatusHistoryEntry.cs
+ ShipmentStatusSource.cs
+ ShippingAddress.cs
+ Warehouse.cs
+obj/Debug/net10.0/
+ .NETCoreApp,Version=v10.0.AssemblyAttributes.cs
+ Shipping.Service.AssemblyInfo.cs
+ Shipping.Service.GlobalUsings.g.cs
+Observability/ShippingMetrics.cs
+Program.cs
+
+[metadataReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.AspNetCore.Antiforgery.dll
+ Microsoft.AspNetCore.Authentication.Abstractions.dll
+ Microsoft.AspNetCore.Authentication.BearerToken.dll
+ Microsoft.AspNetCore.Authentication.Cookies.dll
+ Microsoft.AspNetCore.Authentication.Core.dll
+ Microsoft.AspNetCore.Authentication.dll
+ Microsoft.AspNetCore.Authentication.OAuth.dll
+ Microsoft.AspNetCore.Authorization.dll
+ Microsoft.AspNetCore.Authorization.Policy.dll
+ Microsoft.AspNetCore.Components.Authorization.dll
+ Microsoft.AspNetCore.Components.dll
+ Microsoft.AspNetCore.Components.Endpoints.dll
+ Microsoft.AspNetCore.Components.Forms.dll
+ Microsoft.AspNetCore.Components.Server.dll
+ Microsoft.AspNetCore.Components.Web.dll
+ Microsoft.AspNetCore.Connections.Abstractions.dll
+ Microsoft.AspNetCore.CookiePolicy.dll
+ Microsoft.AspNetCore.Cors.dll
+ Microsoft.AspNetCore.Cryptography.Internal.dll
+ Microsoft.AspNetCore.Cryptography.KeyDerivation.dll
+ Microsoft.AspNetCore.DataProtection.Abstractions.dll
+ Microsoft.AspNetCore.DataProtection.dll
+ Microsoft.AspNetCore.DataProtection.Extensions.dll
+ Microsoft.AspNetCore.Diagnostics.Abstractions.dll
+ Microsoft.AspNetCore.Diagnostics.dll
+ Microsoft.AspNetCore.Diagnostics.HealthChecks.dll
+ Microsoft.AspNetCore.dll
+ Microsoft.AspNetCore.HostFiltering.dll
+ Microsoft.AspNetCore.Hosting.Abstractions.dll
+ Microsoft.AspNetCore.Hosting.dll
+ Microsoft.AspNetCore.Hosting.Server.Abstractions.dll
+ Microsoft.AspNetCore.Html.Abstractions.dll
+ Microsoft.AspNetCore.Http.Abstractions.dll
+ Microsoft.AspNetCore.Http.Connections.Common.dll
+ Microsoft.AspNetCore.Http.Connections.dll
+ Microsoft.AspNetCore.Http.dll
+ Microsoft.AspNetCore.Http.Extensions.dll
+ Microsoft.AspNetCore.Http.Features.dll
+ Microsoft.AspNetCore.Http.Results.dll
+ Microsoft.AspNetCore.HttpLogging.dll
+ Microsoft.AspNetCore.HttpOverrides.dll
+ Microsoft.AspNetCore.HttpsPolicy.dll
+ Microsoft.AspNetCore.Identity.dll
+ Microsoft.AspNetCore.Localization.dll
+ Microsoft.AspNetCore.Localization.Routing.dll
+ Microsoft.AspNetCore.Metadata.dll
+ Microsoft.AspNetCore.Mvc.Abstractions.dll
+ Microsoft.AspNetCore.Mvc.ApiExplorer.dll
+ Microsoft.AspNetCore.Mvc.Core.dll
+ Microsoft.AspNetCore.Mvc.Cors.dll
+ Microsoft.AspNetCore.Mvc.DataAnnotations.dll
+ Microsoft.AspNetCore.Mvc.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Json.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Xml.dll
+ Microsoft.AspNetCore.Mvc.Localization.dll
+ Microsoft.AspNetCore.Mvc.Razor.dll
+ Microsoft.AspNetCore.Mvc.RazorPages.dll
+ Microsoft.AspNetCore.Mvc.TagHelpers.dll
+ Microsoft.AspNetCore.Mvc.ViewFeatures.dll
+ Microsoft.AspNetCore.OutputCaching.dll
+ Microsoft.AspNetCore.RateLimiting.dll
+ Microsoft.AspNetCore.Razor.dll
+ Microsoft.AspNetCore.Razor.Runtime.dll
+ Microsoft.AspNetCore.RequestDecompression.dll
+ Microsoft.AspNetCore.ResponseCaching.Abstractions.dll
+ Microsoft.AspNetCore.ResponseCaching.dll
+ Microsoft.AspNetCore.ResponseCompression.dll
+ Microsoft.AspNetCore.Rewrite.dll
+ Microsoft.AspNetCore.Routing.Abstractions.dll
+ Microsoft.AspNetCore.Routing.dll
+ Microsoft.AspNetCore.Server.HttpSys.dll
+ Microsoft.AspNetCore.Server.IIS.dll
+ Microsoft.AspNetCore.Server.IISIntegration.dll
+ Microsoft.AspNetCore.Server.Kestrel.Core.dll
+ Microsoft.AspNetCore.Server.Kestrel.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll
+ Microsoft.AspNetCore.Session.dll
+ Microsoft.AspNetCore.SignalR.Common.dll
+ Microsoft.AspNetCore.SignalR.Core.dll
+ Microsoft.AspNetCore.SignalR.dll
+ Microsoft.AspNetCore.SignalR.Protocols.Json.dll
+ Microsoft.AspNetCore.StaticAssets.dll
+ Microsoft.AspNetCore.StaticFiles.dll
+ Microsoft.AspNetCore.WebSockets.dll
+ Microsoft.AspNetCore.WebUtilities.dll
+ Microsoft.Extensions.Caching.Abstractions.dll
+ Microsoft.Extensions.Caching.Memory.dll
+ Microsoft.Extensions.Configuration.Abstractions.dll
+ Microsoft.Extensions.Configuration.Binder.dll
+ Microsoft.Extensions.Configuration.CommandLine.dll
+ Microsoft.Extensions.Configuration.dll
+ Microsoft.Extensions.Configuration.EnvironmentVariables.dll
+ Microsoft.Extensions.Configuration.FileExtensions.dll
+ Microsoft.Extensions.Configuration.Ini.dll
+ Microsoft.Extensions.Configuration.Json.dll
+ Microsoft.Extensions.Configuration.KeyPerFile.dll
+ Microsoft.Extensions.Configuration.UserSecrets.dll
+ Microsoft.Extensions.Configuration.Xml.dll
+ Microsoft.Extensions.DependencyInjection.Abstractions.dll
+ Microsoft.Extensions.DependencyInjection.dll
+ Microsoft.Extensions.Diagnostics.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.dll
+ Microsoft.Extensions.Features.dll
+ Microsoft.Extensions.FileProviders.Abstractions.dll
+ Microsoft.Extensions.FileProviders.Composite.dll
+ Microsoft.Extensions.FileProviders.Embedded.dll
+ Microsoft.Extensions.FileProviders.Physical.dll
+ Microsoft.Extensions.FileSystemGlobbing.dll
+ Microsoft.Extensions.Hosting.Abstractions.dll
+ Microsoft.Extensions.Hosting.dll
+ Microsoft.Extensions.Http.dll
+ Microsoft.Extensions.Identity.Core.dll
+ Microsoft.Extensions.Identity.Stores.dll
+ Microsoft.Extensions.Localization.Abstractions.dll
+ Microsoft.Extensions.Localization.dll
+ Microsoft.Extensions.Logging.Abstractions.dll
+ Microsoft.Extensions.Logging.Configuration.dll
+ Microsoft.Extensions.Logging.Console.dll
+ Microsoft.Extensions.Logging.Debug.dll
+ Microsoft.Extensions.Logging.dll
+ Microsoft.Extensions.Logging.EventLog.dll
+ Microsoft.Extensions.Logging.EventSource.dll
+ Microsoft.Extensions.Logging.TraceSource.dll
+ Microsoft.Extensions.ObjectPool.dll
+ Microsoft.Extensions.Options.ConfigurationExtensions.dll
+ Microsoft.Extensions.Options.DataAnnotations.dll
+ Microsoft.Extensions.Options.dll
+ Microsoft.Extensions.Primitives.dll
+ Microsoft.Extensions.Validation.dll
+ Microsoft.Extensions.WebEncoders.dll
+ Microsoft.JSInterop.dll
+ Microsoft.Net.Http.Headers.dll
+ System.Diagnostics.EventLog.dll
+ System.Formats.Cbor.dll
+ System.Security.Cryptography.Xml.dll
+ System.Threading.RateLimiting.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.CSharp.dll
+ Microsoft.VisualBasic.Core.dll
+ Microsoft.VisualBasic.dll
+ Microsoft.Win32.Primitives.dll
+ Microsoft.Win32.Registry.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.Immutable.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Annotations.dll
+ System.ComponentModel.DataAnnotations.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Configuration.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.DataSetExtensions.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.DiagnosticSource.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Formats.Asn1.dll
+ System.Formats.Tar.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.Brotli.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.AccessControl.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipelines.dll
+ System.IO.Pipes.AccessControl.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.AsyncEnumerable.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.Http.Json.dll
+ System.Net.HttpListener.dll
+ System.Net.Mail.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Quic.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.ServerSentEvents.dll
+ System.Net.ServicePoint.dll
+ System.Net.Sockets.dll
+ System.Net.WebClient.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebProxy.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Metadata.dll
+ System.Reflection.Primitives.dll
+ System.Reflection.TypeExtensions.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.Unsafe.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.JavaScript.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Intrinsics.dll
+ System.Runtime.Loader.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.AccessControl.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Cng.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.OpenSsl.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.dll
+ System.Security.Principal.dll
+ System.Security.Principal.Windows.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.ServiceProcess.dll
+ System.Text.Encoding.CodePages.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.Encodings.Web.dll
+ System.Text.Json.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.AccessControl.dll
+ System.Threading.Channels.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.Dataflow.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.Transactions.Local.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Web.HttpUtility.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+ WindowsBase.dll
+<NUGET>/
+ azure.core.amqp/1.3.1/lib/netstandard2.0/Azure.Core.Amqp.dll
+ azure.core/1.47.1/lib/net8.0/Azure.Core.dll
+ azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
+ azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
+ azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
+ ecommerce.shared/2.14.0/lib/net10.0/ECommerce.Shared.dll
+ google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
+ grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
+ grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll
+ grpc.net.common/2.52.0/lib/net7.0/Grpc.Net.Common.dll
+ microsoft.aspnetcore.authentication.jwtbearer/10.0.5/lib/net10.0/Microsoft.AspNetCore.Authentication.JwtBearer.dll
+ microsoft.azure.amqp/2.6.7/lib/netstandard2.0/Microsoft.Azure.Amqp.dll
+ microsoft.bcl.asyncinterfaces/8.0.0/lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll
+ microsoft.bcl.cryptography/9.0.4/lib/net9.0/Microsoft.Bcl.Cryptography.dll
+ microsoft.data.sqlclient/6.1.1/ref/net9.0/Microsoft.Data.SqlClient.dll
+ microsoft.entityframeworkcore.abstractions/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Abstractions.dll
+ microsoft.entityframeworkcore.relational/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Relational.dll
+ microsoft.entityframeworkcore.sqlserver/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.SqlServer.dll
+ microsoft.entityframeworkcore/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.dll
+ microsoft.identity.client.extensions.msal/4.73.1/lib/net8.0/Microsoft.Identity.Client.Extensions.Msal.dll
+ microsoft.identity.client/4.73.1/lib/net8.0/Microsoft.Identity.Client.dll
+ microsoft.identitymodel.abstractions/8.0.1/lib/net9.0/Microsoft.IdentityModel.Abstractions.dll
+ microsoft.identitymodel.jsonwebtokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.JsonWebTokens.dll
+ microsoft.identitymodel.logging/8.0.1/lib/net9.0/Microsoft.IdentityModel.Logging.dll
+ microsoft.identitymodel.protocols.openidconnect/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.dll
+ microsoft.identitymodel.protocols/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.dll
+ microsoft.identitymodel.tokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.Tokens.dll
+ microsoft.openapi/1.6.14/lib/netstandard2.0/Microsoft.OpenApi.dll
+ microsoft.sqlserver.server/1.0.0/lib/netstandard2.0/Microsoft.SqlServer.Server.dll
+ opentelemetry.api.providerbuilderextensions/1.10.0/lib/net9.0/OpenTelemetry.Api.ProviderBuilderExtensions.dll
+ opentelemetry.api/1.10.0/lib/net9.0/OpenTelemetry.Api.dll
+ opentelemetry.exporter.console/1.9.0/lib/net8.0/OpenTelemetry.Exporter.Console.dll
+ opentelemetry.exporter.opentelemetryprotocol/1.9.0/lib/net8.0/OpenTelemetry.Exporter.OpenTelemetryProtocol.dll
+ opentelemetry.exporter.prometheus.aspnetcore/1.10.0-beta.1/lib/net9.0/OpenTelemetry.Exporter.Prometheus.AspNetCore.dll
+ opentelemetry.extensions.hosting/1.9.0/lib/net8.0/OpenTelemetry.Extensions.Hosting.dll
+ opentelemetry.instrumentation.aspnetcore/1.9.0/lib/net8.0/OpenTelemetry.Instrumentation.AspNetCore.dll
+ opentelemetry.instrumentation.sqlclient/1.9.0-beta.1/lib/net8.0/OpenTelemetry.Instrumentation.SqlClient.dll
+ opentelemetry.persistentstorage.abstractions/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.Abstractions.dll
+ opentelemetry.persistentstorage.filesystem/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.FileSystem.dll
+ opentelemetry/1.10.0/lib/net9.0/OpenTelemetry.dll
+ pipelines.sockets.unofficial/2.2.8/lib/net5.0/Pipelines.Sockets.Unofficial.dll
+ polly.core/8.6.6/lib/net8.0/Polly.Core.dll
+ rabbitmq.client/6.8.1/lib/netstandard2.0/RabbitMQ.Client.dll
+ stackexchange.redis/2.8.16/lib/net6.0/StackExchange.Redis.dll
+ swashbuckle.aspnetcore.swagger/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.Swagger.dll
+ swashbuckle.aspnetcore.swaggergen/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.dll
+ swashbuckle.aspnetcore.swaggerui/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.dll
+ system.clientmodel/1.5.1/lib/net8.0/System.ClientModel.dll
+ system.identitymodel.tokens.jwt/8.0.1/lib/net9.0/System.IdentityModel.Tokens.Jwt.dll
+ system.memory.data/8.0.1/lib/net8.0/System.Memory.Data.dll
+ system.security.cryptography.pkcs/9.0.4/lib/net9.0/System.Security.Cryptography.Pkcs.dll
+ system.security.cryptography.protecteddata/9.0.4/lib/net9.0/System.Security.Cryptography.ProtectedData.dll
+
+[analyzerReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.AspNetCore.App.Analyzers.dll
+ Microsoft.AspNetCore.App.CodeFixes.dll
+ Microsoft.AspNetCore.App.SourceGenerators.dll
+ Microsoft.AspNetCore.Components.Analyzers.dll
+ Microsoft.Extensions.Logging.Generators.dll
+ Microsoft.Extensions.Options.SourceGeneration.dll
+ Microsoft.Extensions.Validation.ValidationsGenerator.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.Interop.ComInterfaceGenerator.dll
+ Microsoft.Interop.JavaScript.JSImportGenerator.dll
+ Microsoft.Interop.LibraryImportGenerator.dll
+ Microsoft.Interop.SourceGeneration.dll
+ System.Text.Json.SourceGeneration.dll
+ System.Text.RegularExpressions.Generator.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk.Razor/source-generators/
+ Microsoft.AspNetCore.Razor.Utilities.Shared.dll
+ Microsoft.CodeAnalysis.Razor.Compiler.dll
+ Microsoft.Extensions.ObjectPool.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk.Web/analyzers/cs/
+ Microsoft.AspNetCore.Analyzers.dll
+ Microsoft.AspNetCore.Mvc.Analyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/
+ Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll
+ Microsoft.CodeAnalysis.NetAnalyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/codestyle/cs/
+ Microsoft.CodeAnalysis.CodeStyle.dll
+ Microsoft.CodeAnalysis.CodeStyle.Fixes.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.dll
+<NUGET>/microsoft.codeanalysis.analyzers/3.11.0/analyzers/dotnet/cs/
+ Microsoft.CodeAnalysis.Analyzers.dll
+ Microsoft.CodeAnalysis.CSharp.Analyzers.dll
+<NUGET>/
+ microsoft.entityframeworkcore.analyzers/10.0.5/analyzers/dotnet/cs/Microsoft.EntityFrameworkCore.Analyzers.dll
+ system.clientmodel/1.5.1/analyzers/dotnet/cs/System.ClientModel.SourceGeneration.dll
+
+[analyzerConfigFiles]
+../../.editorconfig
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_10_recommended.globalconfig
+obj/Debug/net10.0/Shipping.Service.GeneratedMSBuildEditorConfig.editorconfig

--- a/shipping-microservice/Shipping.Service/Shipping.Service.csproj.lscache
+++ b/shipping-microservice/Shipping.Service/Shipping.Service.csproj.lscache
@@ -443,7 +443,7 @@ Program.cs
  azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
  azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
  azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
- ecommerce.shared/2.14.0/lib/net10.0/ECommerce.Shared.dll
+ ecommerce.shared/2.15.0/lib/net10.0/ECommerce.Shared.dll
  google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
  grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
  grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll

--- a/shipping-microservice/Shipping.Service/Shipping.Service.csproj.lscache
+++ b/shipping-microservice/Shipping.Service/Shipping.Service.csproj.lscache
@@ -443,7 +443,7 @@ Program.cs
  azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
  azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
  azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
- ecommerce.shared/2.15.0/lib/net10.0/ECommerce.Shared.dll
+ ecommerce.shared/2.16.0/lib/net10.0/ECommerce.Shared.dll
  google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
  grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
  grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll

--- a/shipping-microservice/Shipping.Tests/Carriers/CarrierStatusApplierTests.cs
+++ b/shipping-microservice/Shipping.Tests/Carriers/CarrierStatusApplierTests.cs
@@ -1,0 +1,102 @@
+using Shipping.Service.Carriers;
+using Shipping.Service.IntegrationEvents;
+using Shipping.Service.Models;
+
+namespace Shipping.Tests.Carriers;
+
+public class CarrierStatusApplierTests
+{
+    [Fact]
+    public async Task Given_DeliveredCarrierStatus_When_Applied_Then_ReturnsMilestoneAndStatusChangedEvents()
+    {
+        var shipmentId = Guid.NewGuid();
+        var orderId = Guid.NewGuid();
+        var occurredAt = new DateTime(2026, 5, 16, 9, 30, 0, DateTimeKind.Utc);
+        var shipment = CreateShippedShipment(shipmentId, orderId);
+
+        var events = await CarrierStatusApplier.ApplyAsync(
+            shipment,
+            new CarrierStatus(CarrierStatusCode.Delivered, Detail: null),
+            ShipmentStatusSource.CarrierWebhook,
+            occurredAt);
+
+        Assert.Equal(ShipmentStatus.Delivered, shipment.Status);
+        Assert.Collection(
+            events,
+            evt =>
+            {
+                var delivered = Assert.IsType<ShipmentDeliveredEvent>(evt);
+                Assert.Equal(shipmentId, delivered.ShipmentId);
+                Assert.Equal(orderId, delivered.OrderId);
+                Assert.Equal(occurredAt, delivered.OccurredAt);
+            },
+            evt =>
+            {
+                var changed = Assert.IsType<ShipmentStatusChangedEvent>(evt);
+                Assert.Equal(shipmentId, changed.ShipmentId);
+                Assert.Equal(ShipmentStatus.Shipped, changed.FromStatus);
+                Assert.Equal(ShipmentStatus.Delivered, changed.ToStatus);
+                Assert.Equal(occurredAt, changed.OccurredAt);
+            });
+    }
+
+    [Fact]
+    public async Task Given_FailedCarrierStatus_When_Applied_Then_ReturnsFailureAndStatusChangedEvents()
+    {
+        var shipmentId = Guid.NewGuid();
+        var orderId = Guid.NewGuid();
+        var occurredAt = new DateTime(2026, 5, 16, 9, 45, 0, DateTimeKind.Utc);
+        var shipment = CreateShippedShipment(shipmentId, orderId);
+
+        var events = await CarrierStatusApplier.ApplyAsync(
+            shipment,
+            new CarrierStatus(CarrierStatusCode.Failed, Detail: "Carrier damaged package"),
+            ShipmentStatusSource.CarrierPoll,
+            occurredAt);
+
+        Assert.Equal(ShipmentStatus.Failed, shipment.Status);
+        Assert.Collection(
+            events,
+            evt =>
+            {
+                var failed = Assert.IsType<ShipmentFailedEvent>(evt);
+                Assert.Equal(shipmentId, failed.ShipmentId);
+                Assert.Equal(orderId, failed.OrderId);
+                Assert.Equal("Carrier damaged package", failed.Reason);
+                Assert.Equal(occurredAt, failed.OccurredAt);
+            },
+            evt =>
+            {
+                var changed = Assert.IsType<ShipmentStatusChangedEvent>(evt);
+                Assert.Equal(shipmentId, changed.ShipmentId);
+                Assert.Equal(ShipmentStatus.Shipped, changed.FromStatus);
+                Assert.Equal(ShipmentStatus.Failed, changed.ToStatus);
+                Assert.Equal(occurredAt, changed.OccurredAt);
+            });
+    }
+
+    private static Shipment CreateShippedShipment(Guid shipmentId, Guid orderId)
+    {
+        var shipment = Shipment.Create(
+            id: shipmentId,
+            orderId: orderId,
+            customerId: "cust-carrier-status",
+            warehouseId: 1,
+            createdAt: new DateTime(2026, 5, 16, 8, 0, 0, DateTimeKind.Utc));
+        shipment.AddLine(productId: 1, quantity: 1);
+
+        var transitionAt = new DateTime(2026, 5, 16, 8, 5, 0, DateTimeKind.Utc);
+        Assert.True(shipment.TryPick(transitionAt, ShipmentStatusSource.Admin));
+        Assert.True(shipment.TryPack(transitionAt, ShipmentStatusSource.Admin));
+        Assert.True(shipment.TryDispatch(
+            carrierKey: FakeGroundCarrierGateway.Key,
+            trackingNumber: $"GND-{shipmentId:N}".ToUpperInvariant(),
+            labelRef: "label://fake-ground/test",
+            quotedPrice: Money.Usd(5m),
+            shippingAddress: new ShippingAddress("A", "B", null, "C", null, "00000", "US"),
+            occurredAt: transitionAt,
+            source: ShipmentStatusSource.Admin));
+
+        return shipment;
+    }
+}

--- a/shipping-microservice/Shipping.Tests/Shipping.Tests.csproj.lscache
+++ b/shipping-microservice/Shipping.Tests/Shipping.Tests.csproj.lscache
@@ -69,6 +69,7 @@ Authentication/TestAuthHandler.cs
 Carriers/
  CarrierGatewayContractTests.cs
  CarrierPollingServiceTests.cs
+ CarrierStatusApplierTests.cs
  RateShoppingServiceTests.cs
 Domain/
  QaSeedFixturesTests.cs

--- a/shipping-microservice/Shipping.Tests/Shipping.Tests.csproj.lscache
+++ b/shipping-microservice/Shipping.Tests/Shipping.Tests.csproj.lscache
@@ -1,0 +1,506 @@
+version=1
+
+# This file caches language service data to improve the performance of C# Dev Kit.
+# It is not intended for manual editing. It can safely be deleted and will be
+# regenerated automatically. For more information, see https://aka.ms/lscache
+#
+# To control where cache files are stored, use the following VS Code setting:
+#   "dotnet.projectsystem.cacheInProjectFolder": true
+
+[project]
+language=C#
+primary
+lastDtbSucceeded
+
+[properties]
+AssemblyName=Shipping.Tests
+CommandLineArgsForDesignTimeEvaluation=-langversion:14.0 -define:TRACE
+CompilerGeneratedFilesOutputPath=
+MaxSupportedLangVersion=14.0
+ProjectAssetsFile=<PATH>obj/project.assets.json
+RootNamespace=Shipping.Tests
+RunAnalyzers=
+RunAnalyzersDuringLiveAnalysis=
+SolutionPath=<PATH>../../MicroservicesInDotNet.sln
+TargetFrameworkIdentifier=.NETCoreApp
+TargetPath=<PATH>bin/Debug/net10.0/Shipping.Tests.dll
+TargetRefPath=<PATH>obj/Debug/net10.0/ref/Shipping.Tests.dll
+TemporaryDependencyNodeTargetIdentifier=net10.0
+
+[commandLineArguments]
+/noconfig
+/unsafe-
+/checked-
+/nowarn:NU1603,NU1902,NU1903,NU5104,CA1711,CA1707,CA1716,1701,1702,8002
+/fullpaths
+/nostdlib+
+/errorreport:prompt
+/warn:10
+/define:TRACE;DEBUG;NET;NET10_0;NETCOREAPP;NET5_0_OR_GREATER;NET6_0_OR_GREATER;NET7_0_OR_GREATER;NET8_0_OR_GREATER;NET9_0_OR_GREATER;NET10_0_OR_GREATER;NETCOREAPP1_0_OR_GREATER;NETCOREAPP1_1_OR_GREATER;NETCOREAPP2_0_OR_GREATER;NETCOREAPP2_1_OR_GREATER;NETCOREAPP2_2_OR_GREATER;NETCOREAPP3_0_OR_GREATER;NETCOREAPP3_1_OR_GREATER
+/highentropyva+
+/nullable:enable
+/features:"InterceptorsNamespaces=;Microsoft.Extensions.Validation.Generated"
+/debug+
+/debug:portable
+/filealign:512
+/optimize-
+/out:obj\Debug\net10.0\Shipping.Tests.dll
+/refout:obj\Debug\net10.0\refint\Shipping.Tests.dll
+/target:exe
+/warnaserror+
+/utf8output
+/deterministic+
+/langversion:14.0
+/warnaserror+:NU1605,SYSLIB0011
+
+[sourceFiles]
+<NUGET>/microsoft.net.test.sdk/17.14.1/build/net8.0/Microsoft.NET.Test.Sdk.Program.cs
+Api/
+ GetShipmentsByOrderTests.cs
+ HealthChecksTests.cs
+ InternalOutboxEndpointsTests.cs
+ ListShipmentsTests.cs
+ ShipmentDispatchEndpointsTests.cs
+ ShipmentOwnershipTests.cs
+ ShipmentTerminalTransitionTests.cs
+ ShipmentTransitionEndpointsTests.cs
+ ShipmentWebhookTests.cs
+Authentication/TestAuthHandler.cs
+Carriers/
+ CarrierGatewayContractTests.cs
+ CarrierPollingServiceTests.cs
+ RateShoppingServiceTests.cs
+Domain/
+ QaSeedFixturesTests.cs
+ ShipmentTests.cs
+IntegrationEvents/
+ EventStreamConsolidationTests.cs
+ MessagingProviderBootTests.cs
+ OrderCancelledFlowTests.cs
+ ShipmentCreationFlowTests.cs
+IntegrationTestBase.cs
+obj/Debug/net10.0/
+ .NETCoreApp,Version=v10.0.AssemblyAttributes.cs
+ Shipping.Tests.AssemblyInfo.cs
+ Shipping.Tests.GlobalUsings.g.cs
+Observability/ShippingMetricsTests.cs
+ShippingWebApplicationFactory.cs
+
+[metadataReferences]
+../Shipping.Service/obj/Debug/net10.0/ref/Shipping.Service.dll
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.AspNetCore.Antiforgery.dll
+ Microsoft.AspNetCore.Authentication.Abstractions.dll
+ Microsoft.AspNetCore.Authentication.BearerToken.dll
+ Microsoft.AspNetCore.Authentication.Cookies.dll
+ Microsoft.AspNetCore.Authentication.Core.dll
+ Microsoft.AspNetCore.Authentication.dll
+ Microsoft.AspNetCore.Authentication.OAuth.dll
+ Microsoft.AspNetCore.Authorization.dll
+ Microsoft.AspNetCore.Authorization.Policy.dll
+ Microsoft.AspNetCore.Components.Authorization.dll
+ Microsoft.AspNetCore.Components.dll
+ Microsoft.AspNetCore.Components.Endpoints.dll
+ Microsoft.AspNetCore.Components.Forms.dll
+ Microsoft.AspNetCore.Components.Server.dll
+ Microsoft.AspNetCore.Components.Web.dll
+ Microsoft.AspNetCore.Connections.Abstractions.dll
+ Microsoft.AspNetCore.CookiePolicy.dll
+ Microsoft.AspNetCore.Cors.dll
+ Microsoft.AspNetCore.Cryptography.Internal.dll
+ Microsoft.AspNetCore.Cryptography.KeyDerivation.dll
+ Microsoft.AspNetCore.DataProtection.Abstractions.dll
+ Microsoft.AspNetCore.DataProtection.dll
+ Microsoft.AspNetCore.DataProtection.Extensions.dll
+ Microsoft.AspNetCore.Diagnostics.Abstractions.dll
+ Microsoft.AspNetCore.Diagnostics.dll
+ Microsoft.AspNetCore.Diagnostics.HealthChecks.dll
+ Microsoft.AspNetCore.dll
+ Microsoft.AspNetCore.HostFiltering.dll
+ Microsoft.AspNetCore.Hosting.Abstractions.dll
+ Microsoft.AspNetCore.Hosting.dll
+ Microsoft.AspNetCore.Hosting.Server.Abstractions.dll
+ Microsoft.AspNetCore.Html.Abstractions.dll
+ Microsoft.AspNetCore.Http.Abstractions.dll
+ Microsoft.AspNetCore.Http.Connections.Common.dll
+ Microsoft.AspNetCore.Http.Connections.dll
+ Microsoft.AspNetCore.Http.dll
+ Microsoft.AspNetCore.Http.Extensions.dll
+ Microsoft.AspNetCore.Http.Features.dll
+ Microsoft.AspNetCore.Http.Results.dll
+ Microsoft.AspNetCore.HttpLogging.dll
+ Microsoft.AspNetCore.HttpOverrides.dll
+ Microsoft.AspNetCore.HttpsPolicy.dll
+ Microsoft.AspNetCore.Identity.dll
+ Microsoft.AspNetCore.Localization.dll
+ Microsoft.AspNetCore.Localization.Routing.dll
+ Microsoft.AspNetCore.Metadata.dll
+ Microsoft.AspNetCore.Mvc.Abstractions.dll
+ Microsoft.AspNetCore.Mvc.ApiExplorer.dll
+ Microsoft.AspNetCore.Mvc.Core.dll
+ Microsoft.AspNetCore.Mvc.Cors.dll
+ Microsoft.AspNetCore.Mvc.DataAnnotations.dll
+ Microsoft.AspNetCore.Mvc.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Json.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Xml.dll
+ Microsoft.AspNetCore.Mvc.Localization.dll
+ Microsoft.AspNetCore.Mvc.Razor.dll
+ Microsoft.AspNetCore.Mvc.RazorPages.dll
+ Microsoft.AspNetCore.Mvc.TagHelpers.dll
+ Microsoft.AspNetCore.Mvc.ViewFeatures.dll
+ Microsoft.AspNetCore.OutputCaching.dll
+ Microsoft.AspNetCore.RateLimiting.dll
+ Microsoft.AspNetCore.Razor.dll
+ Microsoft.AspNetCore.Razor.Runtime.dll
+ Microsoft.AspNetCore.RequestDecompression.dll
+ Microsoft.AspNetCore.ResponseCaching.Abstractions.dll
+ Microsoft.AspNetCore.ResponseCaching.dll
+ Microsoft.AspNetCore.ResponseCompression.dll
+ Microsoft.AspNetCore.Rewrite.dll
+ Microsoft.AspNetCore.Routing.Abstractions.dll
+ Microsoft.AspNetCore.Routing.dll
+ Microsoft.AspNetCore.Server.HttpSys.dll
+ Microsoft.AspNetCore.Server.IIS.dll
+ Microsoft.AspNetCore.Server.IISIntegration.dll
+ Microsoft.AspNetCore.Server.Kestrel.Core.dll
+ Microsoft.AspNetCore.Server.Kestrel.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll
+ Microsoft.AspNetCore.Session.dll
+ Microsoft.AspNetCore.SignalR.Common.dll
+ Microsoft.AspNetCore.SignalR.Core.dll
+ Microsoft.AspNetCore.SignalR.dll
+ Microsoft.AspNetCore.SignalR.Protocols.Json.dll
+ Microsoft.AspNetCore.StaticAssets.dll
+ Microsoft.AspNetCore.StaticFiles.dll
+ Microsoft.AspNetCore.WebSockets.dll
+ Microsoft.AspNetCore.WebUtilities.dll
+ Microsoft.Extensions.Caching.Abstractions.dll
+ Microsoft.Extensions.Caching.Memory.dll
+ Microsoft.Extensions.Configuration.Abstractions.dll
+ Microsoft.Extensions.Configuration.Binder.dll
+ Microsoft.Extensions.Configuration.CommandLine.dll
+ Microsoft.Extensions.Configuration.dll
+ Microsoft.Extensions.Configuration.EnvironmentVariables.dll
+ Microsoft.Extensions.Configuration.FileExtensions.dll
+ Microsoft.Extensions.Configuration.Ini.dll
+ Microsoft.Extensions.Configuration.Json.dll
+ Microsoft.Extensions.Configuration.KeyPerFile.dll
+ Microsoft.Extensions.Configuration.UserSecrets.dll
+ Microsoft.Extensions.Configuration.Xml.dll
+ Microsoft.Extensions.DependencyInjection.Abstractions.dll
+ Microsoft.Extensions.DependencyInjection.dll
+ Microsoft.Extensions.Diagnostics.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.dll
+ Microsoft.Extensions.Features.dll
+ Microsoft.Extensions.FileProviders.Abstractions.dll
+ Microsoft.Extensions.FileProviders.Composite.dll
+ Microsoft.Extensions.FileProviders.Embedded.dll
+ Microsoft.Extensions.FileProviders.Physical.dll
+ Microsoft.Extensions.FileSystemGlobbing.dll
+ Microsoft.Extensions.Hosting.Abstractions.dll
+ Microsoft.Extensions.Hosting.dll
+ Microsoft.Extensions.Http.dll
+ Microsoft.Extensions.Identity.Core.dll
+ Microsoft.Extensions.Identity.Stores.dll
+ Microsoft.Extensions.Localization.Abstractions.dll
+ Microsoft.Extensions.Localization.dll
+ Microsoft.Extensions.Logging.Abstractions.dll
+ Microsoft.Extensions.Logging.Configuration.dll
+ Microsoft.Extensions.Logging.Console.dll
+ Microsoft.Extensions.Logging.Debug.dll
+ Microsoft.Extensions.Logging.dll
+ Microsoft.Extensions.Logging.EventLog.dll
+ Microsoft.Extensions.Logging.EventSource.dll
+ Microsoft.Extensions.Logging.TraceSource.dll
+ Microsoft.Extensions.ObjectPool.dll
+ Microsoft.Extensions.Options.ConfigurationExtensions.dll
+ Microsoft.Extensions.Options.DataAnnotations.dll
+ Microsoft.Extensions.Options.dll
+ Microsoft.Extensions.Primitives.dll
+ Microsoft.Extensions.Validation.dll
+ Microsoft.Extensions.WebEncoders.dll
+ Microsoft.JSInterop.dll
+ Microsoft.Net.Http.Headers.dll
+ System.Diagnostics.EventLog.dll
+ System.Formats.Cbor.dll
+ System.Security.Cryptography.Xml.dll
+ System.Threading.RateLimiting.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.CSharp.dll
+ Microsoft.VisualBasic.Core.dll
+ Microsoft.VisualBasic.dll
+ Microsoft.Win32.Primitives.dll
+ Microsoft.Win32.Registry.dll
+ mscorlib.dll
+ netstandard.dll
+ System.AppContext.dll
+ System.Buffers.dll
+ System.Collections.Concurrent.dll
+ System.Collections.dll
+ System.Collections.Immutable.dll
+ System.Collections.NonGeneric.dll
+ System.Collections.Specialized.dll
+ System.ComponentModel.Annotations.dll
+ System.ComponentModel.DataAnnotations.dll
+ System.ComponentModel.dll
+ System.ComponentModel.EventBasedAsync.dll
+ System.ComponentModel.Primitives.dll
+ System.ComponentModel.TypeConverter.dll
+ System.Configuration.dll
+ System.Console.dll
+ System.Core.dll
+ System.Data.Common.dll
+ System.Data.DataSetExtensions.dll
+ System.Data.dll
+ System.Diagnostics.Contracts.dll
+ System.Diagnostics.Debug.dll
+ System.Diagnostics.DiagnosticSource.dll
+ System.Diagnostics.FileVersionInfo.dll
+ System.Diagnostics.Process.dll
+ System.Diagnostics.StackTrace.dll
+ System.Diagnostics.TextWriterTraceListener.dll
+ System.Diagnostics.Tools.dll
+ System.Diagnostics.TraceSource.dll
+ System.Diagnostics.Tracing.dll
+ System.dll
+ System.Drawing.dll
+ System.Drawing.Primitives.dll
+ System.Dynamic.Runtime.dll
+ System.Formats.Asn1.dll
+ System.Formats.Tar.dll
+ System.Globalization.Calendars.dll
+ System.Globalization.dll
+ System.Globalization.Extensions.dll
+ System.IO.Compression.Brotli.dll
+ System.IO.Compression.dll
+ System.IO.Compression.FileSystem.dll
+ System.IO.Compression.ZipFile.dll
+ System.IO.dll
+ System.IO.FileSystem.AccessControl.dll
+ System.IO.FileSystem.dll
+ System.IO.FileSystem.DriveInfo.dll
+ System.IO.FileSystem.Primitives.dll
+ System.IO.FileSystem.Watcher.dll
+ System.IO.IsolatedStorage.dll
+ System.IO.MemoryMappedFiles.dll
+ System.IO.Pipelines.dll
+ System.IO.Pipes.AccessControl.dll
+ System.IO.Pipes.dll
+ System.IO.UnmanagedMemoryStream.dll
+ System.Linq.AsyncEnumerable.dll
+ System.Linq.dll
+ System.Linq.Expressions.dll
+ System.Linq.Parallel.dll
+ System.Linq.Queryable.dll
+ System.Memory.dll
+ System.Net.dll
+ System.Net.Http.dll
+ System.Net.Http.Json.dll
+ System.Net.HttpListener.dll
+ System.Net.Mail.dll
+ System.Net.NameResolution.dll
+ System.Net.NetworkInformation.dll
+ System.Net.Ping.dll
+ System.Net.Primitives.dll
+ System.Net.Quic.dll
+ System.Net.Requests.dll
+ System.Net.Security.dll
+ System.Net.ServerSentEvents.dll
+ System.Net.ServicePoint.dll
+ System.Net.Sockets.dll
+ System.Net.WebClient.dll
+ System.Net.WebHeaderCollection.dll
+ System.Net.WebProxy.dll
+ System.Net.WebSockets.Client.dll
+ System.Net.WebSockets.dll
+ System.Numerics.dll
+ System.Numerics.Vectors.dll
+ System.ObjectModel.dll
+ System.Reflection.DispatchProxy.dll
+ System.Reflection.dll
+ System.Reflection.Emit.dll
+ System.Reflection.Emit.ILGeneration.dll
+ System.Reflection.Emit.Lightweight.dll
+ System.Reflection.Extensions.dll
+ System.Reflection.Metadata.dll
+ System.Reflection.Primitives.dll
+ System.Reflection.TypeExtensions.dll
+ System.Resources.Reader.dll
+ System.Resources.ResourceManager.dll
+ System.Resources.Writer.dll
+ System.Runtime.CompilerServices.Unsafe.dll
+ System.Runtime.CompilerServices.VisualC.dll
+ System.Runtime.dll
+ System.Runtime.Extensions.dll
+ System.Runtime.Handles.dll
+ System.Runtime.InteropServices.dll
+ System.Runtime.InteropServices.JavaScript.dll
+ System.Runtime.InteropServices.RuntimeInformation.dll
+ System.Runtime.Intrinsics.dll
+ System.Runtime.Loader.dll
+ System.Runtime.Numerics.dll
+ System.Runtime.Serialization.dll
+ System.Runtime.Serialization.Formatters.dll
+ System.Runtime.Serialization.Json.dll
+ System.Runtime.Serialization.Primitives.dll
+ System.Runtime.Serialization.Xml.dll
+ System.Security.AccessControl.dll
+ System.Security.Claims.dll
+ System.Security.Cryptography.Algorithms.dll
+ System.Security.Cryptography.Cng.dll
+ System.Security.Cryptography.Csp.dll
+ System.Security.Cryptography.dll
+ System.Security.Cryptography.Encoding.dll
+ System.Security.Cryptography.OpenSsl.dll
+ System.Security.Cryptography.Primitives.dll
+ System.Security.Cryptography.X509Certificates.dll
+ System.Security.dll
+ System.Security.Principal.dll
+ System.Security.Principal.Windows.dll
+ System.Security.SecureString.dll
+ System.ServiceModel.Web.dll
+ System.ServiceProcess.dll
+ System.Text.Encoding.CodePages.dll
+ System.Text.Encoding.dll
+ System.Text.Encoding.Extensions.dll
+ System.Text.Encodings.Web.dll
+ System.Text.Json.dll
+ System.Text.RegularExpressions.dll
+ System.Threading.AccessControl.dll
+ System.Threading.Channels.dll
+ System.Threading.dll
+ System.Threading.Overlapped.dll
+ System.Threading.Tasks.Dataflow.dll
+ System.Threading.Tasks.dll
+ System.Threading.Tasks.Extensions.dll
+ System.Threading.Tasks.Parallel.dll
+ System.Threading.Thread.dll
+ System.Threading.ThreadPool.dll
+ System.Threading.Timer.dll
+ System.Transactions.dll
+ System.Transactions.Local.dll
+ System.ValueTuple.dll
+ System.Web.dll
+ System.Web.HttpUtility.dll
+ System.Windows.dll
+ System.Xml.dll
+ System.Xml.Linq.dll
+ System.Xml.ReaderWriter.dll
+ System.Xml.Serialization.dll
+ System.Xml.XDocument.dll
+ System.Xml.XmlDocument.dll
+ System.Xml.XmlSerializer.dll
+ System.Xml.XPath.dll
+ System.Xml.XPath.XDocument.dll
+ WindowsBase.dll
+<NUGET>/
+ azure.core.amqp/1.3.1/lib/netstandard2.0/Azure.Core.Amqp.dll
+ azure.core/1.47.1/lib/net8.0/Azure.Core.dll
+ azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
+ azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
+ azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
+ ecommerce.shared/2.14.0/lib/net10.0/ECommerce.Shared.dll
+ google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
+ grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
+ grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll
+ grpc.net.common/2.52.0/lib/net7.0/Grpc.Net.Common.dll
+ microsoft.aspnetcore.authentication.jwtbearer/10.0.5/lib/net10.0/Microsoft.AspNetCore.Authentication.JwtBearer.dll
+ microsoft.aspnetcore.mvc.testing/10.0.5/lib/net10.0/Microsoft.AspNetCore.Mvc.Testing.dll
+ microsoft.aspnetcore.testhost/10.0.5/lib/net10.0/Microsoft.AspNetCore.TestHost.dll
+ microsoft.azure.amqp/2.6.7/lib/netstandard2.0/Microsoft.Azure.Amqp.dll
+ microsoft.bcl.asyncinterfaces/8.0.0/lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll
+ microsoft.bcl.cryptography/9.0.4/lib/net9.0/Microsoft.Bcl.Cryptography.dll
+ microsoft.codecoverage/17.14.1/lib/net8.0/Microsoft.VisualStudio.CodeCoverage.Shim.dll
+ microsoft.data.sqlclient/6.1.1/ref/net9.0/Microsoft.Data.SqlClient.dll
+ microsoft.entityframeworkcore.abstractions/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Abstractions.dll
+ microsoft.entityframeworkcore.relational/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Relational.dll
+ microsoft.entityframeworkcore.sqlserver/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.SqlServer.dll
+ microsoft.entityframeworkcore/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.dll
+ microsoft.extensions.dependencymodel/10.0.5/lib/net10.0/Microsoft.Extensions.DependencyModel.dll
+ microsoft.identity.client.extensions.msal/4.73.1/lib/net8.0/Microsoft.Identity.Client.Extensions.Msal.dll
+ microsoft.identity.client/4.73.1/lib/net8.0/Microsoft.Identity.Client.dll
+ microsoft.identitymodel.abstractions/8.0.1/lib/net9.0/Microsoft.IdentityModel.Abstractions.dll
+ microsoft.identitymodel.jsonwebtokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.JsonWebTokens.dll
+ microsoft.identitymodel.logging/8.0.1/lib/net9.0/Microsoft.IdentityModel.Logging.dll
+ microsoft.identitymodel.protocols.openidconnect/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.dll
+ microsoft.identitymodel.protocols/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.dll
+ microsoft.identitymodel.tokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.Tokens.dll
+ microsoft.openapi/1.6.14/lib/netstandard2.0/Microsoft.OpenApi.dll
+ microsoft.sqlserver.server/1.0.0/lib/netstandard2.0/Microsoft.SqlServer.Server.dll
+ microsoft.testplatform.testhost/17.14.1/lib/net8.0/
+  Microsoft.TestPlatform.CommunicationUtilities.dll
+  Microsoft.TestPlatform.CoreUtilities.dll
+  Microsoft.TestPlatform.CrossPlatEngine.dll
+  Microsoft.TestPlatform.PlatformAbstractions.dll
+  Microsoft.TestPlatform.Utilities.dll
+  Microsoft.VisualStudio.TestPlatform.Common.dll
+  Microsoft.VisualStudio.TestPlatform.ObjectModel.dll
+  testhost.dll
+ newtonsoft.json/13.0.3/lib/net6.0/Newtonsoft.Json.dll
+ opentelemetry.api.providerbuilderextensions/1.10.0/lib/net9.0/OpenTelemetry.Api.ProviderBuilderExtensions.dll
+ opentelemetry.api/1.10.0/lib/net9.0/OpenTelemetry.Api.dll
+ opentelemetry.exporter.console/1.9.0/lib/net8.0/OpenTelemetry.Exporter.Console.dll
+ opentelemetry.exporter.opentelemetryprotocol/1.9.0/lib/net8.0/OpenTelemetry.Exporter.OpenTelemetryProtocol.dll
+ opentelemetry.exporter.prometheus.aspnetcore/1.10.0-beta.1/lib/net9.0/OpenTelemetry.Exporter.Prometheus.AspNetCore.dll
+ opentelemetry.extensions.hosting/1.9.0/lib/net8.0/OpenTelemetry.Extensions.Hosting.dll
+ opentelemetry.instrumentation.aspnetcore/1.9.0/lib/net8.0/OpenTelemetry.Instrumentation.AspNetCore.dll
+ opentelemetry.instrumentation.sqlclient/1.9.0-beta.1/lib/net8.0/OpenTelemetry.Instrumentation.SqlClient.dll
+ opentelemetry.persistentstorage.abstractions/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.Abstractions.dll
+ opentelemetry.persistentstorage.filesystem/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.FileSystem.dll
+ opentelemetry/1.10.0/lib/net9.0/OpenTelemetry.dll
+ pipelines.sockets.unofficial/2.2.8/lib/net5.0/Pipelines.Sockets.Unofficial.dll
+ polly.core/8.6.6/lib/net8.0/Polly.Core.dll
+ rabbitmq.client/6.8.1/lib/netstandard2.0/RabbitMQ.Client.dll
+ stackexchange.redis/2.8.16/lib/net6.0/StackExchange.Redis.dll
+ swashbuckle.aspnetcore.swagger/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.Swagger.dll
+ swashbuckle.aspnetcore.swaggergen/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.dll
+ swashbuckle.aspnetcore.swaggerui/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.dll
+ system.clientmodel/1.5.1/lib/net8.0/System.ClientModel.dll
+ system.identitymodel.tokens.jwt/8.0.1/lib/net9.0/System.IdentityModel.Tokens.Jwt.dll
+ system.memory.data/8.0.1/lib/net8.0/System.Memory.Data.dll
+ system.security.cryptography.pkcs/9.0.4/lib/net9.0/System.Security.Cryptography.Pkcs.dll
+ system.security.cryptography.protecteddata/9.0.4/lib/net9.0/System.Security.Cryptography.ProtectedData.dll
+ xunit.abstractions/2.0.3/lib/netstandard2.0/xunit.abstractions.dll
+ xunit.assert/2.9.3/lib/net6.0/xunit.assert.dll
+ xunit.extensibility.core/2.9.3/lib/netstandard1.1/xunit.core.dll
+ xunit.extensibility.execution/2.9.3/lib/netstandard1.1/xunit.execution.dotnet.dll
+
+[analyzerReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.AspNetCore.App.Analyzers.dll
+ Microsoft.AspNetCore.App.CodeFixes.dll
+ Microsoft.AspNetCore.App.SourceGenerators.dll
+ Microsoft.AspNetCore.Components.Analyzers.dll
+ Microsoft.Extensions.Logging.Generators.dll
+ Microsoft.Extensions.Options.SourceGeneration.dll
+ Microsoft.Extensions.Validation.ValidationsGenerator.dll
+<DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.Interop.ComInterfaceGenerator.dll
+ Microsoft.Interop.JavaScript.JSImportGenerator.dll
+ Microsoft.Interop.LibraryImportGenerator.dll
+ Microsoft.Interop.SourceGeneration.dll
+ System.Text.Json.SourceGeneration.dll
+ System.Text.RegularExpressions.Generator.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/
+ Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll
+ Microsoft.CodeAnalysis.NetAnalyzers.dll
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/codestyle/cs/
+ Microsoft.CodeAnalysis.CodeStyle.dll
+ Microsoft.CodeAnalysis.CodeStyle.Fixes.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.dll
+ Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.dll
+<NUGET>/
+ microsoft.entityframeworkcore.analyzers/10.0.5/analyzers/dotnet/cs/Microsoft.EntityFrameworkCore.Analyzers.dll
+ system.clientmodel/1.5.1/analyzers/dotnet/cs/System.ClientModel.SourceGeneration.dll
+ xunit.analyzers/1.18.0/analyzers/dotnet/cs/
+  xunit.analyzers.dll
+  xunit.analyzers.fixes.dll
+
+[analyzerConfigFiles]
+../../.editorconfig
+<DOTNET>/sdk/10.0.204/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_10_recommended.globalconfig
+obj/Debug/net10.0/Shipping.Tests.GeneratedMSBuildEditorConfig.editorconfig

--- a/shipping-microservice/Shipping.Tests/Shipping.Tests.csproj.lscache
+++ b/shipping-microservice/Shipping.Tests/Shipping.Tests.csproj.lscache
@@ -404,7 +404,7 @@ ShippingWebApplicationFactory.cs
  azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
  azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
  azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
- ecommerce.shared/2.15.0/lib/net10.0/ECommerce.Shared.dll
+ ecommerce.shared/2.16.0/lib/net10.0/ECommerce.Shared.dll
  google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
  grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
  grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll

--- a/shipping-microservice/Shipping.Tests/Shipping.Tests.csproj.lscache
+++ b/shipping-microservice/Shipping.Tests/Shipping.Tests.csproj.lscache
@@ -403,7 +403,7 @@ ShippingWebApplicationFactory.cs
  azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
  azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
  azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
- ecommerce.shared/2.14.0/lib/net10.0/ECommerce.Shared.dll
+ ecommerce.shared/2.15.0/lib/net10.0/ECommerce.Shared.dll
  google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
  grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
  grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll

--- a/shipping-microservice/Shipping.Tests/Shipping.Tests.csproj.lscache
+++ b/shipping-microservice/Shipping.Tests/Shipping.Tests.csproj.lscache
@@ -46,7 +46,7 @@ TemporaryDependencyNodeTargetIdentifier=net10.0
 /optimize-
 /out:obj\Debug\net10.0\Shipping.Tests.dll
 /refout:obj\Debug\net10.0\refint\Shipping.Tests.dll
-/target:exe
+/target:library
 /warnaserror+
 /utf8output
 /deterministic+
@@ -54,7 +54,6 @@ TemporaryDependencyNodeTargetIdentifier=net10.0
 /warnaserror+:NU1605,SYSLIB0011
 
 [sourceFiles]
-<NUGET>/microsoft.net.test.sdk/17.14.1/build/net8.0/Microsoft.NET.Test.Sdk.Program.cs
 Api/
  GetShipmentsByOrderTests.cs
  HealthChecksTests.cs
@@ -89,147 +88,6 @@ ShippingWebApplicationFactory.cs
 
 [metadataReferences]
 ../Shipping.Service/obj/Debug/net10.0/ref/Shipping.Service.dll
-<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/ref/net10.0/
- Microsoft.AspNetCore.Antiforgery.dll
- Microsoft.AspNetCore.Authentication.Abstractions.dll
- Microsoft.AspNetCore.Authentication.BearerToken.dll
- Microsoft.AspNetCore.Authentication.Cookies.dll
- Microsoft.AspNetCore.Authentication.Core.dll
- Microsoft.AspNetCore.Authentication.dll
- Microsoft.AspNetCore.Authentication.OAuth.dll
- Microsoft.AspNetCore.Authorization.dll
- Microsoft.AspNetCore.Authorization.Policy.dll
- Microsoft.AspNetCore.Components.Authorization.dll
- Microsoft.AspNetCore.Components.dll
- Microsoft.AspNetCore.Components.Endpoints.dll
- Microsoft.AspNetCore.Components.Forms.dll
- Microsoft.AspNetCore.Components.Server.dll
- Microsoft.AspNetCore.Components.Web.dll
- Microsoft.AspNetCore.Connections.Abstractions.dll
- Microsoft.AspNetCore.CookiePolicy.dll
- Microsoft.AspNetCore.Cors.dll
- Microsoft.AspNetCore.Cryptography.Internal.dll
- Microsoft.AspNetCore.Cryptography.KeyDerivation.dll
- Microsoft.AspNetCore.DataProtection.Abstractions.dll
- Microsoft.AspNetCore.DataProtection.dll
- Microsoft.AspNetCore.DataProtection.Extensions.dll
- Microsoft.AspNetCore.Diagnostics.Abstractions.dll
- Microsoft.AspNetCore.Diagnostics.dll
- Microsoft.AspNetCore.Diagnostics.HealthChecks.dll
- Microsoft.AspNetCore.dll
- Microsoft.AspNetCore.HostFiltering.dll
- Microsoft.AspNetCore.Hosting.Abstractions.dll
- Microsoft.AspNetCore.Hosting.dll
- Microsoft.AspNetCore.Hosting.Server.Abstractions.dll
- Microsoft.AspNetCore.Html.Abstractions.dll
- Microsoft.AspNetCore.Http.Abstractions.dll
- Microsoft.AspNetCore.Http.Connections.Common.dll
- Microsoft.AspNetCore.Http.Connections.dll
- Microsoft.AspNetCore.Http.dll
- Microsoft.AspNetCore.Http.Extensions.dll
- Microsoft.AspNetCore.Http.Features.dll
- Microsoft.AspNetCore.Http.Results.dll
- Microsoft.AspNetCore.HttpLogging.dll
- Microsoft.AspNetCore.HttpOverrides.dll
- Microsoft.AspNetCore.HttpsPolicy.dll
- Microsoft.AspNetCore.Identity.dll
- Microsoft.AspNetCore.Localization.dll
- Microsoft.AspNetCore.Localization.Routing.dll
- Microsoft.AspNetCore.Metadata.dll
- Microsoft.AspNetCore.Mvc.Abstractions.dll
- Microsoft.AspNetCore.Mvc.ApiExplorer.dll
- Microsoft.AspNetCore.Mvc.Core.dll
- Microsoft.AspNetCore.Mvc.Cors.dll
- Microsoft.AspNetCore.Mvc.DataAnnotations.dll
- Microsoft.AspNetCore.Mvc.dll
- Microsoft.AspNetCore.Mvc.Formatters.Json.dll
- Microsoft.AspNetCore.Mvc.Formatters.Xml.dll
- Microsoft.AspNetCore.Mvc.Localization.dll
- Microsoft.AspNetCore.Mvc.Razor.dll
- Microsoft.AspNetCore.Mvc.RazorPages.dll
- Microsoft.AspNetCore.Mvc.TagHelpers.dll
- Microsoft.AspNetCore.Mvc.ViewFeatures.dll
- Microsoft.AspNetCore.OutputCaching.dll
- Microsoft.AspNetCore.RateLimiting.dll
- Microsoft.AspNetCore.Razor.dll
- Microsoft.AspNetCore.Razor.Runtime.dll
- Microsoft.AspNetCore.RequestDecompression.dll
- Microsoft.AspNetCore.ResponseCaching.Abstractions.dll
- Microsoft.AspNetCore.ResponseCaching.dll
- Microsoft.AspNetCore.ResponseCompression.dll
- Microsoft.AspNetCore.Rewrite.dll
- Microsoft.AspNetCore.Routing.Abstractions.dll
- Microsoft.AspNetCore.Routing.dll
- Microsoft.AspNetCore.Server.HttpSys.dll
- Microsoft.AspNetCore.Server.IIS.dll
- Microsoft.AspNetCore.Server.IISIntegration.dll
- Microsoft.AspNetCore.Server.Kestrel.Core.dll
- Microsoft.AspNetCore.Server.Kestrel.dll
- Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll
- Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll
- Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll
- Microsoft.AspNetCore.Session.dll
- Microsoft.AspNetCore.SignalR.Common.dll
- Microsoft.AspNetCore.SignalR.Core.dll
- Microsoft.AspNetCore.SignalR.dll
- Microsoft.AspNetCore.SignalR.Protocols.Json.dll
- Microsoft.AspNetCore.StaticAssets.dll
- Microsoft.AspNetCore.StaticFiles.dll
- Microsoft.AspNetCore.WebSockets.dll
- Microsoft.AspNetCore.WebUtilities.dll
- Microsoft.Extensions.Caching.Abstractions.dll
- Microsoft.Extensions.Caching.Memory.dll
- Microsoft.Extensions.Configuration.Abstractions.dll
- Microsoft.Extensions.Configuration.Binder.dll
- Microsoft.Extensions.Configuration.CommandLine.dll
- Microsoft.Extensions.Configuration.dll
- Microsoft.Extensions.Configuration.EnvironmentVariables.dll
- Microsoft.Extensions.Configuration.FileExtensions.dll
- Microsoft.Extensions.Configuration.Ini.dll
- Microsoft.Extensions.Configuration.Json.dll
- Microsoft.Extensions.Configuration.KeyPerFile.dll
- Microsoft.Extensions.Configuration.UserSecrets.dll
- Microsoft.Extensions.Configuration.Xml.dll
- Microsoft.Extensions.DependencyInjection.Abstractions.dll
- Microsoft.Extensions.DependencyInjection.dll
- Microsoft.Extensions.Diagnostics.Abstractions.dll
- Microsoft.Extensions.Diagnostics.dll
- Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll
- Microsoft.Extensions.Diagnostics.HealthChecks.dll
- Microsoft.Extensions.Features.dll
- Microsoft.Extensions.FileProviders.Abstractions.dll
- Microsoft.Extensions.FileProviders.Composite.dll
- Microsoft.Extensions.FileProviders.Embedded.dll
- Microsoft.Extensions.FileProviders.Physical.dll
- Microsoft.Extensions.FileSystemGlobbing.dll
- Microsoft.Extensions.Hosting.Abstractions.dll
- Microsoft.Extensions.Hosting.dll
- Microsoft.Extensions.Http.dll
- Microsoft.Extensions.Identity.Core.dll
- Microsoft.Extensions.Identity.Stores.dll
- Microsoft.Extensions.Localization.Abstractions.dll
- Microsoft.Extensions.Localization.dll
- Microsoft.Extensions.Logging.Abstractions.dll
- Microsoft.Extensions.Logging.Configuration.dll
- Microsoft.Extensions.Logging.Console.dll
- Microsoft.Extensions.Logging.Debug.dll
- Microsoft.Extensions.Logging.dll
- Microsoft.Extensions.Logging.EventLog.dll
- Microsoft.Extensions.Logging.EventSource.dll
- Microsoft.Extensions.Logging.TraceSource.dll
- Microsoft.Extensions.ObjectPool.dll
- Microsoft.Extensions.Options.ConfigurationExtensions.dll
- Microsoft.Extensions.Options.DataAnnotations.dll
- Microsoft.Extensions.Options.dll
- Microsoft.Extensions.Primitives.dll
- Microsoft.Extensions.Validation.dll
- Microsoft.Extensions.WebEncoders.dll
- Microsoft.JSInterop.dll
- Microsoft.Net.Http.Headers.dll
- System.Diagnostics.EventLog.dll
- System.Formats.Cbor.dll
- System.Security.Cryptography.Xml.dll
- System.Threading.RateLimiting.dll
 <DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/ref/net10.0/
  Microsoft.CSharp.dll
  Microsoft.VisualBasic.Core.dll
@@ -398,87 +256,8 @@ ShippingWebApplicationFactory.cs
  System.Xml.XPath.dll
  System.Xml.XPath.XDocument.dll
  WindowsBase.dll
-<NUGET>/
- azure.core.amqp/1.3.1/lib/netstandard2.0/Azure.Core.Amqp.dll
- azure.core/1.47.1/lib/net8.0/Azure.Core.dll
- azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
- azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
- azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
- ecommerce.shared/2.16.0/lib/net10.0/ECommerce.Shared.dll
- google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
- grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
- grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll
- grpc.net.common/2.52.0/lib/net7.0/Grpc.Net.Common.dll
- microsoft.aspnetcore.authentication.jwtbearer/10.0.5/lib/net10.0/Microsoft.AspNetCore.Authentication.JwtBearer.dll
- microsoft.aspnetcore.mvc.testing/10.0.5/lib/net10.0/Microsoft.AspNetCore.Mvc.Testing.dll
- microsoft.aspnetcore.testhost/10.0.5/lib/net10.0/Microsoft.AspNetCore.TestHost.dll
- microsoft.azure.amqp/2.6.7/lib/netstandard2.0/Microsoft.Azure.Amqp.dll
- microsoft.bcl.asyncinterfaces/8.0.0/lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll
- microsoft.bcl.cryptography/9.0.4/lib/net9.0/Microsoft.Bcl.Cryptography.dll
- microsoft.codecoverage/17.14.1/lib/net8.0/Microsoft.VisualStudio.CodeCoverage.Shim.dll
- microsoft.data.sqlclient/6.1.1/ref/net9.0/Microsoft.Data.SqlClient.dll
- microsoft.entityframeworkcore.abstractions/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Abstractions.dll
- microsoft.entityframeworkcore.relational/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Relational.dll
- microsoft.entityframeworkcore.sqlserver/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.SqlServer.dll
- microsoft.entityframeworkcore/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.dll
- microsoft.extensions.dependencymodel/10.0.5/lib/net10.0/Microsoft.Extensions.DependencyModel.dll
- microsoft.identity.client.extensions.msal/4.73.1/lib/net8.0/Microsoft.Identity.Client.Extensions.Msal.dll
- microsoft.identity.client/4.73.1/lib/net8.0/Microsoft.Identity.Client.dll
- microsoft.identitymodel.abstractions/8.0.1/lib/net9.0/Microsoft.IdentityModel.Abstractions.dll
- microsoft.identitymodel.jsonwebtokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.JsonWebTokens.dll
- microsoft.identitymodel.logging/8.0.1/lib/net9.0/Microsoft.IdentityModel.Logging.dll
- microsoft.identitymodel.protocols.openidconnect/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.dll
- microsoft.identitymodel.protocols/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.dll
- microsoft.identitymodel.tokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.Tokens.dll
- microsoft.openapi/1.6.14/lib/netstandard2.0/Microsoft.OpenApi.dll
- microsoft.sqlserver.server/1.0.0/lib/netstandard2.0/Microsoft.SqlServer.Server.dll
- microsoft.testplatform.testhost/17.14.1/lib/net8.0/
-  Microsoft.TestPlatform.CommunicationUtilities.dll
-  Microsoft.TestPlatform.CoreUtilities.dll
-  Microsoft.TestPlatform.CrossPlatEngine.dll
-  Microsoft.TestPlatform.PlatformAbstractions.dll
-  Microsoft.TestPlatform.Utilities.dll
-  Microsoft.VisualStudio.TestPlatform.Common.dll
-  Microsoft.VisualStudio.TestPlatform.ObjectModel.dll
-  testhost.dll
- newtonsoft.json/13.0.3/lib/net6.0/Newtonsoft.Json.dll
- opentelemetry.api.providerbuilderextensions/1.10.0/lib/net9.0/OpenTelemetry.Api.ProviderBuilderExtensions.dll
- opentelemetry.api/1.10.0/lib/net9.0/OpenTelemetry.Api.dll
- opentelemetry.exporter.console/1.9.0/lib/net8.0/OpenTelemetry.Exporter.Console.dll
- opentelemetry.exporter.opentelemetryprotocol/1.9.0/lib/net8.0/OpenTelemetry.Exporter.OpenTelemetryProtocol.dll
- opentelemetry.exporter.prometheus.aspnetcore/1.10.0-beta.1/lib/net9.0/OpenTelemetry.Exporter.Prometheus.AspNetCore.dll
- opentelemetry.extensions.hosting/1.9.0/lib/net8.0/OpenTelemetry.Extensions.Hosting.dll
- opentelemetry.instrumentation.aspnetcore/1.9.0/lib/net8.0/OpenTelemetry.Instrumentation.AspNetCore.dll
- opentelemetry.instrumentation.sqlclient/1.9.0-beta.1/lib/net8.0/OpenTelemetry.Instrumentation.SqlClient.dll
- opentelemetry.persistentstorage.abstractions/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.Abstractions.dll
- opentelemetry.persistentstorage.filesystem/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.FileSystem.dll
- opentelemetry/1.10.0/lib/net9.0/OpenTelemetry.dll
- pipelines.sockets.unofficial/2.2.8/lib/net5.0/Pipelines.Sockets.Unofficial.dll
- polly.core/8.6.6/lib/net8.0/Polly.Core.dll
- rabbitmq.client/6.8.1/lib/netstandard2.0/RabbitMQ.Client.dll
- stackexchange.redis/2.8.16/lib/net6.0/StackExchange.Redis.dll
- swashbuckle.aspnetcore.swagger/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.Swagger.dll
- swashbuckle.aspnetcore.swaggergen/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.dll
- swashbuckle.aspnetcore.swaggerui/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.dll
- system.clientmodel/1.5.1/lib/net8.0/System.ClientModel.dll
- system.identitymodel.tokens.jwt/8.0.1/lib/net9.0/System.IdentityModel.Tokens.Jwt.dll
- system.memory.data/8.0.1/lib/net8.0/System.Memory.Data.dll
- system.security.cryptography.pkcs/9.0.4/lib/net9.0/System.Security.Cryptography.Pkcs.dll
- system.security.cryptography.protecteddata/9.0.4/lib/net9.0/System.Security.Cryptography.ProtectedData.dll
- xunit.abstractions/2.0.3/lib/netstandard2.0/xunit.abstractions.dll
- xunit.assert/2.9.3/lib/net6.0/xunit.assert.dll
- xunit.extensibility.core/2.9.3/lib/netstandard1.1/xunit.core.dll
- xunit.extensibility.execution/2.9.3/lib/netstandard1.1/xunit.execution.dotnet.dll
 
 [analyzerReferences]
-<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/analyzers/dotnet/cs/
- Microsoft.AspNetCore.App.Analyzers.dll
- Microsoft.AspNetCore.App.CodeFixes.dll
- Microsoft.AspNetCore.App.SourceGenerators.dll
- Microsoft.AspNetCore.Components.Analyzers.dll
- Microsoft.Extensions.Logging.Generators.dll
- Microsoft.Extensions.Options.SourceGeneration.dll
- Microsoft.Extensions.Validation.ValidationsGenerator.dll
 <DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/analyzers/dotnet/cs/
  Microsoft.Interop.ComInterfaceGenerator.dll
  Microsoft.Interop.JavaScript.JSImportGenerator.dll
@@ -494,12 +273,6 @@ ShippingWebApplicationFactory.cs
  Microsoft.CodeAnalysis.CodeStyle.Fixes.dll
  Microsoft.CodeAnalysis.CSharp.CodeStyle.dll
  Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.dll
-<NUGET>/
- microsoft.entityframeworkcore.analyzers/10.0.5/analyzers/dotnet/cs/Microsoft.EntityFrameworkCore.Analyzers.dll
- system.clientmodel/1.5.1/analyzers/dotnet/cs/System.ClientModel.SourceGeneration.dll
- xunit.analyzers/1.18.0/analyzers/dotnet/cs/
-  xunit.analyzers.dll
-  xunit.analyzers.fixes.dll
 
 [analyzerConfigFiles]
 ../../.editorconfig

--- a/shipping-microservice/Shipping.Tests/Shipping.Tests.csproj.lscache
+++ b/shipping-microservice/Shipping.Tests/Shipping.Tests.csproj.lscache
@@ -46,7 +46,7 @@ TemporaryDependencyNodeTargetIdentifier=net10.0
 /optimize-
 /out:obj\Debug\net10.0\Shipping.Tests.dll
 /refout:obj\Debug\net10.0\refint\Shipping.Tests.dll
-/target:library
+/target:exe
 /warnaserror+
 /utf8output
 /deterministic+
@@ -54,6 +54,7 @@ TemporaryDependencyNodeTargetIdentifier=net10.0
 /warnaserror+:NU1605,SYSLIB0011
 
 [sourceFiles]
+<NUGET>/microsoft.net.test.sdk/17.14.1/build/net8.0/Microsoft.NET.Test.Sdk.Program.cs
 Api/
  GetShipmentsByOrderTests.cs
  HealthChecksTests.cs
@@ -88,6 +89,147 @@ ShippingWebApplicationFactory.cs
 
 [metadataReferences]
 ../Shipping.Service/obj/Debug/net10.0/ref/Shipping.Service.dll
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/ref/net10.0/
+ Microsoft.AspNetCore.Antiforgery.dll
+ Microsoft.AspNetCore.Authentication.Abstractions.dll
+ Microsoft.AspNetCore.Authentication.BearerToken.dll
+ Microsoft.AspNetCore.Authentication.Cookies.dll
+ Microsoft.AspNetCore.Authentication.Core.dll
+ Microsoft.AspNetCore.Authentication.dll
+ Microsoft.AspNetCore.Authentication.OAuth.dll
+ Microsoft.AspNetCore.Authorization.dll
+ Microsoft.AspNetCore.Authorization.Policy.dll
+ Microsoft.AspNetCore.Components.Authorization.dll
+ Microsoft.AspNetCore.Components.dll
+ Microsoft.AspNetCore.Components.Endpoints.dll
+ Microsoft.AspNetCore.Components.Forms.dll
+ Microsoft.AspNetCore.Components.Server.dll
+ Microsoft.AspNetCore.Components.Web.dll
+ Microsoft.AspNetCore.Connections.Abstractions.dll
+ Microsoft.AspNetCore.CookiePolicy.dll
+ Microsoft.AspNetCore.Cors.dll
+ Microsoft.AspNetCore.Cryptography.Internal.dll
+ Microsoft.AspNetCore.Cryptography.KeyDerivation.dll
+ Microsoft.AspNetCore.DataProtection.Abstractions.dll
+ Microsoft.AspNetCore.DataProtection.dll
+ Microsoft.AspNetCore.DataProtection.Extensions.dll
+ Microsoft.AspNetCore.Diagnostics.Abstractions.dll
+ Microsoft.AspNetCore.Diagnostics.dll
+ Microsoft.AspNetCore.Diagnostics.HealthChecks.dll
+ Microsoft.AspNetCore.dll
+ Microsoft.AspNetCore.HostFiltering.dll
+ Microsoft.AspNetCore.Hosting.Abstractions.dll
+ Microsoft.AspNetCore.Hosting.dll
+ Microsoft.AspNetCore.Hosting.Server.Abstractions.dll
+ Microsoft.AspNetCore.Html.Abstractions.dll
+ Microsoft.AspNetCore.Http.Abstractions.dll
+ Microsoft.AspNetCore.Http.Connections.Common.dll
+ Microsoft.AspNetCore.Http.Connections.dll
+ Microsoft.AspNetCore.Http.dll
+ Microsoft.AspNetCore.Http.Extensions.dll
+ Microsoft.AspNetCore.Http.Features.dll
+ Microsoft.AspNetCore.Http.Results.dll
+ Microsoft.AspNetCore.HttpLogging.dll
+ Microsoft.AspNetCore.HttpOverrides.dll
+ Microsoft.AspNetCore.HttpsPolicy.dll
+ Microsoft.AspNetCore.Identity.dll
+ Microsoft.AspNetCore.Localization.dll
+ Microsoft.AspNetCore.Localization.Routing.dll
+ Microsoft.AspNetCore.Metadata.dll
+ Microsoft.AspNetCore.Mvc.Abstractions.dll
+ Microsoft.AspNetCore.Mvc.ApiExplorer.dll
+ Microsoft.AspNetCore.Mvc.Core.dll
+ Microsoft.AspNetCore.Mvc.Cors.dll
+ Microsoft.AspNetCore.Mvc.DataAnnotations.dll
+ Microsoft.AspNetCore.Mvc.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Json.dll
+ Microsoft.AspNetCore.Mvc.Formatters.Xml.dll
+ Microsoft.AspNetCore.Mvc.Localization.dll
+ Microsoft.AspNetCore.Mvc.Razor.dll
+ Microsoft.AspNetCore.Mvc.RazorPages.dll
+ Microsoft.AspNetCore.Mvc.TagHelpers.dll
+ Microsoft.AspNetCore.Mvc.ViewFeatures.dll
+ Microsoft.AspNetCore.OutputCaching.dll
+ Microsoft.AspNetCore.RateLimiting.dll
+ Microsoft.AspNetCore.Razor.dll
+ Microsoft.AspNetCore.Razor.Runtime.dll
+ Microsoft.AspNetCore.RequestDecompression.dll
+ Microsoft.AspNetCore.ResponseCaching.Abstractions.dll
+ Microsoft.AspNetCore.ResponseCaching.dll
+ Microsoft.AspNetCore.ResponseCompression.dll
+ Microsoft.AspNetCore.Rewrite.dll
+ Microsoft.AspNetCore.Routing.Abstractions.dll
+ Microsoft.AspNetCore.Routing.dll
+ Microsoft.AspNetCore.Server.HttpSys.dll
+ Microsoft.AspNetCore.Server.IIS.dll
+ Microsoft.AspNetCore.Server.IISIntegration.dll
+ Microsoft.AspNetCore.Server.Kestrel.Core.dll
+ Microsoft.AspNetCore.Server.Kestrel.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll
+ Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll
+ Microsoft.AspNetCore.Session.dll
+ Microsoft.AspNetCore.SignalR.Common.dll
+ Microsoft.AspNetCore.SignalR.Core.dll
+ Microsoft.AspNetCore.SignalR.dll
+ Microsoft.AspNetCore.SignalR.Protocols.Json.dll
+ Microsoft.AspNetCore.StaticAssets.dll
+ Microsoft.AspNetCore.StaticFiles.dll
+ Microsoft.AspNetCore.WebSockets.dll
+ Microsoft.AspNetCore.WebUtilities.dll
+ Microsoft.Extensions.Caching.Abstractions.dll
+ Microsoft.Extensions.Caching.Memory.dll
+ Microsoft.Extensions.Configuration.Abstractions.dll
+ Microsoft.Extensions.Configuration.Binder.dll
+ Microsoft.Extensions.Configuration.CommandLine.dll
+ Microsoft.Extensions.Configuration.dll
+ Microsoft.Extensions.Configuration.EnvironmentVariables.dll
+ Microsoft.Extensions.Configuration.FileExtensions.dll
+ Microsoft.Extensions.Configuration.Ini.dll
+ Microsoft.Extensions.Configuration.Json.dll
+ Microsoft.Extensions.Configuration.KeyPerFile.dll
+ Microsoft.Extensions.Configuration.UserSecrets.dll
+ Microsoft.Extensions.Configuration.Xml.dll
+ Microsoft.Extensions.DependencyInjection.Abstractions.dll
+ Microsoft.Extensions.DependencyInjection.dll
+ Microsoft.Extensions.Diagnostics.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll
+ Microsoft.Extensions.Diagnostics.HealthChecks.dll
+ Microsoft.Extensions.Features.dll
+ Microsoft.Extensions.FileProviders.Abstractions.dll
+ Microsoft.Extensions.FileProviders.Composite.dll
+ Microsoft.Extensions.FileProviders.Embedded.dll
+ Microsoft.Extensions.FileProviders.Physical.dll
+ Microsoft.Extensions.FileSystemGlobbing.dll
+ Microsoft.Extensions.Hosting.Abstractions.dll
+ Microsoft.Extensions.Hosting.dll
+ Microsoft.Extensions.Http.dll
+ Microsoft.Extensions.Identity.Core.dll
+ Microsoft.Extensions.Identity.Stores.dll
+ Microsoft.Extensions.Localization.Abstractions.dll
+ Microsoft.Extensions.Localization.dll
+ Microsoft.Extensions.Logging.Abstractions.dll
+ Microsoft.Extensions.Logging.Configuration.dll
+ Microsoft.Extensions.Logging.Console.dll
+ Microsoft.Extensions.Logging.Debug.dll
+ Microsoft.Extensions.Logging.dll
+ Microsoft.Extensions.Logging.EventLog.dll
+ Microsoft.Extensions.Logging.EventSource.dll
+ Microsoft.Extensions.Logging.TraceSource.dll
+ Microsoft.Extensions.ObjectPool.dll
+ Microsoft.Extensions.Options.ConfigurationExtensions.dll
+ Microsoft.Extensions.Options.DataAnnotations.dll
+ Microsoft.Extensions.Options.dll
+ Microsoft.Extensions.Primitives.dll
+ Microsoft.Extensions.Validation.dll
+ Microsoft.Extensions.WebEncoders.dll
+ Microsoft.JSInterop.dll
+ Microsoft.Net.Http.Headers.dll
+ System.Diagnostics.EventLog.dll
+ System.Formats.Cbor.dll
+ System.Security.Cryptography.Xml.dll
+ System.Threading.RateLimiting.dll
 <DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/ref/net10.0/
  Microsoft.CSharp.dll
  Microsoft.VisualBasic.Core.dll
@@ -256,8 +398,87 @@ ShippingWebApplicationFactory.cs
  System.Xml.XPath.dll
  System.Xml.XPath.XDocument.dll
  WindowsBase.dll
+<NUGET>/
+ azure.core.amqp/1.3.1/lib/netstandard2.0/Azure.Core.Amqp.dll
+ azure.core/1.47.1/lib/net8.0/Azure.Core.dll
+ azure.identity/1.14.2/lib/net8.0/Azure.Identity.dll
+ azure.messaging.servicebus/7.18.2/lib/netstandard2.0/Azure.Messaging.ServiceBus.dll
+ azure.monitor.opentelemetry.exporter/1.3.0/lib/net6.0/Azure.Monitor.OpenTelemetry.Exporter.dll
+ ecommerce.shared/2.16.0/lib/net10.0/ECommerce.Shared.dll
+ google.protobuf/3.22.5/lib/net5.0/Google.Protobuf.dll
+ grpc.core.api/2.52.0/lib/netstandard2.1/Grpc.Core.Api.dll
+ grpc.net.client/2.52.0/lib/net7.0/Grpc.Net.Client.dll
+ grpc.net.common/2.52.0/lib/net7.0/Grpc.Net.Common.dll
+ microsoft.aspnetcore.authentication.jwtbearer/10.0.5/lib/net10.0/Microsoft.AspNetCore.Authentication.JwtBearer.dll
+ microsoft.aspnetcore.mvc.testing/10.0.5/lib/net10.0/Microsoft.AspNetCore.Mvc.Testing.dll
+ microsoft.aspnetcore.testhost/10.0.5/lib/net10.0/Microsoft.AspNetCore.TestHost.dll
+ microsoft.azure.amqp/2.6.7/lib/netstandard2.0/Microsoft.Azure.Amqp.dll
+ microsoft.bcl.asyncinterfaces/8.0.0/lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll
+ microsoft.bcl.cryptography/9.0.4/lib/net9.0/Microsoft.Bcl.Cryptography.dll
+ microsoft.codecoverage/17.14.1/lib/net8.0/Microsoft.VisualStudio.CodeCoverage.Shim.dll
+ microsoft.data.sqlclient/6.1.1/ref/net9.0/Microsoft.Data.SqlClient.dll
+ microsoft.entityframeworkcore.abstractions/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Abstractions.dll
+ microsoft.entityframeworkcore.relational/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.Relational.dll
+ microsoft.entityframeworkcore.sqlserver/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.SqlServer.dll
+ microsoft.entityframeworkcore/10.0.5/lib/net10.0/Microsoft.EntityFrameworkCore.dll
+ microsoft.extensions.dependencymodel/10.0.5/lib/net10.0/Microsoft.Extensions.DependencyModel.dll
+ microsoft.identity.client.extensions.msal/4.73.1/lib/net8.0/Microsoft.Identity.Client.Extensions.Msal.dll
+ microsoft.identity.client/4.73.1/lib/net8.0/Microsoft.Identity.Client.dll
+ microsoft.identitymodel.abstractions/8.0.1/lib/net9.0/Microsoft.IdentityModel.Abstractions.dll
+ microsoft.identitymodel.jsonwebtokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.JsonWebTokens.dll
+ microsoft.identitymodel.logging/8.0.1/lib/net9.0/Microsoft.IdentityModel.Logging.dll
+ microsoft.identitymodel.protocols.openidconnect/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.OpenIdConnect.dll
+ microsoft.identitymodel.protocols/8.0.1/lib/net9.0/Microsoft.IdentityModel.Protocols.dll
+ microsoft.identitymodel.tokens/8.0.1/lib/net9.0/Microsoft.IdentityModel.Tokens.dll
+ microsoft.openapi/1.6.14/lib/netstandard2.0/Microsoft.OpenApi.dll
+ microsoft.sqlserver.server/1.0.0/lib/netstandard2.0/Microsoft.SqlServer.Server.dll
+ microsoft.testplatform.testhost/17.14.1/lib/net8.0/
+  Microsoft.TestPlatform.CommunicationUtilities.dll
+  Microsoft.TestPlatform.CoreUtilities.dll
+  Microsoft.TestPlatform.CrossPlatEngine.dll
+  Microsoft.TestPlatform.PlatformAbstractions.dll
+  Microsoft.TestPlatform.Utilities.dll
+  Microsoft.VisualStudio.TestPlatform.Common.dll
+  Microsoft.VisualStudio.TestPlatform.ObjectModel.dll
+  testhost.dll
+ newtonsoft.json/13.0.3/lib/net6.0/Newtonsoft.Json.dll
+ opentelemetry.api.providerbuilderextensions/1.10.0/lib/net9.0/OpenTelemetry.Api.ProviderBuilderExtensions.dll
+ opentelemetry.api/1.10.0/lib/net9.0/OpenTelemetry.Api.dll
+ opentelemetry.exporter.console/1.9.0/lib/net8.0/OpenTelemetry.Exporter.Console.dll
+ opentelemetry.exporter.opentelemetryprotocol/1.9.0/lib/net8.0/OpenTelemetry.Exporter.OpenTelemetryProtocol.dll
+ opentelemetry.exporter.prometheus.aspnetcore/1.10.0-beta.1/lib/net9.0/OpenTelemetry.Exporter.Prometheus.AspNetCore.dll
+ opentelemetry.extensions.hosting/1.9.0/lib/net8.0/OpenTelemetry.Extensions.Hosting.dll
+ opentelemetry.instrumentation.aspnetcore/1.9.0/lib/net8.0/OpenTelemetry.Instrumentation.AspNetCore.dll
+ opentelemetry.instrumentation.sqlclient/1.9.0-beta.1/lib/net8.0/OpenTelemetry.Instrumentation.SqlClient.dll
+ opentelemetry.persistentstorage.abstractions/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.Abstractions.dll
+ opentelemetry.persistentstorage.filesystem/1.0.0/lib/netstandard2.0/OpenTelemetry.PersistentStorage.FileSystem.dll
+ opentelemetry/1.10.0/lib/net9.0/OpenTelemetry.dll
+ pipelines.sockets.unofficial/2.2.8/lib/net5.0/Pipelines.Sockets.Unofficial.dll
+ polly.core/8.6.6/lib/net8.0/Polly.Core.dll
+ rabbitmq.client/6.8.1/lib/netstandard2.0/RabbitMQ.Client.dll
+ stackexchange.redis/2.8.16/lib/net6.0/StackExchange.Redis.dll
+ swashbuckle.aspnetcore.swagger/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.Swagger.dll
+ swashbuckle.aspnetcore.swaggergen/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.dll
+ swashbuckle.aspnetcore.swaggerui/6.6.2/lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.dll
+ system.clientmodel/1.5.1/lib/net8.0/System.ClientModel.dll
+ system.identitymodel.tokens.jwt/8.0.1/lib/net9.0/System.IdentityModel.Tokens.Jwt.dll
+ system.memory.data/8.0.1/lib/net8.0/System.Memory.Data.dll
+ system.security.cryptography.pkcs/9.0.4/lib/net9.0/System.Security.Cryptography.Pkcs.dll
+ system.security.cryptography.protecteddata/9.0.4/lib/net9.0/System.Security.Cryptography.ProtectedData.dll
+ xunit.abstractions/2.0.3/lib/netstandard2.0/xunit.abstractions.dll
+ xunit.assert/2.9.3/lib/net6.0/xunit.assert.dll
+ xunit.extensibility.core/2.9.3/lib/netstandard1.1/xunit.core.dll
+ xunit.extensibility.execution/2.9.3/lib/netstandard1.1/xunit.execution.dotnet.dll
 
 [analyzerReferences]
+<DOTNET>/packs/Microsoft.AspNetCore.App.Ref/10.0.8/analyzers/dotnet/cs/
+ Microsoft.AspNetCore.App.Analyzers.dll
+ Microsoft.AspNetCore.App.CodeFixes.dll
+ Microsoft.AspNetCore.App.SourceGenerators.dll
+ Microsoft.AspNetCore.Components.Analyzers.dll
+ Microsoft.Extensions.Logging.Generators.dll
+ Microsoft.Extensions.Options.SourceGeneration.dll
+ Microsoft.Extensions.Validation.ValidationsGenerator.dll
 <DOTNET>/packs/Microsoft.NETCore.App.Ref/10.0.8/analyzers/dotnet/cs/
  Microsoft.Interop.ComInterfaceGenerator.dll
  Microsoft.Interop.JavaScript.JSImportGenerator.dll
@@ -273,6 +494,12 @@ ShippingWebApplicationFactory.cs
  Microsoft.CodeAnalysis.CodeStyle.Fixes.dll
  Microsoft.CodeAnalysis.CSharp.CodeStyle.dll
  Microsoft.CodeAnalysis.CSharp.CodeStyle.Fixes.dll
+<NUGET>/
+ microsoft.entityframeworkcore.analyzers/10.0.5/analyzers/dotnet/cs/Microsoft.EntityFrameworkCore.Analyzers.dll
+ system.clientmodel/1.5.1/analyzers/dotnet/cs/System.ClientModel.SourceGeneration.dll
+ xunit.analyzers/1.18.0/analyzers/dotnet/cs/
+  xunit.analyzers.dll
+  xunit.analyzers.fixes.dll
 
 [analyzerConfigFiles]
 ../../.editorconfig


### PR DESCRIPTION
Closes #61

## Summary

Implements the full PRD for Payment domain-event depth and the shared Outbox unit-of-work seam across all six planned phases. Every publishing service (Payment, Inventory, Shipping) now expresses transactional work through one atomic interface instead of repeating `CreateExecutionStrategy + TransactionScope + AddOutboxEvent + scope.Complete()` at every call site.

---

## What changed

### Phase 1 — Capture through the deep seam (`#62`)

- Added `IOutboxUnitOfWork` / `OutboxUnitOfWork` to `ECommerce.Shared` (registered by `AddOutbox`).
- `ECommerce.Shared` bumped `2.14.0 → 2.15.0`; Payment consumes `2.15.0`.
- Added `Entity` base and `IDomainEvent` support to the Payment service models.
- Added `PaymentCapturedDomainEvent` and its translation to `PaymentCapturedEvent` in `PaymentContext.ExecuteAsync`.
- Migrated the Capture endpoint to `paymentStore.ExecuteAsync(...)` — zero `TransactionScope` or `AddOutboxEvent` at the call site.

### Phase 2 — Refund through the same seam (`#63`)

- Added `PaymentRefundedDomainEvent` and translation to `PaymentRefundedEvent`.
- Migrated the Refund endpoint to the same `paymentStore.ExecuteAsync(...)` pattern.
- Full-refund default behaviour and HTTP contract unchanged.

### Phase 3 — Authorize and failure parity (`#64`, `#65`)

- Added `PaymentAuthorizedDomainEvent`, `PaymentFailedDomainEvent`, and `PaymentVoidedDomainEvent` with their respective translations.
- Authorize, Fail, and Void transitions are enforced by the `Payment` aggregate state machine.
- Idempotent re-application of transitions is explicit: repeated transitions are no-ops that do not enqueue duplicate domain or outbox events.
- Tests assert every supported transition and every terminal-state rejection, all without EF Core, Outbox, broker, or gateway dependencies.

### Phase 4 — Inventory and Shipping adoption (`#66`, `#67`, `#68`, `#69`)

- Migrated `OrderCreatedEventHandler` (Inventory) to the shared Outbox unit-of-work.
- Migrated remaining Inventory publishing endpoints.
- Migrated Shipping admin transition endpoints.
- Migrated Shipping carrier update paths.
- None of the migrated call sites introduce EF execution-strategy or `TransactionScope` ceremony — the seam owns that.

### Phase 5 — Observability (`#70`)

- `OutboxUnitOfWork` emits an OTEL activity span per execution with `outcome=committed` or `outcome=rolled_back` tags.
- A shared `outbox.transaction` counter metric records success/failure counts across all consuming services.
- Telemetry is transport-neutral and does not reference any broker adapter.

### Phase 6 — Documentation and guardrails (`#71`)

- XML doc on `IOutboxUnitOfWork` marks it as the preferred caller-facing seam.
- `IOutboxStore` low-level primitives remain available for the unit-of-work implementation and infra code; no public methods removed.
- Final code audit confirms no direct `CreateExecutionStrategy + TransactionScope + AddOutboxEvent + Complete` pattern remains in migrated Payment, Inventory, or Shipping paths.

---

## Architectural decisions preserved

- **No change to Integration Event payloads.** `PaymentAuthorizedEvent`, `PaymentCapturedEvent`, and `PaymentRefundedEvent` shapes are unchanged; subscribers see no contract diff.
- **No change to messaging topology.** Outbox unit-of-work is broker-agnostic; `Messaging:Provider` selects RabbitMQ (default) or Azure Service Bus at boot, exactly as before.
- **No central orchestrator.** ADR-0008 (saga choreography) stands.
- **No schema changes.** Domain events are in-memory; Outbox tables remain as defined by ADR-0002.
- **Shared package workflow (ADR-0005).** `2.15.0` ships with Payment; Inventory and Shipping upgraded explicitly.

---

## Testing

| Layer | What is covered |
|---|---|
| Payment aggregate (unit) | Every supported transition, every illegal-state rejection, idempotency semantics — no EF/Outbox/broker |
| `PaymentContext.ExecuteAsync` (integration) | Atomic commit: state + outbox row together; atomic rollback on failure |
| Outbox unit-of-work (integration) | Atomic commit and rollback; OTEL span + metric on both paths |
| Payment endpoints (smoke) | HTTP contract and resulting Outbox state; no assertions on transaction internals |
| Inventory handler / Shipping endpoints (regression) | Outcomes and emitted Integration Events; rewritten where tests were over-specifying internal calls |

Pre-commit runs Basket tests only. Payment, Inventory, Shipping, and `ECommerce.Shared` test suites were run manually before pushing per repo convention.

`dotnet format --verify-no-changes` passes. No new `NoWarn` exemptions added.