### PR TITLE
Refactor inventory reservations into StockItem aggregate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,16 +28,28 @@ docker compose up sql rabbitmq redis -d                         # infra only
 
 Activate once: `dotnet tool restore && dotnet husky install`. Hook runs `dotnet format --verify-no-changes`, `dotnet build --no-restore`, then Basket tests only — **run other suites manually before pushing cross-service changes**.
 
-Known WSL/virtiofs/Docker sandbox issue: pre-commit may fail at `dotnet build --no-restore` with `MSB3248 No such device` due to root-owned or sandbox-created `bin/obj`. Not a regression. Workaround from a writable host shell:
+### Sandbox policy (WSL / virtiofs / Docker)
 
-```bash
-find . -type d \( -name bin -o -name obj \) -prune -exec rm -rf {} +
-dotnet restore && dotnet husky run --group pre-commit
-```
+Known failure: `MSB3248 No such device` on `dotnet build --no-restore` (or on `ECommerce.Shared.Tests` reading a freshly built shared DLL) caused by root-owned or sandbox-created `bin`/`obj`. Not a regression.
 
-Sandbox validation note: `dotnet format --verify-no-changes` and shared-library `dotnet build` can pass clean in Docker sandbox while `ECommerce.Shared.Tests` still fails with `MSB3248 No such device` when reading the freshly built shared DLL. If a sandbox-only automation already used `--no-verify` because of this issue, record the passing commands and require a host workflow to rerun the skipped hook/tests before push or merge.
+**Mandatory order before any commit in sandbox:**
 
-If cleanup is blocked, commit from a host where hooks pass. **Do not bypass hooks.**
+1. Clean + restore + rerun hook:
+   ```bash
+   find . -type d \( -name bin -o -name obj \) -prune -exec rm -rf {} +
+   dotnet restore && dotnet husky run --group pre-commit
+   ```
+2. If still `MSB3248`, retry once more after `dotnet restore --force`.
+3. If hook still fails: **STOP. Do not commit.** Report blocker to user with the exact failing command + error. User commits from host.
+
+**Hard prohibitions** (no exceptions, no "sandbox-only" escape hatch):
+
+- No `--no-verify`, no `-c core.hooksPath=`, no skipping `dotnet format` / `dotnet build` / tests.
+- No `Hooks-Deferred:` / `Validation-Deferred:` / similar commit-message footer.
+- No "passed clean in sandbox, defer remainder to host" partial commits.
+- No closing the issue / marking task done while validation is deferred.
+
+Rationale: a commit with deferred validation pollutes history, blocks downstream automation, and shifts unfinished work onto the user without their consent. The correct sandbox outcome when hooks cannot pass is **handoff, not commit**.
 
 ## Shared library (`ECommerce.Shared`)
 

--- a/docs/wiki/Service-Inventory.md
+++ b/docs/wiki/Service-Inventory.md
@@ -38,6 +38,19 @@ Implementation: `Endpoints/InventoryApiEndpoints.cs`.
 - `20260420140000_Phase5Sync`
 - `20260421120000_AddBackorderRequests`
 
+## Domain model — the `StockItem` aggregate
+
+The reservation lifecycle is owned by a rich `StockItem` aggregate, not by the persistence layer. `StockLevel` and `StockReservation` are members of the aggregate; `StockMovement` rows are recorded by orchestration from what the aggregate returns.
+
+- **`StockItem.Hold`** — reserves stock for an order. Enforces the availability invariant (a hold can never exceed `Available = TotalOnHand - TotalReserved`) and short-circuits idempotently when the order already holds stock. `TotalReserved` and the per-warehouse `StockLevel.Reserved` are mutated together so they cannot drift.
+- **`StockItem.Commit`** — converts an order's `Held` reservations into consumed stock; decrements the reserved and on-hand counters together. Skips non-`Held` reservations, so a double-commit is an idempotent no-op.
+- **`StockItem.Release`** — returns an order's reservations: a `Held` release only frees reserved units; a `Committed` release also restores on-hand stock. Mixed held/committed orders are handled in one call; already-released reservations are skipped (double-release idempotent).
+- **`StockReservation` guarded transitions** — `Status` is `init`-only. Once a reservation exists its state changes only through guarded `Commit()` / `Release()` methods (invoked by the aggregate) that throw on illegal source states. Illegal lifecycle transitions are unrepresentable through the public API.
+
+Each method returns a `*ItemResult` value type (`HoldResult`, `CommitItemResult`, `ReleaseItemResult`) carrying the outcome plus the movements to persist. `InventoryContext`'s `Reserve` / `CommitReservations` / `ReleaseReservations` are thin orchestration: load aggregate, delegate, persist movements, save — no inline state-machine logic. The `IInventoryStore` seam, all `*Result` records, `AlreadyProcessed` semantics, the EF schema, and the published events are unchanged by this refactor.
+
+See [`docs/prd/PRD-StockItem-Aggregate.md`](https://github.com/daonhan/Microservices-in-.NET/blob/main/docs/prd/PRD-StockItem-Aggregate.md) and [`docs/plans/stockitem-aggregate.md`](https://github.com/daonhan/Microservices-in-.NET/blob/main/docs/plans/stockitem-aggregate.md) ([#55](https://github.com/daonhan/Microservices-in-.NET/issues/55)).
+
 ## Saga participation
 
 See [Architecture § Saga](Architecture#saga-order--inventory).
@@ -49,7 +62,9 @@ Inventory.Service/
 ├── Program.cs
 ├── Endpoints/InventoryApiEndpoints.cs
 ├── ApiModels/
-├── Models/                 # StockItem, StockMovement, StockReservation, BackorderRequest
+├── Models/                 # StockItem aggregate (Hold/Commit/Release), StockLevel,
+│                           # StockReservation (guarded), StockMovement, BackorderRequest,
+│                           # Hold/Commit/Release ItemResult value types
 ├── Infrastructure/Data/
 ├── IntegrationEvents/      # published + subscribed handlers
 └── Migrations/

--- a/inventory-microservice/Inventory.Service/Infrastructure/Data/EntityFramework/InventoryContext.cs
+++ b/inventory-microservice/Inventory.Service/Infrastructure/Data/EntityFramework/InventoryContext.cs
@@ -374,45 +374,23 @@ internal class InventoryContext : DbContext, IInventoryStore
         var stockLevels = await StockLevels
             .Where(l => productIds.Contains(l.ProductId))
             .ToListAsync();
-        var stockLevelsByKey = stockLevels.ToDictionary(l => (l.ProductId, l.WarehouseId));
 
         var now = DateTime.UtcNow;
         var releasedLines = new List<ReleasedLine>();
 
-        foreach (var reservation in reservations)
+        foreach (var group in reservations.GroupBy(r => r.ProductId))
         {
-            if (reservation.Status == ReservationStatus.Released)
+            var item = stockItems[group.Key];
+            var levelsByWarehouse = stockLevels
+                .Where(l => l.ProductId == group.Key)
+                .ToDictionary(l => l.WarehouseId);
+
+            var result = item.Release(orderId, group.ToList(), levelsByWarehouse, now);
+            foreach (var movement in result.Movements)
             {
-                continue;
+                RecordStockMovement(movement);
+                releasedLines.Add(new ReleasedLine(movement.ProductId, movement.WarehouseId, movement.Quantity));
             }
-
-            var item = stockItems[reservation.ProductId];
-            var level = stockLevelsByKey[(reservation.ProductId, reservation.WarehouseId)];
-
-            if (reservation.Status == ReservationStatus.Held)
-            {
-                level.Reserved -= reservation.Quantity;
-                item.TotalReserved -= reservation.Quantity;
-            }
-            else if (reservation.Status == ReservationStatus.Committed)
-            {
-                level.OnHand += reservation.Quantity;
-                item.TotalOnHand += reservation.Quantity;
-            }
-
-            reservation.Status = ReservationStatus.Released;
-
-            RecordStockMovement(new StockMovement
-            {
-                ProductId = reservation.ProductId,
-                WarehouseId = reservation.WarehouseId,
-                Type = MovementType.Release,
-                Quantity = reservation.Quantity,
-                OccurredAt = now,
-                OrderId = orderId
-            });
-
-            releasedLines.Add(new ReleasedLine(reservation.ProductId, reservation.WarehouseId, reservation.Quantity));
         }
 
         await SaveChangesAsync();

--- a/inventory-microservice/Inventory.Service/Infrastructure/Data/EntityFramework/InventoryContext.cs
+++ b/inventory-microservice/Inventory.Service/Infrastructure/Data/EntityFramework/InventoryContext.cs
@@ -215,7 +215,8 @@ internal class InventoryContext : DbContext, IInventoryStore
 
         var now = DateTime.UtcNow;
         var failedLines = new List<FailedReserveLine>();
-        var holds = new List<HoldResult>(lines.Count);
+        var plans = new List<(HoldResult Plan, StockItem Item, StockLevel Level)>(lines.Count);
+        var pendingByProduct = new Dictionary<int, int>();
         bool alreadyProcessed = false;
 
         foreach (var line in lines)
@@ -227,20 +228,23 @@ internal class InventoryContext : DbContext, IInventoryStore
                 continue;
             }
 
-            var hold = item.Hold(orderId, defaultWarehouse.Id, line.Quantity, level, existingReservations, now);
-            if (hold.Outcome == HoldOutcome.AlreadyHeld)
+            pendingByProduct.TryGetValue(line.ProductId, out var pending);
+            var plan = item.EvaluateHold(orderId, defaultWarehouse.Id, line.Quantity, existingReservations, pending, now);
+
+            if (plan.Outcome == HoldOutcome.AlreadyHeld)
             {
                 alreadyProcessed = true;
                 continue;
             }
 
-            if (hold.Outcome == HoldOutcome.InsufficientStock)
+            if (plan.Outcome == HoldOutcome.InsufficientStock)
             {
-                failedLines.Add(new FailedReserveLine(line.ProductId, line.Quantity, hold.Available));
+                failedLines.Add(new FailedReserveLine(line.ProductId, line.Quantity, plan.Available));
                 continue;
             }
 
-            holds.Add(hold);
+            pendingByProduct[line.ProductId] = pending + line.Quantity;
+            plans.Add((plan, item, level));
         }
 
         if (alreadyProcessed)
@@ -256,12 +260,13 @@ internal class InventoryContext : DbContext, IInventoryStore
             return new ReserveResult(Reserved: false, AlreadyProcessed: false, [], failedLines);
         }
 
-        var reservedLines = new List<ReservedLine>(holds.Count);
-        foreach (var hold in holds)
+        var reservedLines = new List<ReservedLine>(plans.Count);
+        foreach (var (plan, item, level) in plans)
         {
-            StockReservations.Add(hold.Reservation!);
-            RecordStockMovement(hold.Movement!);
-            reservedLines.Add(new ReservedLine(hold.ProductId, hold.WarehouseId, hold.Quantity));
+            item.ApplyHold(plan, level);
+            StockReservations.Add(plan.Reservation!);
+            RecordStockMovement(plan.Movement!);
+            reservedLines.Add(new ReservedLine(plan.ProductId, plan.WarehouseId, plan.Quantity));
         }
 
         await SaveChangesAsync();
@@ -290,15 +295,19 @@ internal class InventoryContext : DbContext, IInventoryStore
             .Where(l => productIds.Contains(l.ProductId))
             .ToListAsync();
 
+        var levelsByProduct = stockLevels
+            .GroupBy(l => l.ProductId)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyDictionary<int, StockLevel>)g.ToDictionary(l => l.WarehouseId));
+
         var now = DateTime.UtcNow;
         var committedLines = new List<CommittedLine>();
 
         foreach (var group in reservations.GroupBy(r => r.ProductId))
         {
             var item = stockItems[group.Key];
-            var levelsByWarehouse = stockLevels
-                .Where(l => l.ProductId == group.Key)
-                .ToDictionary(l => l.WarehouseId);
+            var levelsByWarehouse = levelsByProduct[group.Key];
 
             var result = item.Commit(orderId, group.ToList(), levelsByWarehouse, now);
             foreach (var movement in result.Movements)
@@ -375,15 +384,19 @@ internal class InventoryContext : DbContext, IInventoryStore
             .Where(l => productIds.Contains(l.ProductId))
             .ToListAsync();
 
+        var levelsByProduct = stockLevels
+            .GroupBy(l => l.ProductId)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyDictionary<int, StockLevel>)g.ToDictionary(l => l.WarehouseId));
+
         var now = DateTime.UtcNow;
         var releasedLines = new List<ReleasedLine>();
 
         foreach (var group in reservations.GroupBy(r => r.ProductId))
         {
             var item = stockItems[group.Key];
-            var levelsByWarehouse = stockLevels
-                .Where(l => l.ProductId == group.Key)
-                .ToDictionary(l => l.WarehouseId);
+            var levelsByWarehouse = levelsByProduct[group.Key];
 
             var result = item.Release(orderId, group.ToList(), levelsByWarehouse, now);
             foreach (var movement in result.Movements)

--- a/inventory-microservice/Inventory.Service/Infrastructure/Data/EntityFramework/InventoryContext.cs
+++ b/inventory-microservice/Inventory.Service/Infrastructure/Data/EntityFramework/InventoryContext.cs
@@ -280,15 +280,6 @@ internal class InventoryContext : DbContext, IInventoryStore
             return new CommitResult(Committed: false, AlreadyProcessed: false, []);
         }
 
-        if (reservations.All(r => r.Status != ReservationStatus.Held))
-        {
-            var already = reservations
-                .Where(r => r.Status == ReservationStatus.Committed)
-                .Select(r => new CommittedLine(r.ProductId, r.WarehouseId, r.Quantity))
-                .ToList();
-            return new CommitResult(Committed: true, AlreadyProcessed: true, already);
-        }
-
         var productIds = reservations.Select(r => r.ProductId).Distinct().ToArray();
 
         var stockItems = await StockItems
@@ -298,39 +289,32 @@ internal class InventoryContext : DbContext, IInventoryStore
         var stockLevels = await StockLevels
             .Where(l => productIds.Contains(l.ProductId))
             .ToListAsync();
-        var stockLevelsByKey = stockLevels.ToDictionary(l => (l.ProductId, l.WarehouseId));
 
         var now = DateTime.UtcNow;
         var committedLines = new List<CommittedLine>();
 
-        foreach (var reservation in reservations)
+        foreach (var group in reservations.GroupBy(r => r.ProductId))
         {
-            if (reservation.Status != ReservationStatus.Held)
+            var item = stockItems[group.Key];
+            var levelsByWarehouse = stockLevels
+                .Where(l => l.ProductId == group.Key)
+                .ToDictionary(l => l.WarehouseId);
+
+            var result = item.Commit(orderId, group.ToList(), levelsByWarehouse, now);
+            foreach (var movement in result.Movements)
             {
-                continue;
+                RecordStockMovement(movement);
+                committedLines.Add(new CommittedLine(movement.ProductId, movement.WarehouseId, movement.Quantity));
             }
+        }
 
-            var item = stockItems[reservation.ProductId];
-            var level = stockLevelsByKey[(reservation.ProductId, reservation.WarehouseId)];
-
-            level.Reserved -= reservation.Quantity;
-            level.OnHand -= reservation.Quantity;
-            item.TotalReserved -= reservation.Quantity;
-            item.TotalOnHand -= reservation.Quantity;
-
-            reservation.Status = ReservationStatus.Committed;
-
-            RecordStockMovement(new StockMovement
-            {
-                ProductId = reservation.ProductId,
-                WarehouseId = reservation.WarehouseId,
-                Type = MovementType.Commit,
-                Quantity = reservation.Quantity,
-                OccurredAt = now,
-                OrderId = orderId
-            });
-
-            committedLines.Add(new CommittedLine(reservation.ProductId, reservation.WarehouseId, reservation.Quantity));
+        if (committedLines.Count == 0)
+        {
+            var already = reservations
+                .Where(r => r.Status == ReservationStatus.Committed)
+                .Select(r => new CommittedLine(r.ProductId, r.WarehouseId, r.Quantity))
+                .ToList();
+            return new CommitResult(Committed: true, AlreadyProcessed: true, already);
         }
 
         await SaveChangesAsync();

--- a/inventory-microservice/Inventory.Service/Infrastructure/Data/EntityFramework/InventoryContext.cs
+++ b/inventory-microservice/Inventory.Service/Infrastructure/Data/EntityFramework/InventoryContext.cs
@@ -192,18 +192,14 @@ internal class InventoryContext : DbContext, IInventoryStore
 
     public async Task<ReserveResult> Reserve(Guid orderId, IReadOnlyList<ReserveLine> lines)
     {
-        var existing = await StockReservations
+        if (lines.Count == 0)
+        {
+            return new ReserveResult(Reserved: false, AlreadyProcessed: false, [], []);
+        }
+
+        var existingReservations = await StockReservations
             .Where(r => r.OrderId == orderId)
             .ToListAsync();
-
-        if (existing.Count > 0)
-        {
-            var already = existing
-                .Select(r => new ReservedLine(r.ProductId, r.WarehouseId, r.Quantity))
-                .ToList();
-
-            return new ReserveResult(Reserved: true, AlreadyProcessed: true, already, []);
-        }
 
         var defaultWarehouse = await Warehouses.FirstAsync(w => w.Code == "DEFAULT");
 
@@ -220,6 +216,7 @@ internal class InventoryContext : DbContext, IInventoryStore
         var now = DateTime.UtcNow;
         var failedLines = new List<FailedReserveLine>();
         var holds = new List<HoldResult>(lines.Count);
+        bool alreadyProcessed = false;
 
         foreach (var line in lines)
         {
@@ -230,7 +227,13 @@ internal class InventoryContext : DbContext, IInventoryStore
                 continue;
             }
 
-            var hold = item.Hold(orderId, defaultWarehouse.Id, line.Quantity, level, [], now);
+            var hold = item.Hold(orderId, defaultWarehouse.Id, line.Quantity, level, existingReservations, now);
+            if (hold.Outcome == HoldOutcome.AlreadyHeld)
+            {
+                alreadyProcessed = true;
+                continue;
+            }
+
             if (hold.Outcome == HoldOutcome.InsufficientStock)
             {
                 failedLines.Add(new FailedReserveLine(line.ProductId, line.Quantity, hold.Available));
@@ -238,6 +241,14 @@ internal class InventoryContext : DbContext, IInventoryStore
             }
 
             holds.Add(hold);
+        }
+
+        if (alreadyProcessed)
+        {
+            var already = existingReservations
+                .Select(r => new ReservedLine(r.ProductId, r.WarehouseId, r.Quantity))
+                .ToList();
+            return new ReserveResult(Reserved: true, AlreadyProcessed: true, already, []);
         }
 
         if (failedLines.Count > 0)

--- a/inventory-microservice/Inventory.Service/Infrastructure/Data/EntityFramework/InventoryContext.cs
+++ b/inventory-microservice/Inventory.Service/Infrastructure/Data/EntityFramework/InventoryContext.cs
@@ -217,20 +217,27 @@ internal class InventoryContext : DbContext, IInventoryStore
             .Where(l => productIds.Contains(l.ProductId) && l.WarehouseId == defaultWarehouse.Id)
             .ToDictionaryAsync(l => l.ProductId);
 
+        var now = DateTime.UtcNow;
         var failedLines = new List<FailedReserveLine>();
+        var holds = new List<HoldResult>(lines.Count);
+
         foreach (var line in lines)
         {
             if (!stockItems.TryGetValue(line.ProductId, out var item) ||
-                !stockLevels.TryGetValue(line.ProductId, out _))
+                !stockLevels.TryGetValue(line.ProductId, out var level))
             {
                 failedLines.Add(new FailedReserveLine(line.ProductId, line.Quantity, 0));
                 continue;
             }
 
-            if (item.Available < line.Quantity)
+            var hold = item.Hold(orderId, defaultWarehouse.Id, line.Quantity, level, [], now);
+            if (hold.Outcome == HoldOutcome.InsufficientStock)
             {
-                failedLines.Add(new FailedReserveLine(line.ProductId, line.Quantity, item.Available));
+                failedLines.Add(new FailedReserveLine(line.ProductId, line.Quantity, hold.Available));
+                continue;
             }
+
+            holds.Add(hold);
         }
 
         if (failedLines.Count > 0)
@@ -238,38 +245,12 @@ internal class InventoryContext : DbContext, IInventoryStore
             return new ReserveResult(Reserved: false, AlreadyProcessed: false, [], failedLines);
         }
 
-        var now = DateTime.UtcNow;
-        var reservedLines = new List<ReservedLine>(lines.Count);
-
-        foreach (var line in lines)
+        var reservedLines = new List<ReservedLine>(holds.Count);
+        foreach (var hold in holds)
         {
-            var item = stockItems[line.ProductId];
-            var level = stockLevels[line.ProductId];
-
-            level.Reserved += line.Quantity;
-            item.TotalReserved += line.Quantity;
-
-            StockReservations.Add(new StockReservation
-            {
-                OrderId = orderId,
-                ProductId = line.ProductId,
-                WarehouseId = defaultWarehouse.Id,
-                Quantity = line.Quantity,
-                Status = ReservationStatus.Held,
-                CreatedAt = now
-            });
-
-            RecordStockMovement(new StockMovement
-            {
-                ProductId = line.ProductId,
-                WarehouseId = defaultWarehouse.Id,
-                Type = MovementType.Reserve,
-                Quantity = line.Quantity,
-                OccurredAt = now,
-                OrderId = orderId
-            });
-
-            reservedLines.Add(new ReservedLine(line.ProductId, defaultWarehouse.Id, line.Quantity));
+            StockReservations.Add(hold.Reservation!);
+            RecordStockMovement(hold.Movement!);
+            reservedLines.Add(new ReservedLine(hold.ProductId, hold.WarehouseId, hold.Quantity));
         }
 
         await SaveChangesAsync();

--- a/inventory-microservice/Inventory.Service/Models/CommitItemResult.cs
+++ b/inventory-microservice/Inventory.Service/Models/CommitItemResult.cs
@@ -1,0 +1,11 @@
+namespace Inventory.Service.Models;
+
+internal enum CommitOutcome
+{
+    Committed = 1,
+    NothingHeld = 2
+}
+
+internal sealed record CommitItemResult(
+    CommitOutcome Outcome,
+    IReadOnlyList<StockMovement> Movements);

--- a/inventory-microservice/Inventory.Service/Models/HoldResult.cs
+++ b/inventory-microservice/Inventory.Service/Models/HoldResult.cs
@@ -1,0 +1,17 @@
+namespace Inventory.Service.Models;
+
+internal enum HoldOutcome
+{
+    Held = 1,
+    AlreadyHeld = 2,
+    InsufficientStock = 3
+}
+
+internal sealed record HoldResult(
+    HoldOutcome Outcome,
+    int ProductId,
+    int WarehouseId,
+    int Quantity,
+    int Available,
+    StockReservation? Reservation,
+    StockMovement? Movement);

--- a/inventory-microservice/Inventory.Service/Models/ReleaseItemResult.cs
+++ b/inventory-microservice/Inventory.Service/Models/ReleaseItemResult.cs
@@ -1,0 +1,11 @@
+namespace Inventory.Service.Models;
+
+internal enum ReleaseOutcome
+{
+    Released = 1,
+    NothingToRelease = 2
+}
+
+internal sealed record ReleaseItemResult(
+    ReleaseOutcome Outcome,
+    IReadOnlyList<StockMovement> Movements);

--- a/inventory-microservice/Inventory.Service/Models/StockItem.cs
+++ b/inventory-microservice/Inventory.Service/Models/StockItem.cs
@@ -117,7 +117,7 @@ internal class StockItem
             TotalReserved -= reservation.Quantity;
             TotalOnHand -= reservation.Quantity;
 
-            reservation.Status = ReservationStatus.Committed;
+            reservation.Commit();
 
             movements.Add(new StockMovement
             {
@@ -132,6 +132,62 @@ internal class StockItem
 
         return new CommitItemResult(
             movements.Count > 0 ? CommitOutcome.Committed : CommitOutcome.NothingHeld,
+            movements);
+    }
+
+    /// <summary>
+    /// Releases this order's reservations. Releasing a <see cref="ReservationStatus.Held"/>
+    /// reservation only returns the reserved units (<see cref="TotalReserved"/> and the
+    /// per-warehouse <see cref="StockLevel.Reserved"/> are decremented together); releasing a
+    /// <see cref="ReservationStatus.Committed"/> reservation also restores on-hand stock
+    /// (<see cref="TotalOnHand"/> and <see cref="StockLevel.OnHand"/> are incremented together).
+    /// Mixed held/committed orders are handled in one call. Already-released reservations are
+    /// skipped, so a double-release is an idempotent no-op reported as
+    /// <see cref="ReleaseOutcome.NothingToRelease"/>.
+    /// </summary>
+    public ReleaseItemResult Release(
+        Guid orderId,
+        IReadOnlyCollection<StockReservation> orderReservations,
+        IReadOnlyDictionary<int, StockLevel> levelsByWarehouse,
+        DateTime timestamp)
+    {
+        var movements = new List<StockMovement>();
+
+        foreach (var reservation in orderReservations)
+        {
+            if (reservation.Status == ReservationStatus.Released)
+            {
+                continue;
+            }
+
+            var level = levelsByWarehouse[reservation.WarehouseId];
+
+            if (reservation.Status == ReservationStatus.Held)
+            {
+                level.Reserved -= reservation.Quantity;
+                TotalReserved -= reservation.Quantity;
+            }
+            else if (reservation.Status == ReservationStatus.Committed)
+            {
+                level.OnHand += reservation.Quantity;
+                TotalOnHand += reservation.Quantity;
+            }
+
+            reservation.Release();
+
+            movements.Add(new StockMovement
+            {
+                ProductId = ProductId,
+                WarehouseId = reservation.WarehouseId,
+                Type = MovementType.Release,
+                Quantity = reservation.Quantity,
+                OccurredAt = timestamp,
+                OrderId = orderId
+            });
+        }
+
+        return new ReleaseItemResult(
+            movements.Count > 0 ? ReleaseOutcome.Released : ReleaseOutcome.NothingToRelease,
             movements);
     }
 }

--- a/inventory-microservice/Inventory.Service/Models/StockItem.cs
+++ b/inventory-microservice/Inventory.Service/Models/StockItem.cs
@@ -86,4 +86,52 @@ internal class StockItem
             reservation,
             movement);
     }
+
+    /// <summary>
+    /// Commits this order's held reservations: the reserved units leave on-hand stock, so
+    /// <see cref="TotalReserved"/>/<see cref="TotalOnHand"/> and the matching per-warehouse
+    /// <see cref="StockLevel.Reserved"/>/<see cref="StockLevel.OnHand"/> are decremented together.
+    /// Reservations that are not <see cref="ReservationStatus.Held"/> are skipped, so a
+    /// double-commit (nothing left in <c>Held</c>) is an idempotent no-op reported as
+    /// <see cref="CommitOutcome.NothingHeld"/>.
+    /// </summary>
+    public CommitItemResult Commit(
+        Guid orderId,
+        IReadOnlyCollection<StockReservation> orderReservations,
+        IReadOnlyDictionary<int, StockLevel> levelsByWarehouse,
+        DateTime timestamp)
+    {
+        var movements = new List<StockMovement>();
+
+        foreach (var reservation in orderReservations)
+        {
+            if (reservation.Status != ReservationStatus.Held)
+            {
+                continue;
+            }
+
+            var level = levelsByWarehouse[reservation.WarehouseId];
+
+            level.Reserved -= reservation.Quantity;
+            level.OnHand -= reservation.Quantity;
+            TotalReserved -= reservation.Quantity;
+            TotalOnHand -= reservation.Quantity;
+
+            reservation.Status = ReservationStatus.Committed;
+
+            movements.Add(new StockMovement
+            {
+                ProductId = ProductId,
+                WarehouseId = reservation.WarehouseId,
+                Type = MovementType.Commit,
+                Quantity = reservation.Quantity,
+                OccurredAt = timestamp,
+                OrderId = orderId
+            });
+        }
+
+        return new CommitItemResult(
+            movements.Count > 0 ? CommitOutcome.Committed : CommitOutcome.NothingHeld,
+            movements);
+    }
 }

--- a/inventory-microservice/Inventory.Service/Models/StockItem.cs
+++ b/inventory-microservice/Inventory.Service/Models/StockItem.cs
@@ -13,4 +13,77 @@ internal class StockItem
     public byte[] RowVersion { get; set; } = null!;
 
     public int Available => TotalOnHand - TotalReserved;
+
+    /// <summary>
+    /// Holds <paramref name="quantity"/> units of this item against an order. The
+    /// aggregate owns the reservation invariants: an order that already holds stock
+    /// short-circuits idempotently, and a hold can never exceed <see cref="Available"/>.
+    /// <see cref="TotalReserved"/> and the per-warehouse <see cref="StockLevel.Reserved"/>
+    /// are mutated together so they cannot drift apart.
+    /// </summary>
+    public HoldResult Hold(
+        Guid orderId,
+        int warehouseId,
+        int quantity,
+        StockLevel level,
+        IReadOnlyCollection<StockReservation> orderReservations,
+        DateTime timestamp)
+    {
+        var existing = orderReservations.FirstOrDefault(r => r.OrderId == orderId);
+        if (existing is not null)
+        {
+            return new HoldResult(
+                HoldOutcome.AlreadyHeld,
+                ProductId,
+                existing.WarehouseId,
+                existing.Quantity,
+                Available,
+                Reservation: null,
+                Movement: null);
+        }
+
+        if (Available < quantity)
+        {
+            return new HoldResult(
+                HoldOutcome.InsufficientStock,
+                ProductId,
+                warehouseId,
+                quantity,
+                Available,
+                Reservation: null,
+                Movement: null);
+        }
+
+        level.Reserved += quantity;
+        TotalReserved += quantity;
+
+        var reservation = new StockReservation
+        {
+            OrderId = orderId,
+            ProductId = ProductId,
+            WarehouseId = warehouseId,
+            Quantity = quantity,
+            Status = ReservationStatus.Held,
+            CreatedAt = timestamp
+        };
+
+        var movement = new StockMovement
+        {
+            ProductId = ProductId,
+            WarehouseId = warehouseId,
+            Type = MovementType.Reserve,
+            Quantity = quantity,
+            OccurredAt = timestamp,
+            OrderId = orderId
+        };
+
+        return new HoldResult(
+            HoldOutcome.Held,
+            ProductId,
+            warehouseId,
+            quantity,
+            Available,
+            reservation,
+            movement);
+    }
 }

--- a/inventory-microservice/Inventory.Service/Models/StockItem.cs
+++ b/inventory-microservice/Inventory.Service/Models/StockItem.cs
@@ -29,6 +29,27 @@ internal class StockItem
         IReadOnlyCollection<StockReservation> orderReservations,
         DateTime timestamp)
     {
+        var plan = EvaluateHold(orderId, warehouseId, quantity, orderReservations, pendingHoldQuantity: 0, timestamp);
+        ApplyHold(plan, level);
+        return plan;
+    }
+
+    /// <summary>
+    /// Computes the outcome of a prospective hold without mutating state. Multi-line callers
+    /// can use this to validate every line before any mutation happens, so a single failed
+    /// line doesn't leave the aggregate or its <see cref="StockLevel"/> partially modified.
+    /// <paramref name="pendingHoldQuantity"/> is the sum of quantities the caller has already
+    /// planned (but not yet applied) for this same product in the current operation, so that
+    /// repeated lines for one product correctly account for cumulative consumption.
+    /// </summary>
+    public HoldResult EvaluateHold(
+        Guid orderId,
+        int warehouseId,
+        int quantity,
+        IReadOnlyCollection<StockReservation> orderReservations,
+        int pendingHoldQuantity,
+        DateTime timestamp)
+    {
         var existing = orderReservations.FirstOrDefault(r => r.OrderId == orderId);
         if (existing is not null)
         {
@@ -42,20 +63,18 @@ internal class StockItem
                 Movement: null);
         }
 
-        if (Available < quantity)
+        var effectiveAvailable = Available - pendingHoldQuantity;
+        if (effectiveAvailable < quantity)
         {
             return new HoldResult(
                 HoldOutcome.InsufficientStock,
                 ProductId,
                 warehouseId,
                 quantity,
-                Available,
+                effectiveAvailable,
                 Reservation: null,
                 Movement: null);
         }
-
-        level.Reserved += quantity;
-        TotalReserved += quantity;
 
         var reservation = new StockReservation
         {
@@ -82,9 +101,25 @@ internal class StockItem
             ProductId,
             warehouseId,
             quantity,
-            Available,
+            effectiveAvailable - quantity,
             reservation,
             movement);
+    }
+
+    /// <summary>
+    /// Applies a previously evaluated hold by mutating <see cref="TotalReserved"/> and the
+    /// per-warehouse <see cref="StockLevel.Reserved"/> together. Non-<see cref="HoldOutcome.Held"/>
+    /// plans are a no-op so callers can apply uniformly.
+    /// </summary>
+    public void ApplyHold(HoldResult plan, StockLevel level)
+    {
+        if (plan.Outcome != HoldOutcome.Held)
+        {
+            return;
+        }
+
+        level.Reserved += plan.Quantity;
+        TotalReserved += plan.Quantity;
     }
 
     /// <summary>

--- a/inventory-microservice/Inventory.Service/Models/StockReservation.cs
+++ b/inventory-microservice/Inventory.Service/Models/StockReservation.cs
@@ -2,6 +2,8 @@ namespace Inventory.Service.Models;
 
 internal class StockReservation
 {
+    private ReservationStatus _status = ReservationStatus.Held;
+
     public long Id { get; set; }
 
     public Guid OrderId { get; set; }
@@ -12,7 +14,49 @@ internal class StockReservation
 
     public int Quantity { get; set; }
 
-    public ReservationStatus Status { get; set; }
+    /// <summary>
+    /// The reservation's lifecycle state. The setter is <c>init</c>-only: once a
+    /// reservation exists its status can only change through the guarded
+    /// <see cref="Commit"/> / <see cref="Release"/> transitions, which the
+    /// <see cref="StockItem"/> aggregate invokes. Illegal transitions throw.
+    /// </summary>
+    public ReservationStatus Status
+    {
+        get => _status;
+        init => _status = value;
+    }
 
     public DateTime CreatedAt { get; set; }
+
+    /// <summary>
+    /// Transitions a <see cref="ReservationStatus.Held"/> reservation to
+    /// <see cref="ReservationStatus.Committed"/>. Any other source state is illegal.
+    /// </summary>
+    public void Commit()
+    {
+        if (_status != ReservationStatus.Held)
+        {
+            throw new InvalidOperationException(
+                $"Cannot commit a reservation in {_status} state; only Held reservations can be committed.");
+        }
+
+        _status = ReservationStatus.Committed;
+    }
+
+    /// <summary>
+    /// Transitions a <see cref="ReservationStatus.Held"/> or
+    /// <see cref="ReservationStatus.Committed"/> reservation to
+    /// <see cref="ReservationStatus.Released"/>. Releasing an already-released
+    /// reservation is illegal — the aggregate guards idempotency by skipping
+    /// already-released reservations rather than calling this twice.
+    /// </summary>
+    public void Release()
+    {
+        if (_status == ReservationStatus.Released)
+        {
+            throw new InvalidOperationException("Cannot release a reservation that is already released.");
+        }
+
+        _status = ReservationStatus.Released;
+    }
 }

--- a/inventory-microservice/Inventory.Tests/Api/ReleaseReservationsTests.cs
+++ b/inventory-microservice/Inventory.Tests/Api/ReleaseReservationsTests.cs
@@ -1,4 +1,6 @@
+using System.Net.Http.Json;
 using ECommerce.Shared.Infrastructure.EventBus.Abstractions;
+using Inventory.Service.ApiModels;
 using Inventory.Service.IntegrationEvents;
 using Inventory.Service.IntegrationEvents.EventHandlers;
 using Inventory.Service.Models;
@@ -127,6 +129,60 @@ public class ReleaseReservationsTests : IntegrationTestBase
         Assert.Equal(productId, itemPublished.ProductId);
         Assert.Equal(1, itemPublished.WarehouseId);
         Assert.Equal(4, itemPublished.Quantity);
+    }
+
+    [Fact]
+    public async Task Given_ReservedThroughApi_When_OrderConfirmed_Then_CommitsAndPublishesStockCommitted()
+    {
+        const int productId = 606;
+        var orderId = Guid.NewGuid();
+
+        InventoryContext.StockItems.Add(new StockItem
+        {
+            ProductId = productId,
+            TotalOnHand = 10,
+            TotalReserved = 0,
+        });
+        InventoryContext.StockLevels.Add(new StockLevel
+        {
+            ProductId = productId,
+            WarehouseId = 1,
+            OnHand = 10,
+            Reserved = 0,
+        });
+        await InventoryContext.SaveChangesAsync();
+
+        Subscribe<StockCommittedEvent>();
+
+        var client = CreateAuthenticatedClient();
+        var reserve = await client.PostAsJsonAsync(
+            $"/{productId}/reserve", new ReserveRequest(orderId, 3));
+        reserve.EnsureSuccessStatusCode();
+
+        await DispatchConfirmAsync(new OrderConfirmedEvent(orderId, "c-1"));
+
+        InventoryContext.ChangeTracker.Clear();
+
+        var reservation = InventoryContext.StockReservations.Single(r => r.OrderId == orderId);
+        Assert.Equal(ReservationStatus.Committed, reservation.Status);
+
+        var item = InventoryContext.StockItems.Single(s => s.ProductId == productId);
+        Assert.Equal(7, item.TotalOnHand);
+        Assert.Equal(0, item.TotalReserved);
+        Assert.Equal(7, item.Available);
+
+        Assert.Contains(InventoryContext.StockMovements,
+            m => m.OrderId == orderId && m.Type == MovementType.Commit);
+
+        SpinWait.SpinUntil(
+            () => ReceivedEvents.ToArray().OfType<StockCommittedEvent>().Any(e => e.OrderId == orderId),
+            TimeSpan.FromSeconds(5));
+        var published = Assert.Single(ReceivedEvents.ToArray().OfType<StockCommittedEvent>(), e => e.OrderId == orderId);
+        Assert.Equal(orderId, published.OrderId);
+        var itemPublished = Assert.Single(published.Items);
+        Assert.Equal(productId, itemPublished.ProductId);
+        Assert.Equal(1, itemPublished.WarehouseId);
+        Assert.Equal(3, itemPublished.Quantity);
     }
 
     [Fact]

--- a/inventory-microservice/Inventory.Tests/Domain/StockItemTests.cs
+++ b/inventory-microservice/Inventory.Tests/Domain/StockItemTests.cs
@@ -116,4 +116,79 @@ public class StockItemTests
         Assert.Null(result.Reservation);
         Assert.Null(result.Movement);
     }
+
+    [Fact]
+    public void Commit_HeldReservation_DrawsReservedDownOutOfOnHand()
+    {
+        var item = new StockItem { ProductId = 1, TotalOnHand = 10, TotalReserved = 4 };
+        var level = new StockLevel { ProductId = 1, WarehouseId = 7, OnHand = 10, Reserved = 4 };
+        var orderId = Guid.NewGuid();
+        var reservation = new StockReservation
+        {
+            OrderId = orderId,
+            ProductId = 1,
+            WarehouseId = 7,
+            Quantity = 4,
+            Status = ReservationStatus.Held,
+        };
+        var now = new DateTime(2026, 5, 16, 12, 0, 0, DateTimeKind.Utc);
+
+        var result = item.Commit(orderId, [reservation], new Dictionary<int, StockLevel> { [7] = level }, now);
+
+        Assert.Equal(CommitOutcome.Committed, result.Outcome);
+        Assert.Equal(6, item.TotalOnHand);
+        Assert.Equal(0, item.TotalReserved);
+        Assert.Equal(6, level.OnHand);
+        Assert.Equal(0, level.Reserved);
+        Assert.Equal(ReservationStatus.Committed, reservation.Status);
+
+        var movement = Assert.Single(result.Movements);
+        Assert.Equal(MovementType.Commit, movement.Type);
+        Assert.Equal(1, movement.ProductId);
+        Assert.Equal(7, movement.WarehouseId);
+        Assert.Equal(4, movement.Quantity);
+        Assert.Equal(orderId, movement.OrderId);
+        Assert.Equal(now, movement.OccurredAt);
+    }
+
+    [Fact]
+    public void Commit_WhenAlreadyCommitted_IsIdempotentNoOp()
+    {
+        var item = new StockItem { ProductId = 1, TotalOnHand = 6, TotalReserved = 0 };
+        var level = new StockLevel { ProductId = 1, WarehouseId = 7, OnHand = 6, Reserved = 0 };
+        var orderId = Guid.NewGuid();
+        var reservation = new StockReservation
+        {
+            OrderId = orderId,
+            ProductId = 1,
+            WarehouseId = 7,
+            Quantity = 4,
+            Status = ReservationStatus.Committed,
+        };
+
+        var result = item.Commit(orderId, [reservation], new Dictionary<int, StockLevel> { [7] = level }, DateTime.UtcNow);
+
+        Assert.Equal(CommitOutcome.NothingHeld, result.Outcome);
+        Assert.Empty(result.Movements);
+        Assert.Equal(6, item.TotalOnHand);
+        Assert.Equal(0, item.TotalReserved);
+        Assert.Equal(6, level.OnHand);
+        Assert.Equal(0, level.Reserved);
+        Assert.Equal(ReservationStatus.Committed, reservation.Status);
+    }
+
+    [Fact]
+    public void Commit_WhenNoHeldReservations_ReportsNothingHeld()
+    {
+        var item = new StockItem { ProductId = 1, TotalOnHand = 5, TotalReserved = 0 };
+        var level = new StockLevel { ProductId = 1, WarehouseId = 7, OnHand = 5, Reserved = 0 };
+
+        var result = item.Commit(
+            Guid.NewGuid(), [], new Dictionary<int, StockLevel> { [7] = level }, DateTime.UtcNow);
+
+        Assert.Equal(CommitOutcome.NothingHeld, result.Outcome);
+        Assert.Empty(result.Movements);
+        Assert.Equal(5, item.TotalOnHand);
+        Assert.Equal(0, item.TotalReserved);
+    }
 }

--- a/inventory-microservice/Inventory.Tests/Domain/StockItemTests.cs
+++ b/inventory-microservice/Inventory.Tests/Domain/StockItemTests.cs
@@ -191,4 +191,128 @@ public class StockItemTests
         Assert.Equal(5, item.TotalOnHand);
         Assert.Equal(0, item.TotalReserved);
     }
+
+    [Fact]
+    public void Release_HeldReservation_ReturnsReservedOnly()
+    {
+        var item = new StockItem { ProductId = 1, TotalOnHand = 10, TotalReserved = 4 };
+        var level = new StockLevel { ProductId = 1, WarehouseId = 7, OnHand = 10, Reserved = 4 };
+        var orderId = Guid.NewGuid();
+        var reservation = new StockReservation
+        {
+            OrderId = orderId,
+            ProductId = 1,
+            WarehouseId = 7,
+            Quantity = 4,
+            Status = ReservationStatus.Held,
+        };
+        var now = new DateTime(2026, 5, 16, 12, 0, 0, DateTimeKind.Utc);
+
+        var result = item.Release(orderId, [reservation], new Dictionary<int, StockLevel> { [7] = level }, now);
+
+        Assert.Equal(ReleaseOutcome.Released, result.Outcome);
+        Assert.Equal(10, item.TotalOnHand);
+        Assert.Equal(0, item.TotalReserved);
+        Assert.Equal(10, level.OnHand);
+        Assert.Equal(0, level.Reserved);
+        Assert.Equal(ReservationStatus.Released, reservation.Status);
+
+        var movement = Assert.Single(result.Movements);
+        Assert.Equal(MovementType.Release, movement.Type);
+        Assert.Equal(1, movement.ProductId);
+        Assert.Equal(7, movement.WarehouseId);
+        Assert.Equal(4, movement.Quantity);
+        Assert.Equal(orderId, movement.OrderId);
+        Assert.Equal(now, movement.OccurredAt);
+    }
+
+    [Fact]
+    public void Release_CommittedReservation_RestoresOnHand()
+    {
+        var item = new StockItem { ProductId = 1, TotalOnHand = 6, TotalReserved = 0 };
+        var level = new StockLevel { ProductId = 1, WarehouseId = 7, OnHand = 6, Reserved = 0 };
+        var orderId = Guid.NewGuid();
+        var reservation = new StockReservation
+        {
+            OrderId = orderId,
+            ProductId = 1,
+            WarehouseId = 7,
+            Quantity = 4,
+            Status = ReservationStatus.Committed,
+        };
+
+        var result = item.Release(orderId, [reservation], new Dictionary<int, StockLevel> { [7] = level }, DateTime.UtcNow);
+
+        Assert.Equal(ReleaseOutcome.Released, result.Outcome);
+        Assert.Equal(10, item.TotalOnHand);
+        Assert.Equal(0, item.TotalReserved);
+        Assert.Equal(10, level.OnHand);
+        Assert.Equal(0, level.Reserved);
+        Assert.Equal(ReservationStatus.Released, reservation.Status);
+        Assert.Single(result.Movements);
+    }
+
+    [Fact]
+    public void Release_MixedHeldAndCommitted_AppliesEachRule()
+    {
+        var item = new StockItem { ProductId = 1, TotalOnHand = 12, TotalReserved = 3 };
+        var heldLevel = new StockLevel { ProductId = 1, WarehouseId = 7, OnHand = 7, Reserved = 3 };
+        var committedLevel = new StockLevel { ProductId = 1, WarehouseId = 8, OnHand = 5, Reserved = 0 };
+        var orderId = Guid.NewGuid();
+        var held = new StockReservation
+        {
+            OrderId = orderId,
+            ProductId = 1,
+            WarehouseId = 7,
+            Quantity = 3,
+            Status = ReservationStatus.Held,
+        };
+        var committed = new StockReservation
+        {
+            OrderId = orderId,
+            ProductId = 1,
+            WarehouseId = 8,
+            Quantity = 4,
+            Status = ReservationStatus.Committed,
+        };
+        var levels = new Dictionary<int, StockLevel> { [7] = heldLevel, [8] = committedLevel };
+
+        var result = item.Release(orderId, [held, committed], levels, DateTime.UtcNow);
+
+        Assert.Equal(ReleaseOutcome.Released, result.Outcome);
+        Assert.Equal(0, item.TotalReserved);
+        Assert.Equal(16, item.TotalOnHand);
+        Assert.Equal(0, heldLevel.Reserved);
+        Assert.Equal(7, heldLevel.OnHand);
+        Assert.Equal(9, committedLevel.OnHand);
+        Assert.Equal(ReservationStatus.Released, held.Status);
+        Assert.Equal(ReservationStatus.Released, committed.Status);
+        Assert.Equal(2, result.Movements.Count);
+    }
+
+    [Fact]
+    public void Release_WhenAlreadyReleased_IsIdempotentNoOp()
+    {
+        var item = new StockItem { ProductId = 1, TotalOnHand = 5, TotalReserved = 0 };
+        var level = new StockLevel { ProductId = 1, WarehouseId = 7, OnHand = 5, Reserved = 0 };
+        var orderId = Guid.NewGuid();
+        var reservation = new StockReservation
+        {
+            OrderId = orderId,
+            ProductId = 1,
+            WarehouseId = 7,
+            Quantity = 2,
+            Status = ReservationStatus.Released,
+        };
+
+        var result = item.Release(orderId, [reservation], new Dictionary<int, StockLevel> { [7] = level }, DateTime.UtcNow);
+
+        Assert.Equal(ReleaseOutcome.NothingToRelease, result.Outcome);
+        Assert.Empty(result.Movements);
+        Assert.Equal(5, item.TotalOnHand);
+        Assert.Equal(0, item.TotalReserved);
+        Assert.Equal(5, level.OnHand);
+        Assert.Equal(0, level.Reserved);
+        Assert.Equal(ReservationStatus.Released, reservation.Status);
+    }
 }

--- a/inventory-microservice/Inventory.Tests/Domain/StockItemTests.cs
+++ b/inventory-microservice/Inventory.Tests/Domain/StockItemTests.cs
@@ -45,4 +45,75 @@ public class StockItemTests
 
         Assert.Equal(-3, item.Available);
     }
+
+    [Fact]
+    public void Hold_WithinAvailable_ReservesAndMutatesItemAndLevelTogether()
+    {
+        var item = new StockItem { ProductId = 1, TotalOnHand = 10, TotalReserved = 0 };
+        var level = new StockLevel { ProductId = 1, WarehouseId = 7, OnHand = 10, Reserved = 0 };
+        var orderId = Guid.NewGuid();
+        var now = new DateTime(2026, 5, 16, 12, 0, 0, DateTimeKind.Utc);
+
+        var result = item.Hold(orderId, warehouseId: 7, quantity: 3, level, [], now);
+
+        Assert.Equal(HoldOutcome.Held, result.Outcome);
+        Assert.Equal(3, item.TotalReserved);
+        Assert.Equal(3, level.Reserved);
+        Assert.Equal(7, item.Available);
+
+        Assert.NotNull(result.Reservation);
+        Assert.Equal(orderId, result.Reservation!.OrderId);
+        Assert.Equal(1, result.Reservation.ProductId);
+        Assert.Equal(7, result.Reservation.WarehouseId);
+        Assert.Equal(3, result.Reservation.Quantity);
+        Assert.Equal(ReservationStatus.Held, result.Reservation.Status);
+        Assert.Equal(now, result.Reservation.CreatedAt);
+
+        Assert.NotNull(result.Movement);
+        Assert.Equal(MovementType.Reserve, result.Movement!.Type);
+        Assert.Equal(3, result.Movement.Quantity);
+        Assert.Equal(orderId, result.Movement.OrderId);
+        Assert.Equal(now, result.Movement.OccurredAt);
+    }
+
+    [Fact]
+    public void Hold_BeyondAvailable_IsRejected_AndDoesNotMutate()
+    {
+        var item = new StockItem { ProductId = 1, TotalOnHand = 2, TotalReserved = 0 };
+        var level = new StockLevel { ProductId = 1, WarehouseId = 7, OnHand = 2, Reserved = 0 };
+
+        var result = item.Hold(Guid.NewGuid(), warehouseId: 7, quantity: 5, level, [], DateTime.UtcNow);
+
+        Assert.Equal(HoldOutcome.InsufficientStock, result.Outcome);
+        Assert.Equal(2, result.Available);
+        Assert.Equal(0, item.TotalReserved);
+        Assert.Equal(0, level.Reserved);
+        Assert.Null(result.Reservation);
+        Assert.Null(result.Movement);
+    }
+
+    [Fact]
+    public void Hold_WhenOrderAlreadyHeld_ShortCircuits_AndDoesNotMutate()
+    {
+        var item = new StockItem { ProductId = 1, TotalOnHand = 10, TotalReserved = 4 };
+        var level = new StockLevel { ProductId = 1, WarehouseId = 7, OnHand = 10, Reserved = 4 };
+        var orderId = Guid.NewGuid();
+        var existing = new StockReservation
+        {
+            OrderId = orderId,
+            ProductId = 1,
+            WarehouseId = 7,
+            Quantity = 4,
+            Status = ReservationStatus.Held,
+        };
+
+        var result = item.Hold(orderId, warehouseId: 7, quantity: 3, level, [existing], DateTime.UtcNow);
+
+        Assert.Equal(HoldOutcome.AlreadyHeld, result.Outcome);
+        Assert.Equal(4, result.Quantity);
+        Assert.Equal(4, item.TotalReserved);
+        Assert.Equal(4, level.Reserved);
+        Assert.Null(result.Reservation);
+        Assert.Null(result.Movement);
+    }
 }

--- a/inventory-microservice/Inventory.Tests/Domain/StockReservationTests.cs
+++ b/inventory-microservice/Inventory.Tests/Domain/StockReservationTests.cs
@@ -1,0 +1,63 @@
+using Inventory.Service.Models;
+
+namespace Inventory.Tests.Domain;
+
+public class StockReservationTests
+{
+    [Fact]
+    public void Commit_FromHeld_TransitionsToCommitted()
+    {
+        var reservation = new StockReservation { Status = ReservationStatus.Held };
+
+        reservation.Commit();
+
+        Assert.Equal(ReservationStatus.Committed, reservation.Status);
+    }
+
+    [Fact]
+    public void Commit_FromCommitted_IsRejected()
+    {
+        var reservation = new StockReservation { Status = ReservationStatus.Committed };
+
+        Assert.Throws<InvalidOperationException>(reservation.Commit);
+        Assert.Equal(ReservationStatus.Committed, reservation.Status);
+    }
+
+    [Fact]
+    public void Commit_FromReleased_IsRejected()
+    {
+        var reservation = new StockReservation { Status = ReservationStatus.Released };
+
+        Assert.Throws<InvalidOperationException>(reservation.Commit);
+        Assert.Equal(ReservationStatus.Released, reservation.Status);
+    }
+
+    [Fact]
+    public void Release_FromHeld_TransitionsToReleased()
+    {
+        var reservation = new StockReservation { Status = ReservationStatus.Held };
+
+        reservation.Release();
+
+        Assert.Equal(ReservationStatus.Released, reservation.Status);
+    }
+
+    [Fact]
+    public void Release_FromCommitted_TransitionsToReleased()
+    {
+        var reservation = new StockReservation { Status = ReservationStatus.Committed };
+
+        reservation.Release();
+
+        Assert.Equal(ReservationStatus.Released, reservation.Status);
+    }
+
+    [Fact]
+    public void Release_FromReleased_IsRejected()
+    {
+        var reservation = new StockReservation { Status = ReservationStatus.Released };
+
+        Assert.Throws<InvalidOperationException>(reservation.Release);
+        Assert.Equal(ReservationStatus.Released, reservation.Status);
+    }
+}


### PR DESCRIPTION
## Summary
Refactor inventory stock reservation flows so the `StockItem` aggregate owns hold, commit, and release behaviors, including idempotency/guard checks around reservation processing.

## Why
Centralizing reservation lifecycle logic in the aggregate reduces scattered business rules and makes inventory state transitions easier to reason about and test.

## Changes
- Move reserve/hold behavior into `StockItem` aggregate.
- Move commit behavior into `StockItem` aggregate.
- Move release behavior into `StockItem` aggregate.
- Delegate already-processed checks and lifecycle guards to domain logic.
- Update inventory service wiki docs for the new aggregate lifecycle.

Closes #55