### PR TITLE
QA smoke gap closure for saga operator and shipping

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -159,6 +159,7 @@ jobs:
           Copy-Item (Join-Path $env:GITHUB_WORKSPACE 'qa/bruno/02-stock-shortage') $collectionRoot -Recurse
           Copy-Item (Join-Path $env:GITHUB_WORKSPACE 'qa/bruno/03-payment-decline') $collectionRoot -Recurse
           Copy-Item (Join-Path $env:GITHUB_WORKSPACE 'qa/bruno/04-admin-ops') $collectionRoot -Recurse
+          Copy-Item (Join-Path $env:GITHUB_WORKSPACE 'qa/bruno/saga-operator') $collectionRoot -Recurse
 
           function Write-Summary([string]$Line) {
             Write-Host $Line
@@ -452,6 +453,14 @@ jobs:
           Invoke-Bruno 'dispatch-shipment' @('01-happy-path/11-dispatch-shipment.bru') $transitionVars | Out-Null
           Invoke-Bruno 'deliver-shipment' @('01-happy-path/12-deliver-shipment.bru') $transitionVars | Out-Null
 
+          Invoke-Bruno 'saga-operator' @(
+            'saga-operator/01-issue-service-token.bru',
+            'saga-operator/02-list-sagas.bru',
+            'saga-operator/03-get-saga-detail.bru',
+            'saga-operator/04-retry-saga.bru',
+            'saga-operator/05-abort-saga.bru'
+          ) | Out-Null
+
           $stockShortageSetup = Invoke-Bruno 'stock-shortage-setup' @(
             '02-stock-shortage/01-login-customer-cancel.bru',
             '02-stock-shortage/02-get-seeded-basket.bru',
@@ -514,44 +523,18 @@ jobs:
           Invoke-Bruno 'admin-inventory' @('04-admin-ops/inventory') | Out-Null
           Invoke-Bruno 'admin-payment' @('04-admin-ops/payment') | Out-Null
 
-          Invoke-Bruno 'admin-shipping-return-path' @(
-            '04-admin-ops/shipping/01-login-admin.bru',
-            '04-admin-ops/shipping/02-pick-pending.bru',
-            '04-admin-ops/shipping/03-pack-picked.bru',
-            '04-admin-ops/shipping/04-dispatch-packed.bru',
-            '04-admin-ops/shipping/07-return-dispatched.bru'
-          ) @{
-            shipmentPickedId = 'c0000000-0000-0000-0000-000000000001'
-            shipmentPackedId = 'c0000000-0000-0000-0000-000000000001'
-            shipmentDispatchedId = 'c0000000-0000-0000-0000-000000000001'
-          } | Out-Null
-
-          Invoke-Bruno 'admin-shipping-deliver-path' @(
-            '04-admin-ops/shipping/01-login-admin.bru',
-            '04-admin-ops/shipping/03-pack-picked.bru',
-            '04-admin-ops/shipping/04-dispatch-packed.bru',
-            '04-admin-ops/shipping/05-deliver-dispatched.bru'
-          ) @{
-            shipmentPickedId = 'c0000000-0000-0000-0000-000000000002'
-            shipmentPackedId = 'c0000000-0000-0000-0000-000000000002'
-            shipmentDispatchedId = 'c0000000-0000-0000-0000-000000000002'
-          } | Out-Null
-
-          Invoke-Bruno 'admin-shipping-fail-path' @(
-            '04-admin-ops/shipping/01-login-admin.bru',
-            '04-admin-ops/shipping/04-dispatch-packed.bru',
-            '04-admin-ops/shipping/06-fail-dispatched.bru'
-          ) @{
-            shipmentPackedId = 'c0000000-0000-0000-0000-000000000003'
-            shipmentDispatchedId = 'c0000000-0000-0000-0000-000000000003'
-          } | Out-Null
-
           Invoke-Bruno 'admin-shipping-webhook' @(
             '04-admin-ops/shipping/webhook.bru'
           ) | Out-Null
 
-          Invoke-Bruno 'admin-shipping-cancel-path' @(
+          Invoke-Bruno 'admin-shipping' @(
             '04-admin-ops/shipping/01-login-admin.bru',
+            '04-admin-ops/shipping/02-pick-pending.bru',
+            '04-admin-ops/shipping/03-pack-picked.bru',
+            '04-admin-ops/shipping/04-dispatch-packed.bru',
+            '04-admin-ops/shipping/05-deliver-dispatched.bru',
+            '04-admin-ops/shipping/06-fail-dispatched.bru',
+            '04-admin-ops/shipping/07-return-dispatched.bru',
             '04-admin-ops/shipping/08-cancel-pending.bru'
           ) | Out-Null
 

--- a/docs/plans/qa-smoke-gap-closure.md
+++ b/docs/plans/qa-smoke-gap-closure.md
@@ -1,0 +1,123 @@
+# Plan: QA Smoke Gap Closure (saga-operator + shipping terminals)
+
+> Source PRD: [docs/prd/PRD-Qa-Smoke-Gap-Closure.md](../prd/PRD-Qa-Smoke-Gap-Closure.md)
+
+Builds on [PRD-Smoke-Test-Bruno-Cli](../prd/PRD-Smoke-Test-Bruno-Cli.md), [PRD-Smoke-Test-Saga-Hardening](../prd/PRD-Smoke-Test-Saga-Hardening.md), [PRD-Qa-Dump-Dataset](../prd/PRD-Qa-Dump-Dataset.md).
+
+## Architectural decisions
+
+Durable across all phases:
+
+- **Auth endpoint unchanged.** `POST {authBaseUrl}/token` continues to accept `application/x-www-form-urlencoded` per RFC 6749. Only the Bruno surface changes.
+- **Saga operator routes unchanged.** Coverage rides on existing `GET /operator/api/sagas`, `GET /operator/api/sagas/{id}`, `POST /operator/api/sagas/{id}/retry`, `POST /operator/api/sagas/{id}/abort`. No new endpoints, claims, or roles.
+- **Single seeding gate.** Every new fixture (saga + shipping) rides the existing `QaSeedingExtensions.IsQaSeedingEnabled` predicate (`Development` OR `Qa:Seed=true`). No new flag, no new composition entry.
+- **Seeding mechanism.** New seeded rows ship as EF `Migration.Up` `InsertData` calls inside `<Svc>.Service/Migrations/`, matching `20260508120000_SeedQaPhase3b_Shipping.cs`. Idempotent by primary key, gated by the existing `MigrateDatabase()` call sites that already sit behind `IsQaSeedingEnabled`.
+- **Fixed GUIDs, mirrored.** Any new GUID/tracking number added to a seeder is mirrored into `qa/bruno/qa-local.bru` and (where the legacy harness still exercises it) `scripts/local-smoke-test.ps1 $Qa` hash, per `docs/qa/README.md`.
+- **Saga parking step.** The seeded `Order` saga parks at `PaymentAuthorizing` with `Status=Running`. Scenario 05 already filters on `?type=Order&status=Running`, so the step choice is non-breaking.
+- **No race with happy/decline/shortage.** Seeded saga uses a synthetic `OrderId` no other scenario references; it stays the sole `Running` row at the moment `02-list-sagas` runs.
+- **Shipping fixture layout.** `c0000000-...04` stays the Delivered-target shipment. Two new siblings: `c0000000-...06` (Failed-target) and `c0000000-...07` (Returned-target). Each gets its own carrier tracking number.
+- **Bruno CLI pinning.** Workaround is exercised against `@usebruno/cli@3.3.0` (the CI-pinned version). Higher CLI versions are out of scope for this plan.
+
+---
+
+## Phase 1: Bruno CLI service-token parity
+
+**User stories**: 2, 15 (workaround + reusable pattern).
+
+### What to build
+
+Make `qa/bruno/saga-operator/01-issue-service-token.bru` transmit the form body cleanly under Bruno CLI 3.3.0 so subsequent steps in the chain have a populated `serviceToken`. Pick empirically between (a) rewriting step 01 with whatever body shape the CLI transmits (raw text body with explicit `Content-Type`, multipart variant, or pre-request script form) or (b) folding the token fetch into a `script:pre-request` on `02-list-sagas.bru` via `bru.runRequest` against a helper request. Whichever variant proves `serviceToken` non-empty on a CLI 3.3.0 run wins.
+
+Add a `docs/qa/README.md` callout naming the `body:form-urlencoded` CLI 3.3.0 regression, the chosen workaround shape, and the version pin so the next CLI upgrade does not silently re-break the suite.
+
+This phase ships independently: steps 02–05 still won't have a deterministic saga to act on (that's P2), but step 01 (or its pre-request equivalent on 02) demonstrably sets `serviceToken` and step 02 returns `200` with an `items` array — even if empty.
+
+### Acceptance criteria
+
+- [ ] `npx --yes @usebruno/cli@3.3.0 run qa/bruno/saga-operator/01-issue-service-token.bru --env-file qa/bruno/qa-local.bru` (or its pre-request equivalent on step 02) returns `200`; the `tests` block asserts `res.body.token` is a non-empty string and `res.body.expiresIn > 0`.
+- [ ] On the same CLI version, `02-list-sagas` returns `200` with `items` as an array (length not asserted yet — that's P2) and does not 401.
+- [ ] Bruno desktop run of the same step still passes (no regression).
+- [ ] `docs/qa/README.md` documents the CLI 3.3.0 form-body regression, the chosen workaround shape, and the CLI version pin.
+- [ ] No changes outside `qa/bruno/saga-operator/`, `qa/bruno/qa-local.bru` (if vars shift), and `docs/qa/README.md`.
+
+---
+
+## Phase 2: Seeded Running saga + saga-operator suite green
+
+**User stories**: 1, 4, 5, 7, 9, 11, 13.
+
+### What to build
+
+A deterministic Order-saga fixture so the saga-operator suite runs end-to-end clean on a freshly booted stack. Add an EF migration in `saga-microservice/Saga.Service/Migrations/` that `InsertData`s one `SagaInstances` row plus one `OrderSagaStates` row with a fixed `SagaId` GUID, `SagaType=Order`, `Status=Running`, `CurrentStep=PaymentAuthorizing`, and a synthetic `OrderId` no other scenario references. The migration runs only when `IsQaSeedingEnabled` is true (already true for the `MigrateDatabase()` call in `Saga.Service/Program.cs:106`).
+
+Expose the fixed `SagaId` to Bruno via a new `operatorSagaId` var in `qa/bruno/qa-local.bru` and tighten `02-list-sagas.bru` to assert the seeded id is present in `items` (the `script:post-response` already sets it from the first element; the new assertion proves it's the seeded one). Steps 03/04/05 already act on `{{operatorSagaId}}` — they need no URL change, only the deterministic source.
+
+Rewrite `docs/qa/scenarios/05-saga-operator-abort.md` to drop the `docker compose stop payment` preamble (step 1) and the `start payment` epilogue: a synthetic Running saga makes the manual park unnecessary. Step 2 (service-token) keeps the same instruction since Phase 1 has it working under CLI.
+
+Add a Domain test in `saga-microservice/Saga.Tests/` modelled on `Shipping.Tests/Domain/QaSeedFixturesTests.cs`: assert the seeded `SagaInstance` row exists with the documented `SagaType`/`Status`/`CurrentStep` after migrations apply.
+
+### Acceptance criteria
+
+- [ ] On a clean stack (`docker compose down -v && up`), `GET {{sagaBaseUrl}}/operator/api/sagas?type=Order&status=Running` returns `items.length >= 1` and includes the seeded `operatorSagaId`.
+- [ ] Sequential CLI run of `01-issue-service-token`, `02-list-sagas`, `03-get-saga-detail`, `04-retry-saga`, `05-abort-saga` is 5/5 green; `04` returns `202` with the seeded `sagaId`; `05` returns `202` with `status=Compensating`.
+- [ ] `02-list-sagas.bru` asserts the seeded `operatorSagaId` is present in the response `items`.
+- [ ] `qa/bruno/qa-local.bru` carries the new `operatorSagaId` GUID alongside existing shipment GUIDs.
+- [ ] New saga seed-presence test in `Saga.Tests` passes and pins `SagaType=Order`, `Status=Running`, `CurrentStep=PaymentAuthorizing` on the seeded `SagaId`.
+- [ ] `docs/qa/scenarios/05-saga-operator-abort.md` no longer instructs `docker compose stop payment` and no longer mentions manual saga parking.
+- [ ] Seed migration is no-op when `IsQaSeedingEnabled` is false (verified by running the migration against a non-Development, no-`Qa:Seed` config — the seeding gate prevents `MigrateDatabase()` from running, so the migration itself is never applied).
+
+---
+
+## Phase 3: Per-terminal shipping fixtures
+
+**User stories**: 3, 6, 8, 12, 14.
+
+### What to build
+
+Split the dispatched-shipment fixture into three siblings so `deliver-dispatched`, `fail-dispatched`, and `return-dispatched` each act on their own row. Keep `c0000000-0000-0000-0000-000000000004` (Delivered-target, existing tracking `QA-TRACK-DISPATCHED-001`). Add `c0000000-0000-0000-0000-000000000006` (Failed-target) and `c0000000-0000-0000-0000-000000000007` (Returned-target), each in `Status=Shipped` with carrier `fake-ground`, distinct tracking numbers (e.g. `QA-TRACK-DISPATCHED-FAIL-001`, `QA-TRACK-DISPATCHED-RETURN-001`), distinct `LabelRef`s, and matching `ShipmentLines` + `ShipmentStatusHistory` rows.
+
+Surfaces touched:
+- `shipping-microservice/Shipping.Service/Infrastructure/Data/EntityFramework/ShippingQaFixtures.cs` — two new `Shipment*Id` + `ShippingOrder*Id` + tracking constants.
+- New `*_SeedQaPhase3c_Shipping.cs` migration (or extend Phase 3b — author's call; new migration is the safer additive choice) inserting the two new shipments/lines/history rows.
+- `qa/bruno/qa-local.bru` — `shipmentFailDispatchedId`, `shipmentReturnDispatchedId`, `shipmentFailDispatchedTrackingNumber`, `shipmentReturnDispatchedTrackingNumber`.
+- `qa/bruno/04-admin-ops/shipping/06-fail-dispatched.bru` — URL var swap to `{{shipmentFailDispatchedId}}`.
+- `qa/bruno/04-admin-ops/shipping/07-return-dispatched.bru` — URL var swap to `{{shipmentReturnDispatchedId}}`.
+- `Shipping.Tests/Domain/QaSeedFixturesTests.cs` — extend the dictionary count + assertions to cover seven shipments and the two new tracking numbers.
+- `docs/qa/scenarios/04-admin-ops.md:210` rewrite — replace "mutually exclusive — pick one per fixture run / `docker compose down -v && up` to reset" with "each terminal transition acts on its own seeded fixture; the trio runs sequentially with no reset."
+- `scripts/local-smoke-test.ps1` `$Qa` hash — mirror the two new IDs if the script references shipping fixtures by name.
+
+This slice is demoable: `npx --yes @usebruno/cli@3.3.0 run qa/bruno/04-admin-ops/shipping --env-file qa/bruno/qa-local.bru` is 8/8 green on a freshly booted stack with no env-var overrides.
+
+### Acceptance criteria
+
+- [ ] `dotnet test shipping-microservice/Shipping.Tests` passes; the dictionary in `QaSeedFixturesTests` asserts seven seeded shipments, the two new ones at `Status=Shipped` with their tracking numbers and `LabelRef`s.
+- [ ] Sequential CLI run of the full `04-admin-ops/shipping` folder (`01`..`08` + `webhook.bru`) is green on a clean stack with no `--env-var` overrides.
+- [ ] No `409 Conflict` responses on steps 05/06/07 in the same run.
+- [ ] `qa/bruno/qa-local.bru` mirrors the two new GUIDs and tracking numbers alongside the existing `shipmentDispatchedId` / `shipmentDispatchedTrackingNumber`.
+- [ ] `docs/qa/scenarios/04-admin-ops.md` section 4 documents per-terminal fixtures; the "`down -v && up` to reset" sentence is removed.
+- [ ] Carrier webhook test (`webhook.bru`) continues to act on `QA-TRACK-DISPATCHED-001` and is unaffected by the two new tracking numbers.
+
+---
+
+## Phase 4: bruno-smoke CI wiring
+
+**User stories**: 7, 8, 10.
+
+### What to build
+
+Add the two newly deterministic suites to `.github/workflows/smoke-test.yml`'s `bruno-smoke` job so coverage rises from 41 to 54 CI-gated requests.
+
+- Copy `qa/bruno/saga-operator` into the temp collection root next to the existing four scenario folders.
+- Add an `Invoke-Bruno 'saga-operator' @('saga-operator/01-issue-service-token.bru', 'saga-operator/02-list-sagas.bru', 'saga-operator/03-get-saga-detail.bru', 'saga-operator/04-retry-saga.bru', 'saga-operator/05-abort-saga.bru')` batch. Place it after the happy-path setup (so the seeded Running saga is still the only one matching `?status=Running`).
+- Collapse the three existing `admin-shipping-*-path` batches (`admin-shipping-return-path`, `admin-shipping-deliver-path`, `admin-shipping-fail-path` at `.github/workflows/smoke-test.yml:517-547`) into a single `Invoke-Bruno 'admin-shipping' @('04-admin-ops/shipping/01-login-admin.bru' .. '04-admin-ops/shipping/08-cancel-pending.bru')` sequential batch. Drop the per-batch `--env-var` overrides (no longer needed once P3's fixture split lands).
+- Keep `admin-shipping-webhook` and `admin-shipping-cancel-path` separate if the existing wrapping requires it (cancel-path acts on `shipmentCancelPendingId`, distinct from the dispatched siblings).
+- Run still `continue-on-error: true` at the job level — no change to the gate's blocking semantics.
+
+### Acceptance criteria
+
+- [ ] `.github/workflows/smoke-test.yml` lists the saga-operator folder in the `Copy-Item` block alongside the existing four.
+- [ ] `bruno-smoke` job's step summary shows a passing `saga-operator` batch reporting 5 requests / 5 tests.
+- [ ] `bruno-smoke` job's step summary shows a single passing `admin-shipping` batch reporting 8 sequential requests instead of the three split batches.
+- [ ] Total `bruno-smoke` request count on a clean run is `54` (41 prior + 5 saga-operator + 8 shipping, minus duplicates from collapsed batches).
+- [ ] No new GitHub Actions workflow file added; the new wiring is fully additive inside the existing `bruno-smoke` job.
+- [ ] On a stack booted without `Qa:Seed=true` (would only happen in a non-Development image), the saga-operator batch is expected to fail because the seeded saga is absent — CI runs against the Development image, so this stays a green path. Documented in the README callout from P1.

--- a/docs/prd/PRD-Qa-Smoke-Gap-Closure.md
+++ b/docs/prd/PRD-Qa-Smoke-Gap-Closure.md
@@ -1,0 +1,85 @@
+# PRD — QA Smoke Gap Closure (saga-operator + shipping terminals)
+
+> Status: draft. Synthesized from the 2026-05-26 `qa/bruno` smoke run that surfaced three gaps not covered by [PRD-Smoke-Test-Bruno-Cli](./PRD-Smoke-Test-Bruno-Cli.md) or [PRD-Smoke-Test-Saga-Hardening](./PRD-Smoke-Test-Saga-Hardening.md). Builds on [PRD-Qa-Dump-Dataset](./PRD-Qa-Dump-Dataset.md). Successor concern: stand up the `saga-operator` Bruno suite as a first-class CI-runnable surface and remove the false-failure noise from `04-admin-ops/shipping`.
+
+## Problem Statement
+
+As a release manager I expect the `qa/bruno/` collection to drive every documented scenario green from a clean stack with one command per suite. Today three known gaps make that impossible:
+
+1. **`saga-operator` suite cannot complete under Bruno CLI 3.3.0.** Step `01-issue-service-token.bru` posts an `application/x-www-form-urlencoded` body to Auth `/token`. Under Bruno CLI 3.3.0 the body is dropped on the wire (Auth replies `400 Unexpected request without body`); `02-list-sagas` then 401s because the service token variable never populates. The same request succeeds via Bruno desktop and via `curl`, so the suite is silently desktop-only. CI cannot extend coverage to operator endpoints.
+2. **`saga-operator` 03-detail / 04-retry / 05-abort have no deterministic Running saga to act on.** Happy, decline, and stock-shortage flows all complete (Confirmed / Cancelled) within milliseconds. By the time step 02 lists `?status=Running`, the result set is empty, `operatorSagaId` never sets, and 03–05 either skip or fail. The scenario document (`docs/qa/scenarios/05-saga-operator-abort.md`) describes a manual setup; there is no fixture or seam to park a saga in `Running` automatically.
+3. **`04-admin-ops/shipping` reports two by-design failures on a sequential run.** Steps 05/06/07 (`deliver-dispatched`, `fail-dispatched`, `return-dispatched`) all target the same fixture `c0000000-...04`. Per `docs/qa/scenarios/04-admin-ops.md:210`, the three terminal transitions are mutually exclusive and the doc tells operators to `docker compose down -v && up` between each. Run sequentially the suite emits two `409 Conflict` results that look like regressions but are not. The shape invites accidental "the suite is failing" alarms and prevents the shipping admin folder from joining the Bruno CLI smoke job as a single ordered batch.
+
+Concretely:
+
+- The smoke gate covers 41/43 Bruno requests today; 2/43 are noise from gap (3) and the full saga-operator suite is excluded from CI entirely.
+- The Bruno desktop / Bruno CLI parity gap means the dataset has surfaces that QA can see but CI cannot.
+- Operators have no automated way to verify the operator-API contract (`/operator/api/sagas`, `/retry`, `/abort`) on every PR.
+
+## Solution
+
+Close all three gaps with surgical changes scoped to the QA collection, one seed-side hook for saga parking, and one shipping seeder split. No new operator endpoints, no new auth flow, no new test runner.
+
+1. **Service-token issuer rewritten for Bruno CLI parity.** Replace `qa/bruno/saga-operator/01-issue-service-token.bru` with a shape that Bruno CLI 3.3.0 transmits cleanly. Two viable options, picked by experiment: (a) move the token-fetch into a `script:pre-request` block on `02-list-sagas.bru` that uses `bru.runRequest` against a JSON helper request, OR (b) keep step `01` but author the body as a raw text body with an explicit `Content-Type` header and a tests block that proves `200`. Whichever shape passes against the unchanged Auth `/token` endpoint wins.
+2. **Deterministic Running-saga fixture.** Add a seeded saga-state row (driven by the QA dataset toggle, alongside the existing seeded customers/products/shipments) that places a single order saga in `Running` at a step the operator API can list. The fixture must satisfy `GET /operator/api/sagas?type=Order&status=Running` returning at least one row with a known `sagaId`. The fixture's existence is conditioned on the same `Qa:Seed` flag the dataset already gates on, so production stacks never see it. The new `operatorSagaId` is added to `qa/bruno/qa-local.bru` alongside the existing fixed IDs.
+3. **Per-terminal shipping fixtures.** Split fixture `c0000000-...04` into three siblings (e.g. `...04`, `...06`, `...07`) so `deliver-dispatched` / `fail-dispatched` / `return-dispatched` each act on their own seeded shipment. Update the seeder, scenario doc, and the three `.bru` files to point at the new IDs. After the split the shipping admin folder runs sequentially 8/8 green.
+4. **Docs callouts.** `docs/qa/README.md` gains: (a) a note that Bruno CLI 3.3.0 has a known regression around `body:form-urlencoded` and the workaround we landed; (b) confirmation that shipping terminals are now per-fixture rather than mutually exclusive. Existing `docs/qa/scenarios/04-admin-ops.md` and `docs/qa/scenarios/05-saga-operator-abort.md` are amended in lockstep with the seed/fixture changes.
+5. **CI parity.** Once the three suites are deterministic, the `bruno-smoke` job from [PRD-Smoke-Test-Bruno-Cli](./PRD-Smoke-Test-Bruno-Cli.md) gains two new scenario batches: the full `saga-operator` suite (5 requests) and the `04-admin-ops/shipping` suite as a single sequential batch (8 requests). Coverage rises from 41 to 54 CI-gated requests on a clean stack run.
+
+## User Stories
+
+1. As a release manager, I want the `qa/bruno/saga-operator` suite to pass under Bruno CLI on a clean stack, so that CI can prove every PR preserves the operator-API contract.
+2. As a release manager, I want a documented Bruno CLI workaround for the `body:form-urlencoded` regression, so that future suites that need form bodies do not silently break on CI while passing on desktop.
+3. As a release manager, I want the `04-admin-ops/shipping` suite to run sequentially with no false-positive 409s, so that suite-level pass/fail is a single trustworthy signal in CI.
+4. As a QA engineer, I want a deterministic Running-saga fixture, so that I can verify the operator-detail/retry/abort endpoints from Bruno desktop without manually parking a saga via SQL.
+5. As a QA engineer, I want the seeded `operatorSagaId` exposed in `qa-local.bru`, so that I can re-run saga-operator scripts without copy-pasting GUIDs.
+6. As a QA engineer, I want the shipping admin-ops doc to describe per-terminal fixtures, so that I do not have to `docker compose down -v` between transitions when verifying a regression.
+7. As a backend engineer touching the saga-orchestrator, I want CI to fail when my change breaks `/operator/api/sagas`, `/retry`, or `/abort`, so that the dlq-replay operator surface stays trustworthy.
+8. As a backend engineer touching the shipping aggregate, I want a CI signal when `deliver`, `fail`, or `return` transitions stop emitting the documented response shape, so that drift between the operator API and the runbook is caught at PR time.
+9. As an SRE running QA scripts in production-shape stacks, I want the new Running-saga fixture gated on the same `Qa:Seed` toggle as the existing dataset, so that no production environment ever sees a seeded saga in flight.
+10. As an SRE running QA scripts, I want the Bruno suites to require only `bru run` plus the staged-collection convention documented in `docs/qa/README.md`, so that no new tooling enters the CI image.
+11. As a documentation maintainer, I want `docs/qa/scenarios/05-saga-operator-abort.md` to drop the manual "park a saga via SQL" preamble once the fixture lands, so that QA runbooks shrink rather than grow.
+12. As a documentation maintainer, I want `docs/qa/scenarios/04-admin-ops.md:210` rewritten to describe sibling fixtures, so that the runbook stops telling operators to reset the entire stack between checks.
+13. As an operator running the saga-operator collection, I want step `02-list-sagas` to return a non-empty array against a freshly booted stack, so that subsequent requests in the chain have an `operatorSagaId` set without manual intervention.
+14. As an operator running the shipping admin-ops collection, I want each terminal transition to leave the rest of the suite green, so that one accidental click does not invalidate the run.
+15. As a Bruno-collection author writing a new suite that needs a service token, I want a documented pattern (form-body workaround or pre-request hook), so that I don't reinvent the same fix per suite.
+
+## Implementation Decisions
+
+- **Service-token issuance.** The Auth `/token` endpoint is **not** changed. It already accepts the seeded `api-gateway` / `dev-api-gateway-secret` form payload via curl. Only the Bruno surface changes: rewrite `saga-operator/01-issue-service-token.bru` (or fold its work into a pre-request script on `02-list-sagas.bru`) to a shape Bruno CLI 3.3.0 transmits. The decision between "rewrite step 01" vs "fold into 02 pre-request" is made empirically; whichever shape passes wins.
+- **Saga parking seam.** Reuse the existing `Qa:Seed` / `Qa__Seed` toggle that gates the QA dataset. The seeded Running saga lives in the same seeder module that produces shipments and customers — no new flag, no new composition root entry. The fixture's `sagaId` is a fixed GUID, written next to the existing shipment GUIDs in `qa/bruno/qa-local.bru`.
+- **Saga step choice.** The fixture parks the saga at the **payment authorization** step, because that is the step Saga's `02-list-sagas` example query targets (the operator runbook also shows examples at this step). The seeded saga sets `status=Running` with no advance work — operators see one row and one transition history entry.
+- **Shipping fixtures.** Three new sibling seeded shipments under the existing seed module, all in `Dispatched` state, each labeled with the terminal transition they exist to exercise (Delivered / Failed / Returned). The original `c0000000-...04` is retained as the "Delivered" fixture so the existing 05 step's GUID does not move; the new GUIDs slot into 06 and 07.
+- **Carrier + tracking metadata.** Each new shipping fixture gets its own tracking number alongside the existing `QA-TRACK-DISPATCHED-001`, so the carrier webhook test does not contend with terminal transitions on the same row.
+- **No new operator endpoints.** Coverage is purely additive on existing `/operator/api/sagas` + transition routes.
+- **CI wiring.** The `bruno-smoke` job picks up the new suites by listing the suite directories the same way it lists `01-happy-path` today. No new workflow file. Saga-operator runs after the happy path (so the seeded Running saga is the only Running saga in the listing).
+- **No data race with happy/decline/shortage runs.** The seeded Running saga is a synthetic row attached to a synthetic order id that no other scenario references. Happy/decline/shortage create real sagas that complete to terminal states; the seeded fixture remains the only `Running` row at the moment `02-list-sagas` runs.
+- **Drift guardrail.** Any new GUID added to the seeder is mirrored in `qa-local.bru` and (if the legacy harness still runs) `scripts/local-smoke-test.ps1` `$Qa` hash, consistent with the existing rule in `docs/qa/README.md`.
+
+## Testing Decisions
+
+A good test here observes the external contract that operators and CI care about — never the seeder's wiring or the saga's internal step machine. The seeded fixtures are valuable because the `.bru` assertions can pin response shape end-to-end without coupling to handler internals.
+
+Module-by-module:
+
+1. **Service-token issuer Bruno step.** Tests live in the `.bru` itself: assert `200`, `token` is a non-empty string, `expiresIn` > 0. Prior art: every `01-login-*.bru` across the suites — same shape, same assertions. The Bruno CLI run is the test runner; no new server-side test needed since Auth `/token` already has unit + endpoint coverage (`auth-microservice/Auth.Tests/Features/IssueServiceToken/`).
+2. **Saga harness.** The harness is a seeder, not an endpoint, so the test is the suite itself: `02-list-sagas` must return a non-empty `items` array and a known `sagaId` on a clean stack. Prior art: `04-admin-ops/payment/02-get-authorized-payment.bru` asserts a seeded fixture row exists with exact field values. The new `02-list-sagas` test gains an assertion that the seeded `operatorSagaId` is present in `items`. Step 03 then pins the detail shape (`sagaId`, `transitions[]`); steps 04/05 assert HTTP 202 + status enum exactly as authored today.
+3. **Shipping seeder split.** Per-fixture tests already exist on each `.bru` (`expect(res.body.status).to.equal("Delivered")` etc.). The split adds nothing new at the request level; it just makes the existing assertions all reachable in one run. Prior art: the symmetric `c0000000-...01`..`...05` fixtures and their respective steps in `04-admin-ops/shipping/`.
+
+Each module is testable in isolation: the Bruno suite tests the integration contract; the underlying Auth/Saga/Shipping aggregates already have dedicated unit + endpoint tests in their respective `*-microservice/*.Tests/` projects (no new server-side tests required by this PRD).
+
+## Out of Scope
+
+- Replacing the PowerShell smoke harness or modifying the `bruno-smoke` job's wrapper. That sits in [PRD-Smoke-Test-Bruno-Cli](./PRD-Smoke-Test-Bruno-Cli.md).
+- Adding new operator-API endpoints, role policies, or claims. The five existing routes (`/operator/api/sagas`, `/operator/api/sagas/{id}`, `/retry`, `/abort`, and the underlying `/token`) cover the coverage gain.
+- Persisting the Bruno CLI form-body bug upstream (filing/tracking the regression with `@usebruno/cli`). Workaround is enough to unblock CI; upstream fix is non-blocking.
+- DLQ replay scenarios. Covered by [PRD-QA-Scenario-DLQ](./PRD-QA-Scenario-DLQ.md).
+- Loadtest, perf, or soak coverage of the operator API. The Bruno suite is a contract gate, not a perf gate.
+- Auth `/token` JSON-body alternative. Re-shaping the endpoint to accept JSON would technically work around the CLI bug, but the existing endpoint matches RFC 6749 `application/x-www-form-urlencoded` expectations and clients (api-gateway) already speak the form shape in production.
+
+## Further Notes
+
+- The Bruno CLI form-body regression is reproducible under CLI 3.3.0 with `body:form-urlencoded`, `body:formUrlEncoded`, and `body:multipart-form` — all three produce an empty body on the wire. The same suite works correctly against Bruno desktop. Pin the chosen workaround to the lowest CLI version that runs the workaround clean, so a future CLI upgrade does not silently re-break the suite.
+- The seeded Running saga must be re-seeded on every `docker compose down -v && up` cycle. The fixture is idempotent (insert-if-absent) the same way the seeded customers and shipments already are. There is no "advance the saga out of Running" cleanup step — the test acts on a synthetic row that never advances.
+- When the chosen saga-operator step is `payment authorization`, the runbook example query in `docs/qa/scenarios/05-saga-operator-abort.md` keeps working unchanged because it already filters on `?type=Order&status=Running` rather than on a specific step name.
+- Once the shipping fixtures split lands, the line in `docs/qa/scenarios/04-admin-ops.md:210` that reads "Run `docker compose down -v && up` to reset" between terminals is removed — it stops being true.

--- a/docs/qa/README.md
+++ b/docs/qa/README.md
@@ -178,6 +178,53 @@ lightweight response-shape check using Chai assertions. Keep request-level
 assertions close to the `.bru` file so a contract drift fails at the request
 that observes it.
 
+## Bruno CLI 3.3.0 form-urlencoded regression
+
+`@usebruno/cli@3.3.0` (the CI-pinned version) drops the body of requests
+declared with `body: form-urlencoded` on the wire (Content-Length: 0).
+The desktop client transmits the same request correctly, so the
+regression is CLI-only. Auth's `POST /token` is the only seeded surface
+that needs a form body (per RFC 6749 `client_credentials`).
+
+The workaround used by `qa/bruno/saga-operator/01-issue-service-token.bru`
+is to switch the body type to `multipartForm`:
+
+```
+post {
+  url: {{authBaseUrl}}/token
+  body: multipartForm
+  auth: none
+}
+
+body:multipart-form {
+  grant_type: client_credentials
+  client_id: {{serviceClientId}}
+  client_secret: {{serviceClientSecret}}
+}
+```
+
+Why multipart works: ASP.NET Core's `[FromForm]` model binder accepts
+both `application/x-www-form-urlencoded` and `multipart/form-data` for
+the same parameters, and the Auth `/token` endpoint already calls
+`DisableAntiforgery()`, so the multipart envelope is parsed identically
+to the form-urlencoded one on the server side.
+
+Why not the other obvious shapes:
+
+- `body: text` with a hand-rolled `key=value&...` payload — the CLI
+  ships the body bytes verbatim and does **not** interpolate `{{var}}`
+  inside `body:text` (verified empirically). The seeded credentials
+  would arrive as literal `{{serviceClientId}}` strings.
+- `body: form-urlencoded` — the regression we are working around.
+- `bru.runRequest` in a `script:pre-request` — adds a helper request
+  and ties the saga-operator chain to script-side state instead of the
+  declarative body.
+
+CI pins `@usebruno/cli@3.3.0`. Any CLI version bump must re-verify
+`saga-operator/01-issue-service-token.bru` still returns 200 with a
+populated `res.body.token`. If the upstream regression is fixed, the
+body type can be reverted to `form-urlencoded` for clarity.
+
 Scenario pages:
 
 - [ASB Emulator Local Profile](asb-emulator-local.md)

--- a/docs/qa/scenarios/04-admin-ops.md
+++ b/docs/qa/scenarios/04-admin-ops.md
@@ -155,17 +155,19 @@ Jaeger: trace shows the Inventory back-order span.
 
 ## Shipping ops
 
-These steps exercise `shipping-microservice` admin endpoints against the seeded shipments owned by `customer-happy`. Five fixtures, one per non-trivial status, sit in the database after a fresh `docker compose up`. Run the requests in `qa/bruno/04-admin-ops/shipping/`. **Every transition below is admin-only** — the customer JWT receives `403`.
+These steps exercise `shipping-microservice` admin endpoints against the seeded shipments owned by `customer-happy`. Seven fixtures sit in the database after a fresh `docker compose up`: five status-walk targets plus two extra `Shipped` siblings so the three terminal transitions (`deliver`, `fail`, `return`) each act on their own row. Run the requests in `qa/bruno/04-admin-ops/shipping/`. **Every transition below is admin-only** — the customer JWT receives `403`.
 
 | Shipment Id | Initial status | Order Id | Tests this transition |
 |---|---|---|---|
 | `c0000000-...01` | `Pending` | `d0000000-...01` | `pick` |
 | `c0000000-...02` | `Picked` | `d0000000-...02` | `pack` |
 | `c0000000-...03` | `Packed` | `d0000000-...03` | `dispatch` |
-| `c0000000-...04` | `Shipped` | `d0000000-...04` | `deliver`, `fail`, `return`, carrier webhook |
+| `c0000000-...04` | `Shipped` | `d0000000-...04` | `deliver`, carrier webhook |
 | `c0000000-...05` | `Pending` | `d0000000-...05` | `cancel` |
+| `c0000000-...06` | `Shipped` | `d0000000-...06` | `fail` |
+| `c0000000-...07` | `Shipped` | `d0000000-...07` | `return` |
 
-Shipment `c0000000-...04` is pre-stamped with `CarrierKey=fake-ground`, `TrackingNumber=QA-TRACK-DISPATCHED-001`, `LabelRef=label://qa/...`, `QuotedPriceAmount=5.00 USD` so the carrier-webhook lookup resolves without first running `dispatch`.
+Shipment `c0000000-...04` is pre-stamped with `CarrierKey=fake-ground`, `TrackingNumber=QA-TRACK-DISPATCHED-001`, `LabelRef=label://qa/...`, `QuotedPriceAmount=5.00 USD` so the carrier-webhook lookup resolves without first running `dispatch`. The two siblings `c0000000-...06` / `c0000000-...07` mirror that shape with `QA-TRACK-DISPATCHED-FAIL-001` and `QA-TRACK-DISPATCHED-RETURN-001`.
 
 ### 1. Pick the pending shipment
 
@@ -207,15 +209,15 @@ Jaeger: trace shows the `/dispatch` request, the carrier `DispatchAsync` span, a
 
 ### 4. Deliver, fail, or return the dispatched shipment
 
-These three transitions all act on `c0000000-...04` and are mutually exclusive — pick one per fixture run.
+Each terminal transition acts on its own seeded fixture; the trio runs sequentially in the same boot with no reset.
 
 - `POST http://localhost:8006/c0000000-...04/deliver` → `200`, `Status=Delivered`, emits `ShipmentDeliveredEvent`.
-- `POST http://localhost:8006/c0000000-...04/fail` with `{ "reason": "..." }` → `200`, `Status=Failed`, emits `ShipmentFailedEvent`.
-- `POST http://localhost:8006/c0000000-...04/return` with `{ "reason": "..." }` → `200`, `Status=Returned`, emits `ShipmentReturnedEvent`.
+- `POST http://localhost:8006/c0000000-...06/fail` with `{ "reason": "..." }` → `200`, `Status=Failed`, emits `ShipmentFailedEvent`.
+- `POST http://localhost:8006/c0000000-...07/return` with `{ "reason": "..." }` → `200`, `Status=Returned`, emits `ShipmentReturnedEvent`.
 
-SQL: same `Shipments` query scoped to `c0000000-...04`. The status history row records the transition source as `Admin (1)`.
+SQL: same `Shipments` query scoped to each row's id. The status history row records the transition source as `Admin (1)`.
 
-Event/log: each transition emits its named milestone event plus a `ShipmentStatusChangedEvent` carrying the from/to pair. To re-test another transition, run `docker compose down -v && up` to reset.
+Event/log: each transition emits its named milestone event plus a `ShipmentStatusChangedEvent` carrying the from/to pair.
 
 ### 5. Cancel the cancellable pending shipment
 

--- a/docs/qa/scenarios/05-saga-operator-abort.md
+++ b/docs/qa/scenarios/05-saga-operator-abort.md
@@ -7,17 +7,11 @@ docker compose down -v
 docker compose up --build
 ```
 
-Use the Bruno collection in `qa/bruno/saga-operator` with the `qa-local` environment. The orchestrator opens a saga for every order; no opt-in flag.
+Use the Bruno collection in `qa/bruno/saga-operator` with the `qa-local` environment. The orchestrator opens a saga for every order; for this scenario a deterministic Running `Order` saga is seeded by `20260526100000_SeedQaPhase2_Saga` (gated by `IsQaSeedingEnabled`) so the operator endpoints have a stable target on a freshly booted stack.
 
-## 1. Open an orchestrated order saga
+## 1. Confirm the seeded operator saga
 
-Pause Payment before placing the order so the saga stays in an in-flight step long enough to operate on:
-
-```powershell
-docker compose stop payment
-```
-
-HTTP: use the happy-path customer flow to create an order for product `9001`. The Saga service should open an `Order` saga for the order and park at `PaymentAuthorizing` after stock reservation.
+The seeded saga has `SagaId = e0000000-0000-0000-0000-000000000001`, `SagaType = Order`, `Status = Running`, `CurrentStep = PaymentAuthorizing`, and a synthetic `OrderId = e0000000-0000-0000-0000-000000000002` no other scenario references.
 
 SQL:
 
@@ -25,12 +19,10 @@ SQL:
 SELECT si.SagaId, si.SagaType, si.CurrentStep, si.Status, os.OrderId
 FROM Saga.dbo.SagaInstances si
 JOIN Saga.dbo.OrderSagaStates os ON os.SagaId = si.SagaId
-ORDER BY si.CreatedAt DESC;
+WHERE si.SagaId = 'e0000000-0000-0000-0000-000000000001';
 ```
 
-Event/log: Saga logs show the order saga opening and dispatching the current in-flight command. Payment remains stopped until the abort is issued.
-
-Jaeger: find the saga transition span for the new `SagaId`.
+Event/log: no runtime action — the fixture is migration-seeded.
 
 ## 2. Issue a service token
 
@@ -44,18 +36,18 @@ Jaeger: find an Auth span for `POST /token`.
 
 ## 3. List and inspect the saga
 
-HTTP: `GET http://localhost:8008/operator/api/sagas?type=Order&status=Running` returns the running saga. `GET http://localhost:8008/operator/api/sagas/{sagaId}` returns the saga detail, including `transitions`.
+HTTP: `GET http://localhost:8008/operator/api/sagas?type=Order&status=Running` returns the seeded saga in the `items` array. `GET http://localhost:8008/operator/api/sagas/{sagaId}` returns the saga detail, including `transitions`.
 
 SQL:
 
 ```sql
 SELECT CurrentStep, Status, LastCommandId, NextTimeoutAt
 FROM Saga.dbo.SagaInstances
-WHERE SagaId = '<sagaId>';
+WHERE SagaId = 'e0000000-0000-0000-0000-000000000001';
 
 SELECT FromStep, ToStep, TriggerKind, Error
 FROM Saga.dbo.SagaTransitions
-WHERE SagaId = '<sagaId>'
+WHERE SagaId = 'e0000000-0000-0000-0000-000000000001'
 ORDER BY Timestamp, Id;
 ```
 
@@ -72,14 +64,14 @@ SQL:
 ```sql
 SELECT LastCommandId, RetryCount, NextTimeoutAt
 FROM Saga.dbo.SagaInstances
-WHERE SagaId = '<sagaId>';
+WHERE SagaId = 'e0000000-0000-0000-0000-000000000001';
 
 SELECT TOP 5 Id, EventType, Sent, Status
 FROM Saga.dbo.OutboxEvents
-ORDER BY CreatedAt DESC;
+WHERE Id = 'e0000000-0000-0000-0000-000000000003';
 ```
 
-Event/log: the outbox row for `LastCommandId` is pending again, and a `TriggerKind=OperatorAction` transition records the retry.
+Event/log: the seeded outbox row for `LastCommandId` is set back to `Sent=0` with `Status=Pending`, and a `TriggerKind=OperatorAction` transition records the retry.
 
 Jaeger: follow the next publish attempt for the requeued command.
 
@@ -92,20 +84,14 @@ SQL:
 ```sql
 SELECT CurrentStep, Status, LastCommandId
 FROM Saga.dbo.SagaInstances
-WHERE SagaId = '<sagaId>';
+WHERE SagaId = 'e0000000-0000-0000-0000-000000000001';
 
 SELECT FromStep, ToStep, TriggerKind, Error
 FROM Saga.dbo.SagaTransitions
-WHERE SagaId = '<sagaId>'
+WHERE SagaId = 'e0000000-0000-0000-0000-000000000001'
 ORDER BY Timestamp, Id;
 ```
 
 Event/log: Saga publishes the first reverse-step command and records an operator-action transition with `Operator abort started saga compensation.`
 
 Jaeger: the compensation command publish should share the saga correlation context.
-
-Restart Payment after the scenario:
-
-```powershell
-docker compose start payment
-```

--- a/qa/bruno/04-admin-ops/shipping/06-fail-dispatched.bru
+++ b/qa/bruno/04-admin-ops/shipping/06-fail-dispatched.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{shippingBaseUrl}}/{{shipmentDispatchedId}}/fail
+  url: {{shippingBaseUrl}}/{{shipmentFailDispatchedId}}/fail
   body: json
   auth: bearer
 }
@@ -28,7 +28,7 @@ tests {
   test("fails the dispatched shipment", function () {
     expect(res.status).to.equal(200);
     expect(res.body).to.be.an("object");
-    expect(res.body.shipmentId).to.equal(bru.getEnvVar("shipmentDispatchedId"));
+    expect(res.body.shipmentId).to.equal(bru.getEnvVar("shipmentFailDispatchedId"));
     expect(res.body.orderId).to.match(/^[0-9a-fA-F-]{36}$/);
     expect(res.body.customerId).to.equal(bru.getEnvVar("customerHappyId"));
     expect(res.body.warehouseId).to.be.a("number");

--- a/qa/bruno/04-admin-ops/shipping/07-return-dispatched.bru
+++ b/qa/bruno/04-admin-ops/shipping/07-return-dispatched.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{shippingBaseUrl}}/{{shipmentDispatchedId}}/return
+  url: {{shippingBaseUrl}}/{{shipmentReturnDispatchedId}}/return
   body: json
   auth: bearer
 }
@@ -28,7 +28,7 @@ tests {
   test("returns the dispatched shipment", function () {
     expect(res.status).to.equal(200);
     expect(res.body).to.be.an("object");
-    expect(res.body.shipmentId).to.equal(bru.getEnvVar("shipmentDispatchedId"));
+    expect(res.body.shipmentId).to.equal(bru.getEnvVar("shipmentReturnDispatchedId"));
     expect(res.body.orderId).to.match(/^[0-9a-fA-F-]{36}$/);
     expect(res.body.customerId).to.equal(bru.getEnvVar("customerHappyId"));
     expect(res.body.warehouseId).to.be.a("number");

--- a/qa/bruno/qa-local.bru
+++ b/qa/bruno/qa-local.bru
@@ -34,5 +34,6 @@ vars {
   shipmentDispatchedTrackingNumber: QA-TRACK-DISPATCHED-001
   shipmentFailDispatchedTrackingNumber: QA-TRACK-DISPATCHED-FAIL-001
   shipmentReturnDispatchedTrackingNumber: QA-TRACK-DISPATCHED-RETURN-001
+  operatorSagaId: e0000000-0000-0000-0000-000000000001
   carrierGroundSecret: change-me-ground
 }

--- a/qa/bruno/qa-local.bru
+++ b/qa/bruno/qa-local.bru
@@ -29,6 +29,10 @@ vars {
   shipmentPackedId: c0000000-0000-0000-0000-000000000003
   shipmentDispatchedId: c0000000-0000-0000-0000-000000000004
   shipmentCancelPendingId: c0000000-0000-0000-0000-000000000005
+  shipmentFailDispatchedId: c0000000-0000-0000-0000-000000000006
+  shipmentReturnDispatchedId: c0000000-0000-0000-0000-000000000007
   shipmentDispatchedTrackingNumber: QA-TRACK-DISPATCHED-001
+  shipmentFailDispatchedTrackingNumber: QA-TRACK-DISPATCHED-FAIL-001
+  shipmentReturnDispatchedTrackingNumber: QA-TRACK-DISPATCHED-RETURN-001
   carrierGroundSecret: change-me-ground
 }

--- a/qa/bruno/saga-operator/01-issue-service-token.bru
+++ b/qa/bruno/saga-operator/01-issue-service-token.bru
@@ -6,15 +6,11 @@ meta {
 
 post {
   url: {{authBaseUrl}}/token
-  body: form-urlencoded
+  body: multipartForm
   auth: none
 }
 
-headers {
-  Content-Type: application/x-www-form-urlencoded
-}
-
-body:form-urlencoded {
+body:multipart-form {
   grant_type: client_credentials
   client_id: {{serviceClientId}}
   client_secret: {{serviceClientSecret}}

--- a/qa/bruno/saga-operator/02-list-sagas.bru
+++ b/qa/bruno/saga-operator/02-list-sagas.bru
@@ -15,17 +15,12 @@ auth:bearer {
 }
 
 tests {
-  test("lists order sagas", function () {
+  test("lists order sagas including the seeded fixture", function () {
     expect(res.status).to.equal(200);
     expect(res.body).to.be.an("object");
     expect(res.body.items).to.be.an("array");
     expect(res.body.total).to.be.a("number");
+    const seededId = bru.getVar("operatorSagaId");
+    expect(res.body.items.some(function (item) { return item.sagaId === seededId; })).to.equal(true);
   });
-}
-
-script:post-response {
-  const first = Array.isArray(res.body.items) ? res.body.items[0] : null;
-  if (first && first.sagaId) {
-    bru.setVar("operatorSagaId", first.sagaId);
-  }
 }

--- a/qa/bruno/saga-operator/02-list-sagas.bru
+++ b/qa/bruno/saga-operator/02-list-sagas.bru
@@ -20,7 +20,7 @@ tests {
     expect(res.body).to.be.an("object");
     expect(res.body.items).to.be.an("array");
     expect(res.body.total).to.be.a("number");
-    const seededId = bru.getVar("operatorSagaId");
+    const seededId = bru.getEnvVar("operatorSagaId");
     expect(res.body.items.some(function (item) { return item.sagaId === seededId; })).to.equal(true);
   });
 }

--- a/qa/bruno/saga-operator/03-get-saga-detail.bru
+++ b/qa/bruno/saga-operator/03-get-saga-detail.bru
@@ -17,7 +17,7 @@ auth:bearer {
 tests {
   test("returns saga detail with transitions", function () {
     expect(res.status).to.equal(200);
-    expect(res.body.sagaId).to.equal(bru.getVar("operatorSagaId"));
+    expect(res.body.sagaId).to.equal(bru.getEnvVar("operatorSagaId"));
     expect(res.body.transitions).to.be.an("array");
   });
 }

--- a/qa/bruno/saga-operator/04-retry-saga.bru
+++ b/qa/bruno/saga-operator/04-retry-saga.bru
@@ -17,7 +17,7 @@ auth:bearer {
 tests {
   test("requeues the in-flight saga command", function () {
     expect(res.status).to.equal(202);
-    expect(res.body.sagaId).to.equal(bru.getVar("operatorSagaId"));
+    expect(res.body.sagaId).to.equal(bru.getEnvVar("operatorSagaId"));
     expect(res.body.currentStep).to.be.a("string").and.not.be.empty;
   });
 }

--- a/qa/bruno/saga-operator/05-abort-saga.bru
+++ b/qa/bruno/saga-operator/05-abort-saga.bru
@@ -17,7 +17,7 @@ auth:bearer {
 tests {
   test("starts saga compensation", function () {
     expect(res.status).to.equal(202);
-    expect(res.body.sagaId).to.equal(bru.getVar("operatorSagaId"));
+    expect(res.body.sagaId).to.equal(bru.getEnvVar("operatorSagaId"));
     expect(res.body.status).to.equal("Compensating");
   });
 }

--- a/saga-microservice/Saga.Service/Infrastructure/Data/EntityFramework/EntityFrameworkExtensions.cs
+++ b/saga-microservice/Saga.Service/Infrastructure/Data/EntityFramework/EntityFrameworkExtensions.cs
@@ -27,4 +27,15 @@ public static class EntityFrameworkExtensions
         using var sagaContext = scope.ServiceProvider.GetRequiredService<SagaContext>();
         sagaContext.Database.Migrate();
     }
+
+    public static void SeedQaOperatorOutboxFixture(this WebApplication webApp)
+    {
+        var commandId = new Guid("e0000000-0000-0000-0000-000000000003");
+        using var scope = webApp.Services.CreateScope();
+        using var sagaContext = scope.ServiceProvider.GetRequiredService<SagaContext>();
+        sagaContext.Database.ExecuteSqlInterpolated(
+            $@"IF NOT EXISTS (SELECT 1 FROM [OutboxEvents] WHERE [Id] = {commandId})
+               INSERT INTO [OutboxEvents] ([Id], [EventType], [Data], [Sent], [Status], [Attempts])
+               VALUES ({commandId}, N'Saga.Service.QaSyntheticEvent, Saga.Service', N'{{}}', 1, 0, 0);");
+    }
 }

--- a/saga-microservice/Saga.Service/Migrations/20260526100000_SeedQaPhase2_Saga.cs
+++ b/saga-microservice/Saga.Service/Migrations/20260526100000_SeedQaPhase2_Saga.cs
@@ -1,0 +1,71 @@
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Saga.Service.Infrastructure.Data.EntityFramework;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace Saga.Service.Migrations
+{
+    /// <inheritdoc />
+    [DbContext(typeof(SagaContext))]
+    [Migration("20260526100000_SeedQaPhase2_Saga")]
+    public partial class SeedQaPhase2_Saga : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "SagaInstances",
+                columns: new[] { "SagaId", "SagaType", "CurrentStep", "Status", "CorrelationId", "CreatedAt", "UpdatedAt", "NextTimeoutAt", "RetryCount", "LastCommandId" },
+                columnTypes: new[] { "uniqueidentifier", "nvarchar(64)", "nvarchar(64)", "nvarchar(32)", "uniqueidentifier", "datetime2", "datetime2", "datetime2", "int", "uniqueidentifier" },
+                values: new object[]
+                {
+                    new Guid("e0000000-0000-0000-0000-000000000001"),
+                    "Order",
+                    "PaymentAuthorizing",
+                    "Running",
+                    new Guid("e0000000-0000-0000-0000-0000000000a1"),
+                    new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
+                    new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
+                    null,
+                    0,
+                    new Guid("e0000000-0000-0000-0000-000000000003")
+                });
+
+            migrationBuilder.InsertData(
+                table: "OrderSagaStates",
+                columns: new[] { "SagaId", "OrderId", "ReservationId", "PaymentId", "ShipmentId", "Amount", "CompensationOrigin", "LastStepResult" },
+                columnTypes: new[] { "uniqueidentifier", "uniqueidentifier", "uniqueidentifier", "uniqueidentifier", "uniqueidentifier", "decimal(18,2)", "nvarchar(64)", "nvarchar(128)" },
+                values: new object[]
+                {
+                    new Guid("e0000000-0000-0000-0000-000000000001"),
+                    new Guid("e0000000-0000-0000-0000-000000000002"),
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    "QaSeed"
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "OrderSagaStates",
+                keyColumn: "SagaId",
+                keyColumnType: "uniqueidentifier",
+                keyValue: new Guid("e0000000-0000-0000-0000-000000000001"));
+
+            migrationBuilder.DeleteData(
+                table: "SagaInstances",
+                keyColumn: "SagaId",
+                keyColumnType: "uniqueidentifier",
+                keyValue: new Guid("e0000000-0000-0000-0000-000000000001"));
+        }
+    }
+}

--- a/saga-microservice/Saga.Service/Program.cs
+++ b/saga-microservice/Saga.Service/Program.cs
@@ -107,6 +107,7 @@ if (QaSeedingExtensions.IsQaSeedingEnabled(app.Environment, app.Configuration))
 {
     app.MigrateDatabase();
     app.ApplyOutboxMigrations();
+    app.SeedQaOperatorOutboxFixture();
 }
 
 app.UsePlatformOpenApi();

--- a/saga-microservice/Saga.Tests/Domain/QaSeedFixturesTests.cs
+++ b/saga-microservice/Saga.Tests/Domain/QaSeedFixturesTests.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Saga.Service.Domain;
+using Saga.Service.Domain.OrderSaga;
+using Saga.Service.Infrastructure.Data.EntityFramework;
+
+namespace Saga.Tests.Domain;
+
+public class QaSeedFixturesTests : IClassFixture<SagaWebApplicationFactory>
+{
+    private static readonly Guid SeededSagaId = new("e0000000-0000-0000-0000-000000000001");
+    private static readonly Guid SeededOrderId = new("e0000000-0000-0000-0000-000000000002");
+
+    private readonly SagaWebApplicationFactory _factory;
+
+    public QaSeedFixturesTests(SagaWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Given_FreshDatabase_When_MigrationsApplied_Then_OperatorSagaFixtureIsPresent()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var sagaContext = scope.ServiceProvider.GetRequiredService<SagaContext>();
+
+        var saga = await sagaContext.SagaInstances
+            .AsNoTracking()
+            .Include(s => s.OrderSagaState)
+            .SingleAsync(s => s.SagaId == SeededSagaId);
+
+        Assert.Equal("Order", saga.SagaType);
+        Assert.Equal(SagaStatus.Running, saga.Status);
+        Assert.Equal(OrderSagaStep.PaymentAuthorizing.ToString(), saga.CurrentStep);
+        Assert.NotNull(saga.OrderSagaState);
+        Assert.Equal(SeededOrderId, saga.OrderSagaState!.OrderId);
+    }
+}

--- a/shipping-microservice/Shipping.Service/Infrastructure/Data/EntityFramework/ShipmentConfiguration.cs
+++ b/shipping-microservice/Shipping.Service/Infrastructure/Data/EntityFramework/ShipmentConfiguration.cs
@@ -113,6 +113,34 @@ internal class ShipmentConfiguration : IEntityTypeConfiguration<Shipment>
                 WarehouseId = QaPersonas.DefaultWarehouseId,
                 Status = ShipmentStatus.Pending,
                 CreatedAt = ShippingQaFixtures.SeedEpoch,
+            },
+            new
+            {
+                Id = ShippingQaFixtures.ShipmentFailDispatchedId,
+                OrderId = ShippingQaFixtures.ShippingOrderFailDispatchedId,
+                CustomerId = customerHappyId,
+                WarehouseId = QaPersonas.DefaultWarehouseId,
+                Status = ShipmentStatus.Shipped,
+                CreatedAt = ShippingQaFixtures.SeedEpoch,
+                CarrierKey = ShippingQaFixtures.DispatchedCarrierKey,
+                TrackingNumber = ShippingQaFixtures.FailDispatchedTrackingNumber,
+                LabelRef = ShippingQaFixtures.FailDispatchedLabelRef,
+                QuotedPriceAmount = (decimal?)ShippingQaFixtures.DispatchedQuotedAmount,
+                QuotedPriceCurrency = ShippingQaFixtures.DispatchedQuotedCurrency,
+            },
+            new
+            {
+                Id = ShippingQaFixtures.ShipmentReturnDispatchedId,
+                OrderId = ShippingQaFixtures.ShippingOrderReturnDispatchedId,
+                CustomerId = customerHappyId,
+                WarehouseId = QaPersonas.DefaultWarehouseId,
+                Status = ShipmentStatus.Shipped,
+                CreatedAt = ShippingQaFixtures.SeedEpoch,
+                CarrierKey = ShippingQaFixtures.DispatchedCarrierKey,
+                TrackingNumber = ShippingQaFixtures.ReturnDispatchedTrackingNumber,
+                LabelRef = ShippingQaFixtures.ReturnDispatchedLabelRef,
+                QuotedPriceAmount = (decimal?)ShippingQaFixtures.DispatchedQuotedAmount,
+                QuotedPriceCurrency = ShippingQaFixtures.DispatchedQuotedCurrency,
             });
     }
 }

--- a/shipping-microservice/Shipping.Service/Infrastructure/Data/EntityFramework/ShipmentLineConfiguration.cs
+++ b/shipping-microservice/Shipping.Service/Infrastructure/Data/EntityFramework/ShipmentLineConfiguration.cs
@@ -48,6 +48,20 @@ internal class ShipmentLineConfiguration : IEntityTypeConfiguration<ShipmentLine
                 ShipmentId = ShippingQaFixtures.ShipmentCancelPendingId,
                 ProductId = QaPersonas.ProductHappyId,
                 Quantity = QaPersonas.ProductHappyQuantity,
+            },
+            new ShipmentLine
+            {
+                Id = ShippingQaFixtures.LineSeedIdStart + 5,
+                ShipmentId = ShippingQaFixtures.ShipmentFailDispatchedId,
+                ProductId = QaPersonas.ProductHappyId,
+                Quantity = QaPersonas.ProductHappyQuantity,
+            },
+            new ShipmentLine
+            {
+                Id = ShippingQaFixtures.LineSeedIdStart + 6,
+                ShipmentId = ShippingQaFixtures.ShipmentReturnDispatchedId,
+                ProductId = QaPersonas.ProductHappyId,
+                Quantity = QaPersonas.ProductHappyQuantity,
             });
     }
 }

--- a/shipping-microservice/Shipping.Service/Infrastructure/Data/EntityFramework/ShipmentStatusHistoryEntryConfiguration.cs
+++ b/shipping-microservice/Shipping.Service/Infrastructure/Data/EntityFramework/ShipmentStatusHistoryEntryConfiguration.cs
@@ -63,6 +63,22 @@ internal class ShipmentStatusHistoryEntryConfiguration : IEntityTypeConfiguratio
                 Status = ShipmentStatus.Pending,
                 OccurredAt = ShippingQaFixtures.SeedEpoch,
                 Source = ShipmentStatusSource.System,
+            },
+            new ShipmentStatusHistoryEntry
+            {
+                Id = ShippingQaFixtures.HistorySeedIdStart + 5,
+                ShipmentId = ShippingQaFixtures.ShipmentFailDispatchedId,
+                Status = ShipmentStatus.Shipped,
+                OccurredAt = ShippingQaFixtures.SeedEpoch,
+                Source = ShipmentStatusSource.System,
+            },
+            new ShipmentStatusHistoryEntry
+            {
+                Id = ShippingQaFixtures.HistorySeedIdStart + 6,
+                ShipmentId = ShippingQaFixtures.ShipmentReturnDispatchedId,
+                Status = ShipmentStatus.Shipped,
+                OccurredAt = ShippingQaFixtures.SeedEpoch,
+                Source = ShipmentStatusSource.System,
             });
     }
 }

--- a/shipping-microservice/Shipping.Service/Infrastructure/Data/EntityFramework/ShippingQaFixtures.cs
+++ b/shipping-microservice/Shipping.Service/Infrastructure/Data/EntityFramework/ShippingQaFixtures.cs
@@ -16,18 +16,28 @@ internal static class ShippingQaFixtures
     public static readonly Guid ShipmentPackedId = new("c0000000-0000-0000-0000-000000000003");
     public static readonly Guid ShipmentDispatchedId = new("c0000000-0000-0000-0000-000000000004");
     public static readonly Guid ShipmentCancelPendingId = new("c0000000-0000-0000-0000-000000000005");
+    public static readonly Guid ShipmentFailDispatchedId = new("c0000000-0000-0000-0000-000000000006");
+    public static readonly Guid ShipmentReturnDispatchedId = new("c0000000-0000-0000-0000-000000000007");
 
     public static readonly Guid ShippingOrderPickPendingId = new("d0000000-0000-0000-0000-000000000001");
     public static readonly Guid ShippingOrderPickedId = new("d0000000-0000-0000-0000-000000000002");
     public static readonly Guid ShippingOrderPackedId = new("d0000000-0000-0000-0000-000000000003");
     public static readonly Guid ShippingOrderDispatchedId = new("d0000000-0000-0000-0000-000000000004");
     public static readonly Guid ShippingOrderCancelPendingId = new("d0000000-0000-0000-0000-000000000005");
+    public static readonly Guid ShippingOrderFailDispatchedId = new("d0000000-0000-0000-0000-000000000006");
+    public static readonly Guid ShippingOrderReturnDispatchedId = new("d0000000-0000-0000-0000-000000000007");
 
     public const string DispatchedCarrierKey = "fake-ground";
     public const string DispatchedTrackingNumber = "QA-TRACK-DISPATCHED-001";
     public const string DispatchedLabelRef = "label://qa/QA-TRACK-DISPATCHED-001";
     public const decimal DispatchedQuotedAmount = 5.00m;
     public const string DispatchedQuotedCurrency = "USD";
+
+    public const string FailDispatchedTrackingNumber = "QA-TRACK-DISPATCHED-FAIL-001";
+    public const string FailDispatchedLabelRef = "label://qa/QA-TRACK-DISPATCHED-FAIL-001";
+
+    public const string ReturnDispatchedTrackingNumber = "QA-TRACK-DISPATCHED-RETURN-001";
+    public const string ReturnDispatchedLabelRef = "label://qa/QA-TRACK-DISPATCHED-RETURN-001";
 
     public const int LineSeedIdStart = 90001;
     public const int HistorySeedIdStart = 90001;

--- a/shipping-microservice/Shipping.Service/Migrations/20260526032839_SeedQaPhase3c_Shipping.Designer.cs
+++ b/shipping-microservice/Shipping.Service/Migrations/20260526032839_SeedQaPhase3c_Shipping.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Shipping.Service.Infrastructure.Data.EntityFramework;
 
@@ -11,9 +12,11 @@ using Shipping.Service.Infrastructure.Data.EntityFramework;
 namespace Shipping.Service.Migrations
 {
     [DbContext(typeof(ShippingContext))]
-    partial class ShippingContextModelSnapshot : ModelSnapshot
+    [Migration("20260526032839_SeedQaPhase3c_Shipping")]
+    partial class SeedQaPhase3c_Shipping
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/shipping-microservice/Shipping.Service/Migrations/20260526032839_SeedQaPhase3c_Shipping.cs
+++ b/shipping-microservice/Shipping.Service/Migrations/20260526032839_SeedQaPhase3c_Shipping.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace Shipping.Service.Migrations
+{
+    /// <inheritdoc />
+    public partial class SeedQaPhase3c_Shipping : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "Shipments",
+                columns: new[] { "Id", "CarrierKey", "CreatedAt", "CustomerId", "LabelRef", "OrderId", "QuotedPriceAmount", "QuotedPriceCurrency", "Status", "TrackingNumber", "WarehouseId" },
+                values: new object[,]
+                {
+                    { new Guid("c0000000-0000-0000-0000-000000000006"), "fake-ground", new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc), "5ff2d67e-c6b5-4870-911f-79393ed416fd", "label://qa/QA-TRACK-DISPATCHED-FAIL-001", new Guid("d0000000-0000-0000-0000-000000000006"), 5.00m, "USD", 3, "QA-TRACK-DISPATCHED-FAIL-001", 1 },
+                    { new Guid("c0000000-0000-0000-0000-000000000007"), "fake-ground", new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc), "5ff2d67e-c6b5-4870-911f-79393ed416fd", "label://qa/QA-TRACK-DISPATCHED-RETURN-001", new Guid("d0000000-0000-0000-0000-000000000007"), 5.00m, "USD", 3, "QA-TRACK-DISPATCHED-RETURN-001", 1 }
+                });
+
+            migrationBuilder.InsertData(
+                table: "ShipmentLines",
+                columns: new[] { "Id", "ProductId", "Quantity", "ShipmentId" },
+                values: new object[,]
+                {
+                    { 90006, 9001, 2, new Guid("c0000000-0000-0000-0000-000000000006") },
+                    { 90007, 9001, 2, new Guid("c0000000-0000-0000-0000-000000000007") }
+                });
+
+            migrationBuilder.InsertData(
+                table: "ShipmentStatusHistory",
+                columns: new[] { "Id", "OccurredAt", "Reason", "ShipmentId", "Source", "Status" },
+                values: new object[,]
+                {
+                    { 90006, new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc), null, new Guid("c0000000-0000-0000-0000-000000000006"), 0, 3 },
+                    { 90007, new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc), null, new Guid("c0000000-0000-0000-0000-000000000007"), 0, 3 }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "ShipmentLines",
+                keyColumn: "Id",
+                keyValue: 90006);
+
+            migrationBuilder.DeleteData(
+                table: "ShipmentLines",
+                keyColumn: "Id",
+                keyValue: 90007);
+
+            migrationBuilder.DeleteData(
+                table: "ShipmentStatusHistory",
+                keyColumn: "Id",
+                keyValue: 90006);
+
+            migrationBuilder.DeleteData(
+                table: "ShipmentStatusHistory",
+                keyColumn: "Id",
+                keyValue: 90007);
+
+            migrationBuilder.DeleteData(
+                table: "Shipments",
+                keyColumn: "Id",
+                keyValue: new Guid("c0000000-0000-0000-0000-000000000006"));
+
+            migrationBuilder.DeleteData(
+                table: "Shipments",
+                keyColumn: "Id",
+                keyValue: new Guid("c0000000-0000-0000-0000-000000000007"));
+        }
+    }
+}

--- a/shipping-microservice/Shipping.Tests/Domain/QaSeedFixturesTests.cs
+++ b/shipping-microservice/Shipping.Tests/Domain/QaSeedFixturesTests.cs
@@ -13,7 +13,7 @@ public class QaSeedFixturesTests : IntegrationTestBase
     }
 
     [Fact]
-    public async Task Given_FreshDatabase_When_MigrationsApplied_Then_FivePhase3bShipmentFixturesArePresent()
+    public async Task Given_FreshDatabase_When_MigrationsApplied_Then_SevenShipmentFixturesArePresent()
     {
         var customerHappyId = QaPersonas.CustomerHappyId.ToString();
 
@@ -26,15 +26,19 @@ public class QaSeedFixturesTests : IntegrationTestBase
                     ShippingQaFixtures.ShipmentPackedId,
                     ShippingQaFixtures.ShipmentDispatchedId,
                     ShippingQaFixtures.ShipmentCancelPendingId,
+                    ShippingQaFixtures.ShipmentFailDispatchedId,
+                    ShippingQaFixtures.ShipmentReturnDispatchedId,
                 }.Contains(s.Id))
             .ToDictionaryAsync(s => s.Id, s => s.Status);
 
-        Assert.Equal(5, seeded.Count);
+        Assert.Equal(7, seeded.Count);
         Assert.Equal(ShipmentStatus.Pending, seeded[ShippingQaFixtures.ShipmentPickPendingId]);
         Assert.Equal(ShipmentStatus.Picked, seeded[ShippingQaFixtures.ShipmentPickedId]);
         Assert.Equal(ShipmentStatus.Packed, seeded[ShippingQaFixtures.ShipmentPackedId]);
         Assert.Equal(ShipmentStatus.Shipped, seeded[ShippingQaFixtures.ShipmentDispatchedId]);
         Assert.Equal(ShipmentStatus.Pending, seeded[ShippingQaFixtures.ShipmentCancelPendingId]);
+        Assert.Equal(ShipmentStatus.Shipped, seeded[ShippingQaFixtures.ShipmentFailDispatchedId]);
+        Assert.Equal(ShipmentStatus.Shipped, seeded[ShippingQaFixtures.ShipmentReturnDispatchedId]);
     }
 
     [Fact]
@@ -52,6 +56,34 @@ public class QaSeedFixturesTests : IntegrationTestBase
     }
 
     [Fact]
+    public async Task Given_FreshDatabase_When_FailDispatchedFixtureLoaded_Then_CarrierFieldsAndTrackingNumberAreSet()
+    {
+        var failDispatched = await ShippingContext.Shipments
+            .AsNoTracking()
+            .SingleAsync(s => s.Id == ShippingQaFixtures.ShipmentFailDispatchedId);
+
+        Assert.Equal(ShippingQaFixtures.DispatchedCarrierKey, failDispatched.CarrierKey);
+        Assert.Equal(ShippingQaFixtures.FailDispatchedTrackingNumber, failDispatched.TrackingNumber);
+        Assert.Equal(ShippingQaFixtures.FailDispatchedLabelRef, failDispatched.LabelRef);
+        Assert.Equal(ShippingQaFixtures.DispatchedQuotedAmount, failDispatched.QuotedPriceAmount);
+        Assert.Equal(ShippingQaFixtures.DispatchedQuotedCurrency, failDispatched.QuotedPriceCurrency);
+    }
+
+    [Fact]
+    public async Task Given_FreshDatabase_When_ReturnDispatchedFixtureLoaded_Then_CarrierFieldsAndTrackingNumberAreSet()
+    {
+        var returnDispatched = await ShippingContext.Shipments
+            .AsNoTracking()
+            .SingleAsync(s => s.Id == ShippingQaFixtures.ShipmentReturnDispatchedId);
+
+        Assert.Equal(ShippingQaFixtures.DispatchedCarrierKey, returnDispatched.CarrierKey);
+        Assert.Equal(ShippingQaFixtures.ReturnDispatchedTrackingNumber, returnDispatched.TrackingNumber);
+        Assert.Equal(ShippingQaFixtures.ReturnDispatchedLabelRef, returnDispatched.LabelRef);
+        Assert.Equal(ShippingQaFixtures.DispatchedQuotedAmount, returnDispatched.QuotedPriceAmount);
+        Assert.Equal(ShippingQaFixtures.DispatchedQuotedCurrency, returnDispatched.QuotedPriceCurrency);
+    }
+
+    [Fact]
     public async Task Given_FreshDatabase_When_SeedShipmentsLoaded_Then_EachHasOneProductHappyLine()
     {
         var seedIds = new[]
@@ -61,6 +93,8 @@ public class QaSeedFixturesTests : IntegrationTestBase
             ShippingQaFixtures.ShipmentPackedId,
             ShippingQaFixtures.ShipmentDispatchedId,
             ShippingQaFixtures.ShipmentCancelPendingId,
+            ShippingQaFixtures.ShipmentFailDispatchedId,
+            ShippingQaFixtures.ShipmentReturnDispatchedId,
         };
 
         var shipments = await ShippingContext.Shipments
@@ -69,7 +103,7 @@ public class QaSeedFixturesTests : IntegrationTestBase
             .Where(s => seedIds.Contains(s.Id))
             .ToListAsync();
 
-        Assert.Equal(5, shipments.Count);
+        Assert.Equal(7, shipments.Count);
         foreach (var shipment in shipments)
         {
             var line = Assert.Single(shipment.Lines);


### PR DESCRIPTION
## Summary

- Work around the Bruno CLI 3.3.0 `application/x-www-form-urlencoded` token request gap and document the pinned workaround.
- Seed a deterministic Running Order saga for the saga-operator Bruno suite and add coverage for the seeded fixture.
- Split shipping dispatched terminal fixtures, update Bruno variables/requests/docs, and wire the deterministic suites into the existing smoke workflow.

Closes #287

## Validation

- `dotnet build` from `saga-microservice`
- `dotnet build` from `shipping-microservice`
- `dotnet test --filter "FullyQualifiedName~QaSeedFixturesTests"` from `saga-microservice`
- `dotnet test --filter "FullyQualifiedName~QaSeedFixturesTests"` from `shipping-microservice`
- `dotnet format --verify-no-changes --verbosity minimal` from `saga-microservice`
- `dotnet format --verify-no-changes --verbosity minimal` from `shipping-microservice`

## Full-suite notes

- `dotnet test` from `saga-microservice` currently fails 2 existing end-to-end tests because the test factory resolves the internal outbox context using `ECommerce.Shared.Infrastructure.Outbox.OutboxContext, ECommerce.Shared`, while the outbox implementation now lives in the split event-bus package.
- `dotnet test` from `shipping-microservice` currently fails 1 existing event-stream test because the hosted outbox publisher can mark early shipment events as published before the test reads unpublished events.