### PR TITLE
Document scope/non-goals and align CI/CD guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,7 +38,7 @@ Services and ports (from [docker-compose.yaml](../docker-compose.yaml)):
 - **Messaging:** RabbitMQ by default or Azure Service Bus via `Messaging:Provider`, wrapped by `IEventBus` from `ECommerce.Shared.EventBus` and provider-aware composition from `ECommerce.Shared.Messaging`
 - **Observability:** OpenTelemetry, Jaeger, Loki, Grafana, Prometheus (see `observability/` and `kubernetes/`)
 - **Containerization:** Docker / Docker Compose; Kubernetes manifests under `kubernetes/`
-- **CI/CD:** **Azure Pipelines** (`azure-pipelines.yml` per service). GitHub Actions is not used.
+- **CI/CD:** GitHub Actions runs build verification (`docker-build.yml`) and QA smoke checks (`smoke-test.yml`) as CI gates; Azure Pipelines (per-service `azure-pipelines.yml`) is the deployment path.
 - **Cloud target:** Azure (AKS manifests prefixed `aks-*` in `kubernetes/`)
 
 ## Build, test, run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ RS256 user JWTs from Auth (`POST /login`); `client_credentials` service tokens (
 
 ## CI/CD
 
-Azure Pipelines per service (`azure-pipelines.yml`). Bicep provisions AKS/ACR/Azure SQL/Service Bus/App Insights. Deploys to `ecommerce-{dev,staging,prod}` namespaces. **GitHub Actions is not used.**
+GitHub Actions runs build verification (`docker-build.yml`) and QA smoke checks (`smoke-test.yml`) as CI gates; Azure Pipelines (per-service `azure-pipelines.yml`) is the deployment path. Bicep provisions AKS/ACR/Azure SQL/Service Bus/App Insights. Deploys to `ecommerce-{dev,staging,prod}` namespaces.
 
 ## Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ RS256 user JWTs from Auth (`POST /login`); `client_credentials` service tokens (
 
 ## CI/CD
 
-Azure Pipelines per service (`azure-pipelines.yml`). Bicep provisions AKS/ACR/Azure SQL/Service Bus/App Insights. Deploys to `ecommerce-{dev,staging,prod}` namespaces. **GitHub Actions is not used.**
+GitHub Actions runs build verification (`docker-build.yml`) and QA smoke checks (`smoke-test.yml`) as CI gates; Azure Pipelines (per-service `azure-pipelines.yml`) is the deployment path. Bicep provisions AKS/ACR/Azure SQL/Service Bus/App Insights. Deploys to `ecommerce-{dev,staging,prod}` namespaces.
 
 ## Conventions
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,7 +1,7 @@
 # E-Commerce Microservices Platform — Project Context
 
 [![Docker Build](https://github.com/daonhan/Microservices-in-.NET/actions/workflows/docker-build.yml/badge.svg)](https://github.com/daonhan/Microservices-in-.NET/actions/workflows/docker-build.yml)
-[![Docker Build](https://github.com/daonhan/Microservices-in-.NET/actions/workflows/smoke-test.yml/badge.svg)](https://github.com/daonhan/Microservices-in-.NET/actions/workflows/smoke-test.yml)
+[![QA Smoke Test](https://github.com/daonhan/Microservices-in-.NET/actions/workflows/smoke-test.yml/badge.svg)](https://github.com/daonhan/Microservices-in-.NET/actions/workflows/smoke-test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![.NET 10](https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet&logoColor=white)](https://dotnet.microsoft.com/)
 
@@ -239,6 +239,25 @@ In rough order of how surprising each one was:
 The gateway's combined Swagger UI is the fastest way to show the "single front door, many services" shape of the platform without explaining the route table first.
 
 ![API Gateway combined Swagger UI](docs/assets/swagger.png)
+
+## Scope & Non-Goals
+
+### What this is
+
+A learning and portfolio backend, not a production storefront. There is no frontend or UI — the public surface is the API Gateway plus the aggregated Swagger it fronts. Payments are simulated: authorize/capture/void/refund are pattern demonstrations rather than calls to a real processor. The intent is depth over breadth — eight services that walk the hard distributed-systems paths (saga orchestration, transactional outbox, JWKS, DLQ operator API, OpenTelemetry end-to-end) rather than a wide-but-shallow commerce catalog. Single-author portfolio and learning intent, written down so a reader can judge the scoping choices in under a minute.
+
+### Non-goals
+
+- No frontend or UI — the public surface is the API Gateway plus aggregated Swagger.
+- Simulated payments — authorize/capture/void/refund are pattern demos, not a real processor integration.
+- Depth-over-breadth — no wide commerce catalog (returns, promotions, multi-tenant pricing, etc.); the eight services in the platform are the scope.
+- Gateway provider switch is boot-time; per-route selection and hot reload are out of scope ([ADR-0001](docs/adr/0001-api-gateway-yarp-default-ocelot-fallback.md)).
+- Ocelot removal deferred — dual-gateway is by design ([PRD-ApiGateway-Yarp](docs/prd/PRD-ApiGateway-Yarp.md)).
+- Local NuGet feed only; no public-feed publishing ([ADR-0005](docs/adr/0005-ecommerce-shared-as-nuget-via-local-feed.md), [shared-libs versioning runbook](docs/runbooks/shared-libs-versioning.md)).
+- Cosmos DB migration deferred; Azure SQL is the current datastore ([PRD — Azure Infrastructure Deployment](docs/prd/azure-infrastructure-deployment.md)).
+- Auth per-slice request validation deferred ([PRD-Auth-CleanArch-VSA-Pilot](docs/prd/PRD-Auth-CleanArch-VSA-Pilot.md)).
+- No microservice code consolidation — services deploy as-is ([PRD-Aks-Deployment](docs/prd/PRD-Aks-Deployment.md)).
+- Gateway-internal JWT claim helper not promoted to shared lib ([PRD-ApiGateway-CleanArch-VSA-Pilot](docs/prd/PRD-ApiGateway-CleanArch-VSA-Pilot.md)).
 
 ## Link tree
 

--- a/README.md
+++ b/README.md
@@ -253,6 +253,10 @@ cp shared-libs/**/bin/Release/*.nupkg local-nuget-packages/
 | **Resilience** | Polly retry pipelines for RabbitMQ, EF Core `EnableRetryOnFailure` for SQL |
 | **Distributed tracing** | OpenTelemetry with context propagation across RabbitMQ messages, including DLQ replay spans |
 
+## Scope & Non-Goals
+
+For what this project is and isn't — the framing (learning/portfolio backend, no frontend, simulated payments, depth-over-breadth) and the consolidated non-goals list with links back to the authoritative ADRs/PRDs/runbooks — see [`CONTEXT.md#scope--non-goals`](CONTEXT.md#scope--non-goals).
+
 ## API Gateway Provider (YARP / Ocelot)
 
 The API Gateway ships with two reverse-proxy implementations compiled into the same project. The active one is selected at runtime via the `Gateway:Provider` config key. Defaults to **`Yarp`**.

--- a/docs/plans/scope-nongoals-cicd-reconcile.md
+++ b/docs/plans/scope-nongoals-cicd-reconcile.md
@@ -88,4 +88,4 @@ Per PRD Testing Decisions: docs-only, automated tests would only couple to prose
    Select-String -Path CLAUDE.md, AGENTS.md, .github/copilot-instructions.md -Pattern "GitHub Actions"
    ```
 4. **Badge** — confirm `CONTEXT.md:4` badge label = "QA Smoke Test", URL still `smoke-test.yml`; both badges still resolve to existing workflows.
-5. **No drift** — `git diff --stat` touches only `CONTEXT.md`, `README.md`, `CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md`. No workflow/pipeline/PATTERNS files.
+5. **No drift** — `git diff --stat` touches only `CONTEXT.md`, `README.md`, `CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md`, and `docs/plans/scope-nongoals-cicd-reconcile.md`. No workflow/pipeline/PATTERNS files.

--- a/docs/plans/scope-nongoals-cicd-reconcile.md
+++ b/docs/plans/scope-nongoals-cicd-reconcile.md
@@ -1,0 +1,91 @@
+# Plan: Scope & Non-Goals consolidation + CI/CD doc reconcile
+
+> Source PRD: [PRD-Scope-NonGoals.md](../prd/PRD-Scope-NonGoals.md) — tracked as [#313](https://github.com/daonhan/Microservices-in-.NET/issues/313)
+
+## Context
+
+Why this change: the repo has no single authoritative answer to "what is this project, and what is it *not*?" The scope (learning/portfolio backend, depth-over-breadth, no frontend, simulated payments) is real but implicit, and the explicit out-of-scope decisions are scattered across a dozen PRDs/ADRs/runbooks. A reader has to reverse-engineer the boundaries from the whole `docs/` tree.
+
+Second, one grounding claim is now factually wrong. `CLAUDE.md`, `AGENTS.md`, and `.github/copilot-instructions.md` all say **"GitHub Actions is not used"** — but the repo ships two active workflows (`docker-build.yml`, `smoke-test.yml`) and `CONTEXT.md` renders badges pointing at them. The accurate framing already exists in `infrastructure-deployment/docs/PATTERNS.md` ("GitHub Actions is not the deployment path for this repo") but never propagated to the agent-facing files.
+
+Outcome: a reader gets the project boundaries in under a minute from one place, and no grounding doc tells an agent something the codebase contradicts.
+
+This is a **documentation-only** change — no code, schema, API, or workflow files are added/removed/edited. Verification is manual review (rendering + link resolution + cross-file consistency), matching prior doc-PRD practice (`PRD-Context`, `PRD-Wiki`).
+
+## Architectural decisions
+
+Durable decisions that apply across all phases:
+
+- **Single source of truth.** The "Scope & Non-Goals" content lives once in `CONTEXT.md` (human-narrated entry point). `README.md` links to it, does not duplicate.
+- **Section anchor.** New `## Scope & Non-Goals` heading in `CONTEXT.md` → GitHub anchor `#scope--non-goals`. README cross-link targets that anchor.
+- **Placement.** Section sits between `## What I learned` (CONTEXT.md:227) and `## Link tree` (CONTEXT.md:243): flow becomes Why → What → Learned → Scope/Non-Goals → Links.
+- **Two groupings inside the section.** (a) *What this is* — one paragraph restating the implicit framing as explicit scope. (b) *Non-goals* — bulleted list, each item one line + link to the authoritative ADR/PRD/runbook that owns the decision. New non-goal = one-line append.
+- **Non-goals are pointers, not re-decisions.** No existing scope decision changes. Each bullet links to its source:
+  | Non-goal | Link target |
+  |----------|-------------|
+  | Gateway provider switch is boot-time; per-route selection + hot reload out of scope | `docs/adr/0001-api-gateway-yarp-default-ocelot-fallback.md` |
+  | Ocelot removal deferred (dual-gateway by design) | `docs/prd/PRD-ApiGateway-Yarp.md` |
+  | Local NuGet feed only; no public-feed publishing | `docs/adr/0005-ecommerce-shared-as-nuget-via-local-feed.md`, `docs/runbooks/shared-libs-versioning.md` |
+  | Cosmos DB migration deferred (Azure SQL current) | `docs/prd/azure-infrastructure-deployment.md` |
+  | Auth per-slice request validation deferred | `docs/prd/PRD-Auth-CleanArch-VSA-Pilot.md` |
+  | No microservice code consolidation (services deploy as-is) | `docs/prd/PRD-Aks-Deployment.md` |
+  | Gateway-internal JWT claim helper not promoted to shared lib | `docs/prd/PRD-ApiGateway-CleanArch-VSA-Pilot.md` |
+  | No frontend/UI (surface is API Gateway + Swagger); simulated payments; depth-over-breadth | framing prose, no external link |
+- **CI/CD reconcile = wording alignment, not behavior change.** Replace blanket "GitHub Actions is not used" with the accurate split: **GitHub Actions runs build verification + QA smoke (CI gates); Azure Pipelines (per-service `azure-pipelines.yml`) is the deployment path.** Corrected sentence identical across `CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md` to prevent re-drift.
+- **Files NOT touched.** No workflow YAML, no `azure-pipelines.yml`, no `PATTERNS.md`, no restructuring of other CONTEXT.md sections. No new abstractions, no link-checker CI.
+
+---
+
+## Phase 1: Scope & Non-Goals section + README cross-link + badge label fix
+
+**User stories**: 1–14, 17, 20
+
+### What to build
+
+Add a new `## Scope & Non-Goals` section to `CONTEXT.md` (between `What I learned` and `Link tree`) with two groupings: a *What this is* framing paragraph and a *Non-goals* bullet list where each bullet links to its authoritative source (per the table above). Add a short cross-link in `README.md` (a `## Scope & Non-Goals` callout pointing to `CONTEXT.md#scope--non-goals`, placed after `## Key Patterns` at README.md:241) — link, do not duplicate content. Fix the mislabeled badge at `CONTEXT.md:4`: it reads `[![Docker Build]...]` but points at `smoke-test.yml`; relabel to **QA Smoke Test** to match the workflow's `name:` (story 17, badge/prose consistency).
+
+### Acceptance criteria
+
+- [ ] `## Scope & Non-Goals` renders in `CONTEXT.md` with a *What this is* paragraph and a *Non-goals* bullet list.
+- [ ] *What this is* states: learning/portfolio backend, no frontend (surface = API Gateway + Swagger), simulated payments, depth-over-breadth, single-author intent.
+- [ ] Every non-goal bullet that has a source links to a real, resolving ADR/PRD/runbook path (all 8 targets confirmed to exist).
+- [ ] `README.md` links to `CONTEXT.md#scope--non-goals` and does not duplicate the content.
+- [ ] `CONTEXT.md:4` badge label reads "QA Smoke Test" and still points at `smoke-test.yml`.
+- [ ] No other CONTEXT.md / README.md section is restructured.
+
+---
+
+## Phase 2: CI/CD wording reconcile across agent-facing files
+
+**User stories**: 15, 16, 18, 19
+
+### What to build
+
+Replace the inaccurate "GitHub Actions is not used" claim in the three agent-grounding files with the accurate split already expressed in `infrastructure-deployment/docs/PATTERNS.md`. The corrected sentence is **identical** across all three files. Fit it to each file's existing format:
+- `CLAUDE.md:87` — `## CI/CD` paragraph (bold sentence today).
+- `AGENTS.md:87` — same paragraph, mirror exactly.
+- `.github/copilot-instructions.md:41` — inline bullet under "Tech stack (actual)".
+
+Corrected framing: GitHub Actions runs build verification (`docker-build.yml`) and QA smoke checks (`smoke-test.yml`) as CI gates; Azure Pipelines (per-service `azure-pipelines.yml`) is the deployment path.
+
+### Acceptance criteria
+
+- [ ] None of the three files contains the string "GitHub Actions is not used".
+- [ ] All three carry an identical corrected CI/CD sentence (build + smoke = GitHub Actions CI gates; Azure Pipelines = deploy path).
+- [ ] No workflow file, `azure-pipelines.yml`, or `PATTERNS.md` is edited.
+- [ ] `dotnet format`-irrelevant (docs only); no build impact.
+
+---
+
+## Verification (manual review — no automated tests)
+
+Per PRD Testing Decisions: docs-only, automated tests would only couple to prose. Verify end-to-end by:
+
+1. **Render check** — open `CONTEXT.md`; confirm `## Scope & Non-Goals` renders between `What I learned` and `Link tree` with both groupings.
+2. **Link resolution** — click/verify every non-goal link resolves to an existing file (8 targets); verify README link jumps to the CONTEXT.md anchor (`#scope--non-goals`).
+3. **Cross-file consistency** — grep all three agent files for "GitHub Actions is not used" → zero hits; grep the new corrected sentence → identical in all three. Quick command:
+   ```powershell
+   Select-String -Path CLAUDE.md, AGENTS.md, .github/copilot-instructions.md -Pattern "GitHub Actions"
+   ```
+4. **Badge** — confirm `CONTEXT.md:4` badge label = "QA Smoke Test", URL still `smoke-test.yml`; both badges still resolve to existing workflows.
+5. **No drift** — `git diff --stat` touches only `CONTEXT.md`, `README.md`, `CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md`. No workflow/pipeline/PATTERNS files.


### PR DESCRIPTION
This PR clarifies repository documentation boundaries and makes CI/CD messaging consistent across core guidance files.

## What changed
- Added a dedicated **Scope & Non-Goals** section to `CONTEXT.md`
- Linked the new scope section from `README.md`
- Reconciled CI/CD wording across `CLAUDE.md`, `AGENTS.md`, and copilot instructions
- Fixed the smoke badge reference in docs

## Why
Repository-level guidance had drifted across documents, which made onboarding and expectation-setting noisier. This update centralizes scope intent and aligns CI/CD documentation so readers get one consistent story.

## Notes for reviewers
This is a documentation-only change; no runtime or service behavior is modified.