### PR TITLE
Add Azure Monitor alerts and observability wiring

### DIFF
--- a/infrastructure-deployment/bicep/modules/alerts.bicep
+++ b/infrastructure-deployment/bicep/modules/alerts.bicep
@@ -103,8 +103,8 @@ resource highHttpErrorRate 'Microsoft.Insights/scheduledQueryRules@2023-03-15' =
 
 // p95 request duration above the threshold per service over the trailing 5 minutes.
 // Mirrors the local HighHttpLatencyP95 Prometheus rule (severity: warning → Sev 2).
-// App Insights `requests.duration` is in milliseconds, so the 1s local threshold
-// maps to 1000ms by default.
+// App Insights `requests.duration` is a timespan. Convert it to numeric
+// milliseconds first so the percentile output is comparable to the ms threshold.
 resource highHttpLatencyP95 'Microsoft.Insights/scheduledQueryRules@2023-03-15' = {
   name: '${namePrefix}-high-http-latency-p95'
   location: location
@@ -122,7 +122,7 @@ resource highHttpLatencyP95 'Microsoft.Insights/scheduledQueryRules@2023-03-15' 
     criteria: {
       allOf: [
         {
-          query: 'requests\n| summarize P95DurationMs = percentile(duration, 95) by cloud_RoleName\n| project cloud_RoleName, P95DurationMs'
+          query: 'requests\n| extend DurationMs = todouble(duration / 1ms)\n| summarize P95DurationMs = percentile(DurationMs, 95) by cloud_RoleName\n| project cloud_RoleName, P95DurationMs'
           timeAggregation: 'Average'
           metricMeasureColumn: 'P95DurationMs'
           operator: 'GreaterThan'

--- a/observability/alerts.yaml
+++ b/observability/alerts.yaml
@@ -2,7 +2,7 @@
 # (Prometheus/Alertmanager started via the root docker-compose.yaml). They are NOT
 # used in the cloud: AKS ships metrics to Application Insights, not Prometheus, so
 # these rules are superseded there by the Azure Monitor alerts defined in Bicep
-# (infrastructure-deployment/bicep), landing in later phases.
+# (infrastructure-deployment/bicep).
 groups:
   - name: microservice-http
     rules:


### PR DESCRIPTION
This PR introduces Azure Monitor-focused observability improvements across infrastructure deployment and AKS manifests.

Summary of changes:
- Adopt Azure Monitor OpenTelemetry distribution for platform observability setup.
- Enable AKS Container Insights monitoring addon.
- Add and wire Azure Monitor alert modules, including:
  - HTTP error-rate and latency alerts
  - ServiceDown alert behavior improvements
  - Inventory low-stock alert
  - Action group module with staging/prod wiring
- Wire alert modules into the main Bicep deployment entrypoint.
- Update ADR-0009 addendum and follow-up docs/comments for correctness and clarity.
- Remove obsolete prometheus.io annotations from cloud AKS manifests.

Why:
- Standardize cloud-native monitoring on Azure Monitor and reduce operational blind spots.
- Improve reliability of alert signal quality (fewer false positives and clearer intent).
- Keep infrastructure-as-code aligned with current observability architecture.

Related:
- #333
- #335
- #336
- #337
- #338